### PR TITLE
Gnn v3

### DIFF
--- a/dataset/create_event_list_and_shuffle.py
+++ b/dataset/create_event_list_and_shuffle.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import random
+
+# CSV 파일 읽기
+large_dataset = pd.read_csv('dataset/raw/large_dataset.csv')
+completed_events = pd.read_csv('dataset/raw/completed_events_small.csv')
+
+# completed_events에서 event_name을 인덱스로 설정
+completed_events.set_index('event', inplace=True)
+
+# 날짜를 찾고 대체
+large_dataset['date'] = large_dataset['event_name'].map(completed_events['date'])
+
+# 날짜 형식 변경
+large_dataset['date'] = pd.to_datetime(large_dataset['date']).dt.strftime('%m/%d/%Y')
+
+# 필요한 열만 선택
+new_dataset = large_dataset[['date', 'r_fighter', 'b_fighter', 'winner', 'weight_class']]
+
+new_dataset.to_csv('dataset/preprocessed/event_list.csv', index=False)
+
+# 승리한 파이터를 r_fighter로 배치하고 winner를 Red로 설정
+for index, row in new_dataset.iterrows():
+    if row['winner'] == 'Blue':
+        # r_fighter와 b_fighter의 값을 교환
+        new_dataset.at[index, 'r_fighter'], new_dataset.at[index, 'b_fighter'] = row['b_fighter'], row['r_fighter']
+        # winner를 Red로 설정
+        new_dataset.at[index, 'winner'] = 'Red'
+        
+# 업데이트된 데이터셋 저장
+new_dataset.to_csv('dataset/preprocessed/event_list_ordered.csv', index=False)
+
+# weight_class 별로 승리 횟수 균등화를 위한 스왑
+for weight_class, group in new_dataset.groupby('weight_class'):
+    num_rows = len(group)
+    half_rows = num_rows // 2
+    
+    # 현재 r_fighter가 이긴 횟수
+    r_wins = group['winner'].value_counts().get('Red', 0)
+    
+    # r_fighter의 승리 횟수가 절반보다 많으면 스왑
+    if r_wins > half_rows:
+        swap_count = r_wins - half_rows
+        swap_indices = random.sample(group.index.tolist(), swap_count)
+        
+        for index in swap_indices:
+            # r_fighter와 b_fighter의 값을 교환
+            new_dataset.at[index, 'r_fighter'], new_dataset.at[index, 'b_fighter'] = new_dataset.at[index, 'b_fighter'], new_dataset.at[index, 'r_fighter']
+            # winner를 Blue로 설정
+            new_dataset.at[index, 'winner'] = 'Blue'
+
+new_dataset.to_csv('dataset/preprocessed/event_list_shuffled.csv', index=False)

--- a/dataset/preprocessed/event_list.csv
+++ b/dataset/preprocessed/event_list.csv
@@ -1,0 +1,7440 @@
+date,r_fighter,b_fighter,winner,weight_class
+03/23/2024,Amanda Ribas,Rose Namajunas,Blue,Women's Flyweight
+03/23/2024,Karl Williams,Justin Tafa,Red,Heavyweight
+03/23/2024,Edmen Shahbazyan,AJ Dobson,Red,Middleweight
+03/23/2024,Payton Talbott,Cameron Saaiman,Red,Bantamweight
+03/23/2024,Billy Quarantillo,Youssef Zalal,Blue,Featherweight
+03/23/2024,Fernando Padilla,Luis Pajuelo,Red,Featherweight
+03/23/2024,Kurt Holobaugh,Trey Ogden,Blue,Lightweight
+03/23/2024,Ricardo Ramos,Julian Erosa,Blue,Featherweight
+03/23/2024,Miles Johns,Cody Gibson,Red,Bantamweight
+03/23/2024,Jarno Errens,Steven Nguyen,Red,Featherweight
+03/23/2024,Montserrat Rendon,Daria Zhelezniakova,Blue,Women's Bantamweight
+03/23/2024,Igor Severino,Andre Lima,Blue,Flyweight
+03/23/2024,Mohammed Usman,Mick Parkin,Blue,Heavyweight
+03/16/2024,Tai Tuivasa,Marcin Tybura,Blue,Heavyweight
+03/16/2024,Ovince Saint Preux,Kennedy Nzechukwu,Red,Light Heavyweight
+03/16/2024,Christian Rodriguez,Isaac Dulgarian,Red,Featherweight
+03/16/2024,Pannie Kianzad,Macy Chiasson,Blue,Women's Bantamweight
+03/16/2024,Gerald Meerschaert,Bryan Barberena,Red,Middleweight
+03/16/2024,Natan Levy,Mike Davis,Blue,Lightweight
+03/16/2024,Josiane Nunes,Chelsea Chandler,Blue,Women's Bantamweight
+03/16/2024,Jafel Filho,Ode Osbourne,Red,Flyweight
+03/16/2024,Josh Culibao,Danny Silva,Blue,Featherweight
+03/16/2024,Jaqueline Amorim,Cory McKenna,Red,Women's Strawweight
+03/16/2024,Thiago Moises,Mitch Ramirez,Red,Lightweight
+03/16/2024,Charalampos Grigoriou,Chad Anheliger,Blue,Bantamweight
+03/09/2024,Sean O'Malley,Marlon Vera,Red,UFC Bantamweight Title
+03/09/2024,Dustin Poirier,Benoit Saint Denis,Red,Lightweight
+03/09/2024,Kevin Holland,Michael Page,Blue,Welterweight
+03/09/2024,Gilbert Burns,Jack Della Maddalena,Blue,Welterweight
+03/09/2024,Petr Yan,Song Yadong,Red,Bantamweight
+03/09/2024,Curtis Blaydes,Jailton Almeida,Red,Heavyweight
+03/09/2024,Katlyn Cerminara,Maycee Barber,Blue,Women's Flyweight
+03/09/2024,Mateusz Gamrot,Rafael Dos Anjos,Red,Lightweight
+03/09/2024,Pedro Munhoz,Kyler Phillips,Blue,Bantamweight
+03/09/2024,Ion Cutelaba,Philipe Lins,Blue,Light Heavyweight
+03/09/2024,Michel Pereira,Michal Oleksiejczuk,Red,Middleweight
+03/09/2024,Robelis Despaigne,Josh Parisian,Red,Heavyweight
+03/09/2024,CJ Vergara,Asu Almabayev,Blue,Flyweight
+03/09/2024,Joanne Wood,Maryna Moroz,Red,Women's Flyweight
+03/02/2024,Jairzinho Rozenstruik,Shamil Gaziev,Red,Heavyweight
+03/02/2024,Vitor Petrino,Tyson Pedro,Red,Light Heavyweight
+03/02/2024,Alex Perez,Muhammad Mokaev,Blue,Flyweight
+03/02/2024,Umar Nurmagomedov,Bekzat Almakhan,Red,Bantamweight
+03/02/2024,Matt Schnell,Steve Erceg,Blue,Flyweight
+03/02/2024,Eryk Anders,Jamie Pickett,Red,Middleweight
+03/02/2024,Vinicius Oliveira,Benardo Sopaj,Red,Bantamweight
+03/02/2024,Aiemann Zahabi,Javid Basharat,Red,Bantamweight
+03/02/2024,Christian Leroy Duncan,Claudio Ribeiro,Red,Middleweight
+03/02/2024,Ludovit Klein,AJ Cunningham,Red,Lightweight
+03/02/2024,Abdul-Kareem Al-Selwady,Loik Radzhabov,Blue,Lightweight
+02/24/2024,Brandon Moreno,Brandon Royval,Blue,Flyweight
+02/24/2024,Yair Rodriguez,Brian Ortega,Blue,Featherweight
+02/24/2024,Daniel Zellhuber,Francisco Prado,Red,Lightweight
+02/24/2024,Yazmin Jauregui,Sam Hughes,Red,Women's Strawweight
+02/24/2024,Manuel Torres,Chris Duncan,Red,Lightweight
+02/24/2024,Cristian Quinonez,Raoni Barcelos,Blue,Bantamweight
+02/24/2024,Jesus Aguilar,Mateus Mendonca,Red,Flyweight
+02/24/2024,Edgar Chairez,Daniel Lacerda,Red,Flyweight
+02/24/2024,Claudio Puelles,Fares Ziam,Blue,Lightweight
+02/24/2024,Ronaldo Rodriguez,Denys Bondar,Red,Flyweight
+02/24/2024,Victor Altamirano,Felipe dos Santos,Blue,Flyweight
+02/24/2024,Erik Silva,Muhammad Naimov,Blue,Featherweight
+02/17/2024,Alexander Volkanovski,Ilia Topuria,Blue,UFC Featherweight Title
+02/17/2024,Robert Whittaker,Paulo Costa,Red,Middleweight
+02/17/2024,Geoff Neal,Ian Machado Garry,Blue,Welterweight
+02/17/2024,Merab Dvalishvili,Henry Cejudo,Red,Bantamweight
+02/17/2024,Anthony Hernandez,Roman Kopylov,Red,Middleweight
+02/17/2024,Amanda Lemos,Mackenzie Dern,Red,Women's Strawweight
+02/17/2024,Marcos Rogerio de Lima,Junior Tafa,Red,Heavyweight
+02/17/2024,Rinya Nakamura,Carlos Vera,Red,Bantamweight
+02/17/2024,Zhang Mingyang,Brendson Ribeiro,Red,Light Heavyweight
+02/17/2024,Josh Quinlan,Danny Barlow,Blue,Welterweight
+02/17/2024,Oban Elliott,Val Woodburn,Red,Welterweight
+02/17/2024,Andrea Lee,Miranda Maverick,Blue,Women's Flyweight
+02/10/2024,Jack Hermansson,Joe Pyfer,Red,Middleweight
+02/10/2024,Dan Ige,Andre Fili,Red,Featherweight
+02/10/2024,Robert Bryczek,Ihor Potieria,Blue,Middleweight
+02/10/2024,Brad Tavares,Gregory Rodrigues,Blue,Middleweight
+02/10/2024,Michael Johnson,Darrius Flowers,Red,Lightweight
+02/10/2024,Rodolfo Vieira,Armen Petrosyan,Red,Middleweight
+02/10/2024,Trevin Giles,Carlos Prates,Blue,Welterweight
+02/10/2024,Bolaji Oki,Timmy Cuamba,Red,Lightweight
+02/10/2024,Loma Lookboonmee,Bruna Brasil,Red,Women's Strawweight
+02/10/2024,Devin Clark,Marcin Prachnio,Blue,Light Heavyweight
+02/10/2024,Max Griffin,Jeremiah Wells,Red,Welterweight
+02/10/2024,Zac Pauga,Bogdan Guskov,Blue,Light Heavyweight
+02/10/2024,Fernie Garcia,Hyder Amil,Blue,Featherweight
+02/03/2024,Roman Dolidze,Nassourdine Imavov,Blue,Middleweight
+02/03/2024,Renato Moicano,Drew Dober,Red,Lightweight
+02/03/2024,Randy Brown,Muslim Salikhov,Red,Welterweight
+02/03/2024,Viviane Araujo,Natalia Silva,Blue,Women's Flyweight
+02/03/2024,Gilbert Urbina,Charles Radtke,Blue,Welterweight
+02/03/2024,Molly McCann,Diana Belbita,Red,Women's Strawweight
+02/03/2024,Azat Maksum,Charles Johnson,Blue,Flyweight
+02/03/2024,Themba Gorimbo,Pete Rodriguez,Red,Welterweight
+02/03/2024,JeongYeong Lee,Blake Bilder,Red,Featherweight
+02/03/2024,Luana Carolina,Julija Stoliarenko,Red,Women's Flyweight
+02/03/2024,Landon Quinones,MarQuel Mederos,Blue,Lightweight
+02/03/2024,Thomas Petersen,Jamal Pogues,Blue,Heavyweight
+01/20/2024,Sean Strickland,Dricus Du Plessis,Blue,UFC Middleweight Title
+01/20/2024,Raquel Pennington,Mayra Bueno Silva,Red,UFC Women's Bantamweight Title
+01/20/2024,Neil Magny,Mike Malott,Red,Welterweight
+01/20/2024,Chris Curtis,Marc-Andre Barriault,Red,Middleweight
+01/20/2024,Arnold Allen,Movsar Evloev,Blue,Featherweight
+01/20/2024,Brad Katona,Garrett Armfield,Blue,Bantamweight
+01/20/2024,Charles Jourdain,Sean Woodson,Blue,Featherweight
+01/20/2024,Serhiy Sidey,Ramon Taveras,Blue,Bantamweight
+01/20/2024,Gillian Robertson,Polyana Viana,Red,Women's Strawweight
+01/20/2024,Yohan Lainesse,Sam Patterson,Blue,Welterweight
+01/20/2024,Jasmine Jasudavicius,Priscila Cachoeira,Red,Women's Bantamweight
+01/20/2024,Malcolm Gordon,Jimmy Flick,Blue,Flyweight
+01/13/2024,Magomed Ankalaev,Johnny Walker,Red,Light Heavyweight
+01/13/2024,Jim Miller,Gabriel Benitez,Red,Lightweight
+01/13/2024,Ricky Simon,Mario Bautista,Blue,Bantamweight
+01/13/2024,Phil Hawes,Brunno Ferreira,Blue,Middleweight
+01/13/2024,Andrei Arlovski,Waldo Cortes-Acosta,Blue,Heavyweight
+01/13/2024,Matthew Semelsberger,Preston Parsons,Blue,Welterweight
+01/13/2024,Marcus McGhee,Gaston Bolanos,Red,Bantamweight
+01/13/2024,Farid Basharat,Taylor Lapilus,Red,Bantamweight
+01/13/2024,Westin Wilson,Jean Silva,Blue,Featherweight
+01/13/2024,Nikolas Motta,Tom Nolan,Red,Lightweight
+01/13/2024,Joshua Van,Felipe Bunes,Red,Flyweight
+12/16/2023,Leon Edwards,Colby Covington,Red,UFC Welterweight Title
+12/16/2023,Alexandre Pantoja,Brandon Royval,Red,UFC Flyweight Title
+12/16/2023,Shavkat Rakhmonov,Stephen Thompson,Red,Welterweight
+12/16/2023,Tony Ferguson,Paddy Pimblett,Blue,Lightweight
+12/16/2023,Josh Emmett,Bryce Mitchell,Red,Featherweight
+12/16/2023,Alonzo Menifield,Dustin Jacoby,Red,Light Heavyweight
+12/16/2023,Irene Aldana,Karol Rosa,Red,Women's Bantamweight
+12/16/2023,Cody Garbrandt,Brian Kelleher,Red,Bantamweight
+12/16/2023,Casey O'Neill,Ariane Lipski,Blue,Women's Flyweight
+12/16/2023,Tagir Ulanbekov,Cody Durden,Red,Flyweight
+12/16/2023,Andre Fili,Lucas Almeida,Red,Featherweight
+12/16/2023,Martin Buday,Shamil Gaziev,Blue,Heavyweight
+12/09/2023,Song Yadong,Chris Gutierrez,Red,Bantamweight
+12/09/2023,Anthony Smith,Khalil Rountree Jr.,Blue,Light Heavyweight
+12/09/2023,Nasrat Haqparast,Jamie Mullarkey,Red,Lightweight
+12/09/2023,Tim Elliott,Sumudaerji,Red,Bantamweight
+12/09/2023,JunYong Park,Andre Muniz,Blue,Middleweight
+12/09/2023,Song Kenan,Kevin Jousset,Blue,Welterweight
+12/09/2023,HyunSung Park,Shannon Ross,Red,Flyweight
+12/09/2023,Steve Garcia,Melquizael Costa,Red,Lightweight
+12/09/2023,Luana Santos,Stephanie Egger,Red,Women's Bantamweight
+12/09/2023,Tatsuro Taira,Carlos Hernandez,Red,Flyweight
+12/09/2023,Rayanne Amanda,Talita Alencar,Blue,Women's Strawweight
+12/02/2023,Beneil Dariush,Arman Tsarukyan,Blue,Lightweight
+12/02/2023,Jalin Turner,Bobby Green,Red,Lightweight
+12/02/2023,Rob Font,Deiveson Figueiredo,Blue,Bantamweight
+12/02/2023,Sean Brady,Kelvin Gastelum,Red,Welterweight
+12/02/2023,Clay Guida,Joaquim Silva,Blue,Lightweight
+12/02/2023,Punahele Soriano,Dustin Stoltzfus,Blue,Middleweight
+12/02/2023,Miesha Tate,Julia Avila,Red,Women's Bantamweight
+12/02/2023,Zach Reese,Cody Brundage,Blue,Middleweight
+12/02/2023,Drakkar Klose,Joe Solecki,Red,Lightweight
+12/02/2023,Rodolfo Bellato,Ihor Potieria,Red,Light Heavyweight
+12/02/2023,Wellington Turman,Jared Gooden,Blue,Welterweight
+12/02/2023,Veronica Hardy,Jamey-Lyn Horth,Red,Women's Flyweight
+11/18/2023,Brendan Allen,Paul Craig,Red,Middleweight
+11/18/2023,Michael Morales,Jake Matthews,Red,Welterweight
+11/18/2023,Chase Hooper,Jordan Leavitt,Red,Lightweight
+11/18/2023,Payton Talbott,Nick Aguirre,Red,Bantamweight
+11/18/2023,Luana Pinheiro,Amanda Ribas,Blue,Women's Strawweight
+11/18/2023,Uros Medic,Myktybek Orolbai,Blue,Welterweight
+11/18/2023,Jonathan Pearce,Joanderson Brito,Blue,Featherweight
+11/18/2023,Chad Anheliger,Jose Johnson,Blue,Bantamweight
+11/18/2023,Christian Leroy Duncan,Denis Tiuliulin,Red,Middleweight
+11/18/2023,Mick Parkin,Caio Machado,Red,Heavyweight
+11/18/2023,Jeka Saragih,Lucas Alexander,Red,Featherweight
+11/18/2023,Lucie Pudilova,Ailin Perez,Blue,Women's Bantamweight
+11/18/2023,Charles Johnson,Rafael Estevam,Blue,Flyweight
+11/11/2023,Jiri Prochazka,Alex Pereira,Blue,UFC Light Heavyweight Title
+11/11/2023,Sergei Pavlovich,Tom Aspinall,Blue,UFC Interim Heavyweight Title
+11/11/2023,Jessica Andrade,Mackenzie Dern,Red,Women's Strawweight
+11/11/2023,Matt Frevola,Benoit Saint Denis,Blue,Lightweight
+11/11/2023,Diego Lopes,Pat Sabatini,Red,Featherweight
+11/11/2023,Steve Erceg,Alessandro Costa,Red,Flyweight
+11/11/2023,Tabatha Ricci,Loopy Godinez,Blue,Women's Strawweight
+11/11/2023,Mateusz Rebecki,Roosevelt Roberts,Red,Lightweight
+11/11/2023,Jared Gordon,Mark Madsen,Red,Lightweight
+11/11/2023,John Castaneda,Kyung Ho Kang,Red,Catch Weight
+11/11/2023,Joshua Van,Kevin Borjas,Red,Flyweight
+11/11/2023,Dennis Buzukja,Jamall Emmers,Blue,Featherweight
+11/04/2023,Jailton Almeida,Derrick Lewis,Red,Heavyweight
+11/04/2023,Gabriel Bonfim,Nicolas Dalby,Blue,Welterweight
+11/04/2023,Rodrigo Nascimento,Don'Tale Mayes,Red,Heavyweight
+11/04/2023,Caio Borralho,Abus Magomedov,Red,Middleweight
+11/04/2023,Elves Brener,Kaynan Kruschewsky,Red,Catch Weight
+11/04/2023,Vitor Petrino,Modestas Bukauskas,Red,Light Heavyweight
+11/04/2023,Angela Hill,Denise Gomes,Red,Women's Strawweight
+11/04/2023,Eduarda Moura,Montserrat Conejo Ruiz,Red,Women's Strawweight
+11/04/2023,Kaue Fernandes,Marc Diakiese,Blue,Lightweight
+10/21/2023,Islam Makhachev,Alexander Volkanovski,Red,UFC Lightweight Title
+10/21/2023,Kamaru Usman,Khamzat Chimaev,Blue,Middleweight
+10/21/2023,Ikram Aliskerov,Warlley Alves,Red,Middleweight
+10/21/2023,Said Nurmagomedov,Muin Gafurov,Red,Bantamweight
+10/21/2023,Tim Elliott,Muhammad Mokaev,Blue,Flyweight
+10/21/2023,Mohammad Yahya,Trevor Peek,Blue,Lightweight
+10/21/2023,Abu Azaitar,Sedriques Dumas,Blue,Middleweight
+10/21/2023,Mike Breeden,Anshul Jubli,Red,Lightweight
+10/21/2023,Nathaniel Wood,Muhammad Naimov,Blue,Featherweight
+10/21/2023,Viktoriia Dudakova,Jinh Yu Frey,Red,Women's Strawweight
+10/21/2023,Shara Magomedov,Bruno Silva,Red,Middleweight
+10/14/2023,Sodiq Yusuff,Edson Barboza,Blue,Featherweight
+10/14/2023,Jennifer Maia,Viviane Araujo,Blue,Women's Flyweight
+10/14/2023,Jonathan Martinez,Adrian Yanez,Red,Bantamweight
+10/14/2023,Andre Petroski,Michel Pereira,Blue,Middleweight
+10/14/2023,Christian Rodriguez,Cameron Saaiman,Red,Bantamweight
+10/14/2023,Darren Elkins,TJ Brown,Red,Featherweight
+10/14/2023,Tainara Lisboa,Ravena Oliveira,Red,Women's Bantamweight
+10/14/2023,Terrance McKinney,Brendon Marotte,Red,Lightweight
+10/14/2023,Irina Alekseeva,Melissa Dixon,Blue,Women's Bantamweight
+10/14/2023,Chris Gutierrez,Alatengheili,Red,Bantamweight
+10/14/2023,Ashley Yoder,Emily Ducote,Blue,Women's Strawweight
+10/07/2023,Grant Dawson,Bobby Green,Blue,Lightweight
+10/07/2023,Joe Pyfer,Abdul Razak Alhassan,Red,Middleweight
+10/07/2023,Alex Morono,Joaquin Buckley,Blue,Welterweight
+10/07/2023,Drew Dober,Ricky Glenn,Red,Lightweight
+10/07/2023,Alexander Hernandez,Bill Algeo,Blue,Featherweight
+10/07/2023,Karolina Kowalkiewicz,Diana Belbita,Red,Women's Strawweight
+10/07/2023,Nate Maness,Mateus Mendonca,Red,Flyweight
+10/07/2023,Vanessa Demopoulos,Kanako Murata,Red,Women's Strawweight
+10/07/2023,Aoriqileng,Johnny Munoz,Red,Bantamweight
+10/07/2023,Montana De La Rosa,JJ Aldrich,Blue,Women's Flyweight
+09/23/2023,Rafael Fiziev,Mateusz Gamrot,Blue,Lightweight
+09/23/2023,Bryce Mitchell,Dan Ige,Red,Featherweight
+09/23/2023,Marina Rodriguez,Michelle Waterson-Gomez,Red,Women's Strawweight
+09/23/2023,Bryan Battle,AJ Fletcher,Red,Welterweight
+09/23/2023,Ricardo Ramos,Charles Jourdain,Blue,Featherweight
+09/23/2023,Tim Means,Andre Fialho,Red,Welterweight
+09/23/2023,Jacob Malkoun,Cody Brundage,Blue,Middleweight
+09/23/2023,Mohammed Usman,Jake Collier,Red,Heavyweight
+09/23/2023,Mizuki,Hannah Goldy,Red,Women's Strawweight
+09/23/2023,Tamires Vidal,Montserrat Rendon,Blue,Women's Bantamweight
+09/16/2023,Kevin Holland,Jack Della Maddalena,Blue,Welterweight
+09/16/2023,Raul Rosas Jr.,Terrence Mitchell,Red,Bantamweight
+09/16/2023,Daniel Zellhuber,Christos Giagos,Red,Lightweight
+09/16/2023,Fernando Padilla,Kyle Nelson,Blue,Featherweight
+09/16/2023,Loopy Godinez,Elise Reed,Red,Women's Strawweight
+09/16/2023,Roman Kopylov,Josh Fremd,Red,Middleweight
+09/16/2023,Tracy Cortez,Jasmine Jasudavicius,Red,Women's Flyweight
+09/16/2023,Alex Reyes,Charlie Campbell,Blue,Lightweight
+09/16/2023,Josefine Knutsson,Marnic Mann,Red,Women's Strawweight
+09/09/2023,Israel Adesanya,Sean Strickland,Blue,UFC Middleweight Title
+09/09/2023,Tai Tuivasa,Alexander Volkov,Blue,Heavyweight
+09/09/2023,Manel Kape,Felipe dos Santos,Red,Flyweight
+09/09/2023,Justin Tafa,Austen Lane,Red,Heavyweight
+09/09/2023,Tyson Pedro,Anton Turkalj,Red,Light Heavyweight
+09/09/2023,Carlos Ulberg,Da Woon Jung,Red,Light Heavyweight
+09/09/2023,Jack Jenkins,Chepe Mariscal,Blue,Featherweight
+09/09/2023,Jamie Mullarkey,John Makdessi,Red,Lightweight
+09/09/2023,Nasrat Haqparast,Landon Quinones,Red,Lightweight
+09/09/2023,Blood Diamond,Charles Radtke,Blue,Welterweight
+09/09/2023,Shane Young,Gabriel Miranda,Blue,Featherweight
+09/09/2023,Kevin Jousset,Kiefer Crosbie,Red,Welterweight
+09/02/2023,Ciryl Gane,Serghei Spivac,Red,Heavyweight
+09/02/2023,Manon Fiorot,Rose Namajunas,Red,Women's Flyweight
+09/02/2023,Benoit Saint Denis,Thiago Moises,Red,Lightweight
+09/02/2023,Volkan Oezdemir,Bogdan Guskov,Red,Light Heavyweight
+09/02/2023,William Gomis,Yanis Ghemmouri,Red,Featherweight
+09/02/2023,Morgan Charriere,Manolo Zecchini,Red,Featherweight
+09/02/2023,Taylor Lapilus,Caolan Loughran,Red,Bantamweight
+09/02/2023,Ange Loosa,Rhys McKee,Red,Welterweight
+09/02/2023,Nora Cornolle,Joselyne Edwards,Red,Women's Bantamweight
+09/02/2023,Farid Basharat,Kleydson Rodrigues,Red,Bantamweight
+09/02/2023,Zarah Fairn,Jacqueline Cavalcanti,Blue,Catch Weight
+08/26/2023,Max Holloway,Chan Sung Jung,Red,Featherweight
+08/26/2023,Anthony Smith,Ryan Spann,Red,Light Heavyweight
+08/26/2023,Giga Chikadze,Alex Caceres,Red,Featherweight
+08/26/2023,Rinya Nakamura,Fernie Garcia,Red,Bantamweight
+08/26/2023,Erin Blanchfield,Taila Santos,Red,Women's Flyweight
+08/26/2023,Junior Tafa,Parker Porter,Red,Heavyweight
+08/26/2023,Waldo Cortes-Acosta,Lukasz Brzeski,Red,Heavyweight
+08/26/2023,Toshiomi Kazama,Garrett Armfield,Blue,Bantamweight
+08/26/2023,Chidi Njokuani,Michal Oleksiejczuk,Blue,Middleweight
+08/26/2023,Song Kenan,Rolando Bedoya,Red,Welterweight
+08/26/2023,Billy Goff,Yusaku Kinoshita,Red,Welterweight
+08/26/2023,Liang Na,JJ Aldrich,Blue,Women's Flyweight
+08/26/2023,SeungWoo Choi,Jarno Errens,Red,Featherweight
+08/19/2023,Aljamain Sterling,Sean O'Malley,Blue,UFC Bantamweight Title
+08/19/2023,Zhang Weili,Amanda Lemos,Red,UFC Women's Strawweight Title
+08/19/2023,Neil Magny,Ian Machado Garry,Blue,Welterweight
+08/19/2023,Da'Mon Blackshear,Mario Bautista,Blue,Bantamweight
+08/19/2023,Marlon Vera,Pedro Munhoz,Red,Bantamweight
+08/19/2023,Chris Weidman,Brad Tavares,Blue,Middleweight
+08/19/2023,Gregory Rodrigues,Denis Tiuliulin,Red,Middleweight
+08/19/2023,Kurt Holobaugh,Austin Hubbard,Red,Lightweight
+08/19/2023,Brad Katona,Cody Gibson,Red,Bantamweight
+08/19/2023,Andre Petroski,Gerald Meerschaert,Red,Middleweight
+08/19/2023,Andrea Lee,Natalia Silva,Blue,Women's Flyweight
+08/19/2023,Karine Silva,Maryna Moroz,Red,Women's Flyweight
+08/12/2023,Vicente Luque,Rafael Dos Anjos,Red,Welterweight
+08/12/2023,Cub Swanson,Hakeem Dawodu,Red,Featherweight
+08/12/2023,Khalil Rountree Jr.,Chris Daukaus,Red,Light Heavyweight
+08/12/2023,Polyana Viana,Iasmin Lucindo,Blue,Women's Strawweight
+08/12/2023,AJ Dobson,Tafon Nchukwi,Red,Middleweight
+08/12/2023,Josh Fremd,Jamie Pickett,Red,Middleweight
+08/12/2023,JP Buys,Marcus McGhee,Blue,Bantamweight
+08/12/2023,Terrance McKinney,Mike Breeden,Red,Lightweight
+08/12/2023,Francis Marshall,Isaac Dulgarian,Blue,Featherweight
+08/12/2023,Josh Parisian,Martin Buday,Blue,Heavyweight
+08/12/2023,Jaqueline Amorim,Montserrat Conejo Ruiz,Red,Women's Strawweight
+08/12/2023,Da'Mon Blackshear,Jose Johnson,Red,Bantamweight
+08/12/2023,Juliana Miller,Luana Santos,Blue,Women's Flyweight
+08/05/2023,Cory Sandhagen,Rob Font,Red,Catch Weight
+08/05/2023,Jessica Andrade,Tatiana Suarez,Blue,Women's Strawweight
+08/05/2023,Dustin Jacoby,Kennedy Nzechukwu,Red,Light Heavyweight
+08/05/2023,Diego Lopes,Gavin Tucker,Red,Featherweight
+08/05/2023,Tanner Boser,Aleksa Camur,Red,Light Heavyweight
+08/05/2023,Ignacio Bahamondes,Ludovit Klein,Blue,Lightweight
+08/05/2023,Kyler Phillips,Raoni Barcelos,Red,Bantamweight
+08/05/2023,Jeremiah Wells,Carlston Harris,Blue,Welterweight
+08/05/2023,Billy Quarantillo,Damon Jackson,Red,Featherweight
+08/05/2023,Cody Durden,Jake Hadley,Red,Flyweight
+08/05/2023,Sean Woodson,Dennis Buzukja,Red,Featherweight
+08/05/2023,Ode Osbourne,Asu Almabayev,Blue,Flyweight
+07/29/2023,Dustin Poirier,Justin Gaethje,Blue,Lightweight
+07/29/2023,Jan Blachowicz,Alex Pereira,Blue,Light Heavyweight
+07/29/2023,Derrick Lewis,Marcos Rogerio de Lima,Red,Heavyweight
+07/29/2023,Tony Ferguson,Bobby Green,Blue,Lightweight
+07/29/2023,Michael Chiesa,Kevin Holland,Blue,Welterweight
+07/29/2023,Gabriel Bonfim,Trevin Giles,Red,Welterweight
+07/29/2023,CJ Vergara,Vinicius Salvador,Red,Flyweight
+07/29/2023,Roman Kopylov,Claudio Ribeiro,Red,Middleweight
+07/29/2023,Jake Matthews,Darrius Flowers,Red,Welterweight
+07/29/2023,Matthew Semelsberger,Uros Medic,Blue,Welterweight
+07/29/2023,Miranda Maverick,Priscila Cachoeira,Red,Women's Flyweight
+07/22/2023,Tom Aspinall,Marcin Tybura,Red,Heavyweight
+07/22/2023,Molly McCann,Julija Stoliarenko,Blue,Women's Flyweight
+07/22/2023,Nathaniel Wood,Andre Fili,Red,Featherweight
+07/22/2023,Paul Craig,Andre Muniz,Red,Middleweight
+07/22/2023,Jai Herbert,Fares Ziam,Blue,Lightweight
+07/22/2023,Lerone Murphy,Josh Culibao,Red,Featherweight
+07/22/2023,Davey Grant,Daniel Marcos,Blue,Bantamweight
+07/22/2023,Danny Roberts,Jonny Parsons,Blue,Welterweight
+07/22/2023,Marc Diakiese,Joel Alvarez,Blue,Lightweight
+07/22/2023,Mick Parkin,Jamal Pogues,Red,Heavyweight
+07/22/2023,Makhmud Muradov,Bryan Barberena,Red,Middleweight
+07/22/2023,Ketlen Vieira,Pannie Kianzad,Red,Women's Bantamweight
+07/22/2023,Chris Duncan,Yanal Ashmouz,Red,Lightweight
+07/22/2023,Shauna Bannon,Bruna Brasil,Blue,Women's Strawweight
+07/22/2023,Jafel Filho,Daniel Barez,Red,Flyweight
+07/15/2023,Jack Della Maddalena,Bassil Hafez,Red,Welterweight
+07/15/2023,Ottman Azaitar,Francisco Prado,Blue,Lightweight
+07/15/2023,Albert Duraev,JunYong Park,Blue,Middleweight
+07/15/2023,Norma Dumont,Chelsea Chandler,Red,Women's Featherweight
+07/15/2023,Nazim Sadykhov,Terrance McKinney,Red,Lightweight
+07/15/2023,Tucker Lutz,Melsik Baghdasaryan,Blue,Featherweight
+07/15/2023,Viktoriia Dudakova,Istela Nunes,Red,Women's Strawweight
+07/15/2023,Austin Lingo,Melquizael Costa,Blue,Featherweight
+07/15/2023,Evan Elder,Genaro Valdez,Red,Lightweight
+07/15/2023,Tyson Nam,Azat Maksum,Blue,Flyweight
+07/15/2023,Alexander Munoz,Carl Deaton,Red,Lightweight
+07/15/2023,Ashlee Evans-Smith,Ailin Perez,Blue,Women's Bantamweight
+07/08/2023,Alexander Volkanovski,Yair Rodriguez,Red,UFC Featherweight Title
+07/08/2023,Brandon Moreno,Alexandre Pantoja,Blue,UFC Flyweight Title
+07/08/2023,Robert Whittaker,Dricus Du Plessis,Blue,Middleweight
+07/08/2023,Jalin Turner,Dan Hooker,Blue,Lightweight
+07/08/2023,Bo Nickal,Val Woodburn,Red,Middleweight
+07/08/2023,Robbie Lawler,Niko Price,Red,Welterweight
+07/08/2023,Tatsuro Taira,Edgar Chairez,Red,Catch Weight
+07/08/2023,Yazmin Jauregui,Denise Gomes,Blue,Women's Strawweight
+07/08/2023,Jimmy Crute,Alonzo Menifield,Blue,Light Heavyweight
+07/08/2023,Vitor Petrino,Marcin Prachnio,Red,Light Heavyweight
+07/08/2023,Cameron Saaiman,Terrence Mitchell,Red,Bantamweight
+07/08/2023,Shannon Ross,Jesus Aguilar,Blue,Flyweight
+07/08/2023,Kamuela Kirk,Esteban Ribovics,Blue,Lightweight
+07/01/2023,Sean Strickland,Abus Magomedov,Red,Middleweight
+07/01/2023,Damir Ismagulov,Grant Dawson,Blue,Lightweight
+07/01/2023,Max Griffin,Michael Morales,Blue,Welterweight
+07/01/2023,Ariane Lipski,Melissa Gatto,Red,Women's Flyweight
+07/01/2023,Ismael Bonfim,Benoit Saint Denis,Blue,Lightweight
+07/01/2023,Brunno Ferreira,Nursulton Ruziboev,Blue,Middleweight
+07/01/2023,Kevin Lee,Rinat Fakhretdinov,Blue,Welterweight
+07/01/2023,Joanderson Brito,Westin Wilson,Red,Featherweight
+07/01/2023,Yana Santos,Karol Rosa,Blue,Women's Featherweight
+07/01/2023,Guram Kutateladze,Elves Brener,Blue,Lightweight
+07/01/2023,Ivana Petrovic,Luana Carolina,Blue,Women's Flyweight
+07/01/2023,Alexandr Romanov,Blagoy Ivanov,Red,Heavyweight
+06/24/2023,Josh Emmett,Ilia Topuria,Blue,Featherweight
+06/24/2023,Amanda Ribas,Maycee Barber,Blue,Women's Flyweight
+06/24/2023,David Onama,Gabriel Santos,Red,Featherweight
+06/24/2023,Brendan Allen,Bruno Silva,Red,Middleweight
+06/24/2023,Neil Magny,Phil Rowe,Red,Welterweight
+06/24/2023,Randy Brown,Wellington Turman,Red,Welterweight
+06/24/2023,Mateusz Rebecki,Loik Radzhabov,Red,Lightweight
+06/24/2023,Tabatha Ricci,Gillian Robertson,Red,Women's Strawweight
+06/24/2023,Zhalgas Zhumagulov,Joshua Van,Blue,Flyweight
+06/24/2023,Trevor Peek,Chepe Mariscal,Blue,Lightweight
+06/24/2023,Jamall Emmers,Jack Jenkins,Blue,Featherweight
+06/24/2023,Cody Brundage,Sedriques Dumas,Blue,Middleweight
+06/17/2023,Marvin Vettori,Jared Cannonier,Blue,Middleweight
+06/17/2023,Arman Tsarukyan,Joaquim Silva,Red,Lightweight
+06/17/2023,Armen Petrosyan,Christian Leroy Duncan,Red,Middleweight
+06/17/2023,Pat Sabatini,Lucas Almeida,Red,Featherweight
+06/17/2023,Manuel Torres,Nikolas Motta,Red,Lightweight
+06/17/2023,Nicolas Dalby,Muslim Salikhov,Red,Welterweight
+06/17/2023,Jimmy Flick,Alessandro Costa,Blue,Flyweight
+06/17/2023,Kyung Ho Kang,Cristian Quinonez,Red,Bantamweight
+06/17/2023,Carlos Hernandez,Denys Bondar,Red,Flyweight
+06/17/2023,Tereza Bleda,Gabriella Fernandes,Red,Women's Flyweight
+06/17/2023,Zac Pauga,Modestas Bukauskas,Blue,Light Heavyweight
+06/10/2023,Amanda Nunes,Irene Aldana,Red,UFC Women's Bantamweight Title
+06/10/2023,Charles Oliveira,Beneil Dariush,Red,Lightweight
+06/10/2023,Mike Malott,Adam Fugitt,Red,Welterweight
+06/10/2023,Dan Ige,Nate Landwehr,Red,Featherweight
+06/10/2023,Marc-Andre Barriault,Eryk Anders,Red,Middleweight
+06/10/2023,Miranda Maverick,Jasmine Jasudavicius,Blue,Women's Flyweight
+06/10/2023,Aiemann Zahabi,Aoriqileng,Red,Bantamweight
+06/10/2023,Kyle Nelson,Blake Bilder,Red,Featherweight
+06/10/2023,David Dvorak,Steve Erceg,Blue,Flyweight
+06/10/2023,Diana Belbita,Maria Oliveira,Red,Women's Strawweight
+06/03/2023,Kai Kara-France,Amir Albazi,Blue,Flyweight
+06/03/2023,Alex Caceres,Daniel Pineda,Red,Featherweight
+06/03/2023,Jim Miller,Jesse Butler,Red,Lightweight
+06/03/2023,Tim Elliott,Victor Altamirano,Red,Flyweight
+06/03/2023,Karine Silva,Ketlen Souza,Red,Women's Flyweight
+06/03/2023,Abubakar Nurmagomedov,Elizeu Zaleski dos Santos,Blue,Welterweight
+06/03/2023,Daniel Santos,Johnny Munoz,Red,Bantamweight
+06/03/2023,Andrei Arlovski,Don'Tale Mayes,Blue,Heavyweight
+06/03/2023,John Castaneda,Muin Gafurov,Red,Bantamweight
+06/03/2023,Jamie Mullarkey,Muhammad Naimov,Blue,Lightweight
+06/03/2023,Elise Reed,Jinh Yu Frey,Red,Women's Strawweight
+06/03/2023,Da'Mon Blackshear,Luan Lacerda,Red,Bantamweight
+06/03/2023,Philipe Lins,Maxim Grishin,Red,Light Heavyweight
+05/20/2023,Mackenzie Dern,Angela Hill,Red,Women's Strawweight
+05/20/2023,Edmen Shahbazyan,Anthony Hernandez,Blue,Middleweight
+05/20/2023,Emily Ducote,Loopy Godinez,Blue,Catch Weight
+05/20/2023,Andre Fialho,Joaquin Buckley,Blue,Welterweight
+05/20/2023,Diego Ferreira,Michael Johnson,Red,Lightweight
+05/20/2023,Maheshate,Viacheslav Borshchev,Blue,Lightweight
+05/20/2023,Karolina Kowalkiewicz,Vanessa Demopoulos,Red,Women's Strawweight
+05/20/2023,Orion Cosce,Gilbert Urbina,Blue,Welterweight
+05/20/2023,Ilir Latifi,Rodrigo Nascimento,Blue,Heavyweight
+05/20/2023,Chase Hooper,Nick Fiore,Red,Lightweight
+05/20/2023,Natalia Silva,Victoria Leonardo,Red,Women's Flyweight
+05/20/2023,Takashi Sato,Themba Gorimbo,Blue,Welterweight
+05/13/2023,Jairzinho Rozenstruik,Jailton Almeida,Blue,Heavyweight
+05/13/2023,Anthony Smith,Johnny Walker,Blue,Light Heavyweight
+05/13/2023,Daniel Rodriguez,Ian Machado Garry,Blue,Welterweight
+05/13/2023,Carlos Ulberg,Ihor Potieria,Red,Light Heavyweight
+05/13/2023,Tim Means,Alex Morono,Blue,Welterweight
+05/13/2023,Matt Brown,Court McGee,Red,Welterweight
+05/13/2023,Karl Williams,Chase Sherman,Red,Heavyweight
+05/13/2023,Cody Stamann,Douglas Silva de Andrade,Blue,Catch Weight
+05/13/2023,Ji Yeon Kim,Mandy Bohm,Blue,Women's Flyweight
+05/13/2023,Bryan Battle,Gabe Green,Red,Welterweight
+05/13/2023,Jessica-Rose Clark,Tainara Lisboa,Blue,Women's Bantamweight
+05/06/2023,Aljamain Sterling,Henry Cejudo,Red,UFC Bantamweight Title
+05/06/2023,Belal Muhammad,Gilbert Burns,Red,Welterweight
+05/06/2023,Jessica Andrade,Yan Xiaonan,Blue,Women's Strawweight
+05/06/2023,Movsar Evloev,Diego Lopes,Red,Featherweight
+05/06/2023,Kron Gracie,Charles Jourdain,Blue,Featherweight
+05/06/2023,Drew Dober,Matt Frevola,Blue,Lightweight
+05/06/2023,Kennedy Nzechukwu,Devin Clark,Red,Light Heavyweight
+05/06/2023,Khaos Williams,Rolando Bedoya,Red,Welterweight
+05/06/2023,Marina Rodriguez,Virna Jandiroba,Blue,Women's Strawweight
+05/06/2023,Braxton Smith,Parker Porter,Blue,Heavyweight
+05/06/2023,Phil Hawes,Ikram Aliskerov,Blue,Middleweight
+05/06/2023,Joseph Holmes,Claudio Ribeiro,Blue,Middleweight
+04/29/2023,Song Yadong,Ricky Simon,Red,Bantamweight
+04/29/2023,Caio Borralho,Michal Oleksiejczuk,Red,Middleweight
+04/29/2023,Rodolfo Vieira,Cody Brundage,Red,Middleweight
+04/29/2023,Julian Erosa,Fernando Padilla,Blue,Featherweight
+04/29/2023,Marcos Rogerio de Lima,Waldo Cortes-Acosta,Red,Heavyweight
+04/29/2023,Josh Quinlan,Trey Waters,Blue,Welterweight
+04/29/2023,Martin Buday,Jake Collier,Red,Heavyweight
+04/29/2023,Cody Durden,Charles Johnson,Red,Flyweight
+04/29/2023,Stephanie Egger,Irina Alekseeva,Blue,Women's Bantamweight
+04/29/2023,Journey Newson,Marcus McGhee,Blue,Catch Weight
+04/29/2023,Hailey Cowan,Jamey-Lyn Horth,Blue,Women's Bantamweight
+04/22/2023,Sergei Pavlovich,Curtis Blaydes,Red,Heavyweight
+04/22/2023,Brad Tavares,Bruno Silva,Blue,Middleweight
+04/22/2023,Iasmin Lucindo,Brogan Walker,Red,Women's Flyweight
+04/22/2023,Jeremiah Wells,Matthew Semelsberger,Red,Welterweight
+04/22/2023,Ricky Glenn,Christos Giagos,Blue,Lightweight
+04/22/2023,Rani Yahya,Montel Jackson,Blue,Bantamweight
+04/22/2023,Karol Rosa,Norma Dumont,Blue,Women's Featherweight
+04/22/2023,Mohammed Usman,Junior Tafa,Red,Heavyweight
+04/22/2023,Francis Marshall,William Gomis,Blue,Featherweight
+04/22/2023,Brady Hiestand,Batgerel Danaa,Red,Bantamweight
+04/15/2023,Max Holloway,Arnold Allen,Red,Featherweight
+04/15/2023,Edson Barboza,Billy Quarantillo,Red,Featherweight
+04/15/2023,Dustin Jacoby,Azamat Murzakanov,Blue,Light Heavyweight
+04/15/2023,Tanner Boser,Ion Cutelaba,Blue,Light Heavyweight
+04/15/2023,Pedro Munhoz,Chris Gutierrez,Red,Bantamweight
+04/15/2023,Clay Guida,Rafa Garcia,Blue,Lightweight
+04/15/2023,Bill Algeo,TJ Brown,Red,Featherweight
+04/15/2023,Brandon Royval,Matheus Nicolau,Red,Flyweight
+04/15/2023,Zak Cummings,Ed Herman,Red,Light Heavyweight
+04/15/2023,Gillian Robertson,Piera Rodriguez,Red,Women's Strawweight
+04/15/2023,Lando Vannata,Daniel Zellhuber,Blue,Lightweight
+04/15/2023,Bruna Brasil,Denise Gomes,Blue,Women's Strawweight
+04/15/2023,Aaron Phillips,Gaston Bolanos,Blue,Bantamweight
+04/15/2023,Joselyne Edwards,Lucie Pudilova,Red,Women's Bantamweight
+04/08/2023,Alex Pereira,Israel Adesanya,Blue,UFC Middleweight Title
+04/08/2023,Gilbert Burns,Jorge Masvidal,Red,Welterweight
+04/08/2023,Rob Font,Adrian Yanez,Red,Bantamweight
+04/08/2023,Kevin Holland,Santiago Ponzinibbio,Red,Welterweight
+04/08/2023,Raul Rosas Jr.,Christian Rodriguez,Blue,Bantamweight
+04/08/2023,Chris Curtis,Kelvin Gastelum,Blue,Middleweight
+04/08/2023,Michelle Waterson-Gomez,Luana Pinheiro,Blue,Women's Strawweight
+04/08/2023,Gerald Meerschaert,Joe Pyfer,Blue,Middleweight
+04/08/2023,Cynthia Calvillo,Loopy Godinez,Blue,Women's Strawweight
+04/08/2023,Ignacio Bahamondes,Trey Ogden,Red,Catch Weight
+04/08/2023,Shayilan Nuerdanbieke,Steve Garcia,Blue,Featherweight
+04/08/2023,Jaqueline Amorim,Sam Hughes,Blue,Women's Strawweight
+03/25/2023,Marlon Vera,Cory Sandhagen,Blue,Bantamweight
+03/25/2023,Holly Holm,Yana Santos,Red,Women's Bantamweight
+03/25/2023,Nate Landwehr,Austin Lingo,Red,Featherweight
+03/25/2023,Andrea Lee,Maycee Barber,Blue,Women's Flyweight
+03/25/2023,Chidi Njokuani,Albert Duraev,Blue,Middleweight
+03/25/2023,Daniel Pineda,Tucker Lutz,Red,Featherweight
+03/25/2023,Steven Peterson,Lucas Alexander,Blue,Featherweight
+03/25/2023,Trevin Giles,Preston Parsons,Red,Welterweight
+03/25/2023,CJ Vergara,Daniel Lacerda,Red,Flyweight
+03/25/2023,Victor Altamirano,Vinicius Salvador,Red,Flyweight
+03/18/2023,Leon Edwards,Kamaru Usman,Red,UFC Welterweight Title
+03/18/2023,Justin Gaethje,Rafael Fiziev,Red,Lightweight
+03/18/2023,Gunnar Nelson,Bryan Barberena,Red,Welterweight
+03/18/2023,Jennifer Maia,Casey O'Neill,Red,Women's Flyweight
+03/18/2023,Marvin Vettori,Roman Dolidze,Red,Middleweight
+03/18/2023,Jack Shore,Makwan Amirkhani,Red,Featherweight
+03/18/2023,Chris Duncan,Omar Morales,Red,Lightweight
+03/18/2023,Sam Patterson,Yanal Ashmouz,Blue,Lightweight
+03/18/2023,Muhammad Mokaev,Jafel Filho,Red,Flyweight
+03/18/2023,Lerone Murphy,Gabriel Santos,Red,Featherweight
+03/18/2023,Christian Leroy Duncan,Dusko Todorovic,Red,Middleweight
+03/18/2023,Jake Hadley,Malcolm Gordon,Red,Flyweight
+03/18/2023,Joanne Wood,Luana Carolina,Red,Women's Flyweight
+03/18/2023,Juliana Miller,Veronica Hardy,Blue,Women's Flyweight
+03/11/2023,Petr Yan,Merab Dvalishvili,Blue,Bantamweight
+03/11/2023,Alexander Volkov,Alexandr Romanov,Red,Heavyweight
+03/11/2023,Nikita Krylov,Ryan Spann,Red,Catch Weight
+03/11/2023,Said Nurmagomedov,Jonathan Martinez,Blue,Bantamweight
+03/11/2023,Mario Bautista,Guido Cannetti,Red,Bantamweight
+03/11/2023,Vitor Petrino,Anton Turkalj,Red,Light Heavyweight
+03/11/2023,Karl Williams,Lukasz Brzeski,Red,Heavyweight
+03/11/2023,Raphael Assuncao,Davey Grant,Blue,Bantamweight
+03/11/2023,Sedriques Dumas,Josh Fremd,Blue,Middleweight
+03/11/2023,Victor Henry,Tony Gravely,Red,Bantamweight
+03/11/2023,Ariane Lipski,JJ Aldrich,Red,Women's Flyweight
+03/11/2023,Tyson Nam,Bruno Silva,Blue,Flyweight
+03/11/2023,Carlston Harris,Jared Gooden,Red,Welterweight
+03/04/2023,Jon Jones,Ciryl Gane,Red,UFC Heavyweight Title
+03/04/2023,Valentina Shevchenko,Alexa Grasso,Blue,UFC Women's Flyweight Title
+03/04/2023,Geoff Neal,Shavkat Rakhmonov,Blue,Welterweight
+03/04/2023,Mateusz Gamrot,Jalin Turner,Red,Lightweight
+03/04/2023,Bo Nickal,Jamie Pickett,Red,Middleweight
+03/04/2023,Cody Garbrandt,Trevin Jones,Red,Bantamweight
+03/04/2023,Derek Brunson,Dricus Du Plessis,Blue,Middleweight
+03/04/2023,Viviane Araujo,Amanda Ribas,Blue,Women's Flyweight
+03/04/2023,Julian Marquez,Marc-Andre Barriault,Blue,Middleweight
+03/04/2023,Ian Machado Garry,Song Kenan,Red,Welterweight
+03/04/2023,Mana Martinez,Cameron Saaiman,Blue,Bantamweight
+03/04/2023,Jessica Penne,Tabatha Ricci,Blue,Women's Strawweight
+03/04/2023,Da'Mon Blackshear,Farid Basharat,Blue,Bantamweight
+03/04/2023,Esteban Ribovics,Loik Radzhabov,Blue,Lightweight
+02/25/2023,Andre Muniz,Brendan Allen,Blue,Middleweight
+02/25/2023,Augusto Sakai,Don'Tale Mayes,Red,Heavyweight
+02/25/2023,Tatiana Suarez,Montana De La Rosa,Red,Women's Flyweight
+02/25/2023,Mike Malott,Yohan Lainesse,Red,Welterweight
+02/25/2023,Erick Gonzalez,Trevor Peek,Blue,Lightweight
+02/25/2023,Jasmine Jasudavicius,Gabriella Fernandes,Red,Women's Flyweight
+02/25/2023,Jordan Leavitt,Victor Martinez,Red,Lightweight
+02/25/2023,Ode Osbourne,Charles Johnson,Red,Catch Weight
+02/25/2023,Joe Solecki,Carl Deaton,Red,Lightweight
+02/25/2023,Rafael Alves,Nurullo Aliev,Blue,Lightweight
+02/18/2023,Jessica Andrade,Erin Blanchfield,Blue,Women's Flyweight
+02/18/2023,Jordan Wright,Zac Pauga,Blue,Light Heavyweight
+02/18/2023,Josh Parisian,Jamal Pogues,Blue,Heavyweight
+02/18/2023,William Knight,Marcin Prachnio,Blue,Light Heavyweight
+02/18/2023,Jim Miller,Alexander Hernandez,Blue,Lightweight
+02/18/2023,Nazim Sadykhov,Evan Elder,Red,Lightweight
+02/18/2023,Lina Lansberg,Mayra Bueno Silva,Blue,Women's Bantamweight
+02/18/2023,Jamall Emmers,Khusein Askhabov,Red,Featherweight
+02/18/2023,Ovince Saint Preux,Philipe Lins,Blue,Light Heavyweight
+02/18/2023,AJ Fletcher,Themba Gorimbo,Red,Welterweight
+02/18/2023,Clayton Carpenter,Juancamilo Ronderos,Red,Flyweight
+02/11/2023,Islam Makhachev,Alexander Volkanovski,Red,UFC Lightweight Title
+02/11/2023,Yair Rodriguez,Josh Emmett,Red,UFC Interim Featherweight Title
+02/11/2023,Jack Della Maddalena,Randy Brown,Red,Welterweight
+02/11/2023,Justin Tafa,Parker Porter,Red,Heavyweight
+02/11/2023,Tyson Pedro,Modestas Bukauskas,Blue,Light Heavyweight
+02/11/2023,Josh Culibao,Melsik Baghdasaryan,Red,Featherweight
+02/11/2023,Shannon Ross,Kleydson Rodrigues,Blue,Flyweight
+02/11/2023,Jamie Mullarkey,Francisco Prado,Red,Lightweight
+02/11/2023,Jack Jenkins,Don Shainis,Red,Featherweight
+02/11/2023,Loma Lookboonmee,Elise Reed,Red,Women's Strawweight
+02/11/2023,Shane Young,Blake Bilder,Blue,Featherweight
+02/11/2023,Zubaira Tukhugov,Elves Brener,Blue,Lightweight
+02/04/2023,Derrick Lewis,Serghei Spivac,Blue,Heavyweight
+02/04/2023,Da Woon Jung,Devin Clark,Blue,Light Heavyweight
+02/04/2023,Marcin Tybura,Blagoy Ivanov,Red,Heavyweight
+02/04/2023,Yusaku Kinoshita,Adam Fugitt,Blue,Welterweight
+02/04/2023,Jeka Saragih,Anshul Jubli,Blue,Lightweight
+02/04/2023,JeongYeong Lee,Yizha,Red,Featherweight
+02/04/2023,Toshiomi Kazama,Rinya Nakamura,Blue,Bantamweight
+02/04/2023,SeungGuk Choi,HyunSung Park,Blue,Flyweight
+02/04/2023,JunYong Park,Denis Tiuliulin,Red,Middleweight
+02/04/2023,Tatsuro Taira,Jesus Aguilar,Red,Flyweight
+01/21/2023,Glover Teixeira,Jamahal Hill,Blue,UFC Light Heavyweight Title
+01/21/2023,Deiveson Figueiredo,Brandon Moreno,Blue,UFC Flyweight Title
+01/21/2023,Gilbert Burns,Neil Magny,Red,Welterweight
+01/21/2023,Lauren Murphy,Jessica Andrade,Blue,Women's Flyweight
+01/21/2023,Paul Craig,Johnny Walker,Blue,Light Heavyweight
+01/21/2023,Mauricio Rua,Ihor Potieria,Blue,Light Heavyweight
+01/21/2023,Gregory Rodrigues,Brunno Ferreira,Blue,Middleweight
+01/21/2023,Thiago Moises,Melquizael Costa,Red,Lightweight
+01/21/2023,Gabriel Bonfim,Mounir Lazzez,Red,Welterweight
+01/21/2023,Shamil Abdurakhimov,Jailton Almeida,Blue,Heavyweight
+01/21/2023,Luan Lacerda,Cody Stamann,Blue,Bantamweight
+01/21/2023,Ismael Bonfim,Terrance McKinney,Red,Lightweight
+01/21/2023,Warlley Alves,Nicolas Dalby,Blue,Welterweight
+01/21/2023,Josiane Nunes,Zarah Fairn,Red,Women's Featherweight
+01/21/2023,Saimon Oliveira,Daniel Marcos,Blue,Bantamweight
+01/14/2023,Sean Strickland,Nassourdine Imavov,Red,Light Heavyweight
+01/14/2023,Dan Ige,Damon Jackson,Red,Featherweight
+01/14/2023,Punahele Soriano,Roman Kopylov,Blue,Middleweight
+01/14/2023,Ketlen Vieira,Raquel Pennington,Blue,Women's Bantamweight
+01/14/2023,Umar Nurmagomedov,Raoni Barcelos,Red,Bantamweight
+01/14/2023,Javid Basharat,Mateus Mendonca,Red,Bantamweight
+01/14/2023,Claudio Ribeiro,Abdul Razak Alhassan,Blue,Middleweight
+01/14/2023,Mateusz Rebecki,Nick Fiore,Red,Lightweight
+01/14/2023,Allan Nascimento,Carlos Hernandez,Red,Flyweight
+01/14/2023,Dan Argueta,Nick Aguirre,Red,Featherweight
+01/14/2023,Charles Johnson,Jimmy Flick,Red,Flyweight
+12/17/2022,Jared Cannonier,Sean Strickland,Red,Middleweight
+12/17/2022,Arman Tsarukyan,Damir Ismagulov,Red,Lightweight
+12/17/2022,Amir Albazi,Alessandro Costa,Red,Flyweight
+12/17/2022,Alex Caceres,Julian Erosa,Red,Featherweight
+12/17/2022,Drew Dober,Bobby Green,Red,Lightweight
+12/17/2022,Cody Brundage,Michal Oleksiejczuk,Blue,Middleweight
+12/17/2022,Cheyanne Vlismas,Cory McKenna,Blue,Women's Strawweight
+12/17/2022,Jake Matthews,Matthew Semelsberger,Blue,Welterweight
+12/17/2022,Said Nurmagomedov,Saidyokub Kakhramonov,Red,Bantamweight
+12/17/2022,Rafa Garcia,Maheshate,Red,Lightweight
+12/17/2022,Bryan Battle,Rinat Fakhretdinov,Blue,Welterweight
+12/17/2022,David Dvorak,Manel Kape,Blue,Flyweight
+12/17/2022,Sergey Morozov,Journey Newson,Red,Bantamweight
+12/10/2022,Paddy Pimblett,Jared Gordon,Red,Lightweight
+12/10/2022,Santiago Ponzinibbio,Alex Morono,Red,Catch Weight
+12/10/2022,Darren Till,Dricus Du Plessis,Blue,Middleweight
+12/10/2022,Bryce Mitchell,Ilia Topuria,Blue,Featherweight
+12/10/2022,Raul Rosas Jr.,Jay Perrin,Red,Bantamweight
+12/10/2022,Jairzinho Rozenstruik,Chris Daukaus,Red,Heavyweight
+12/10/2022,Edmen Shahbazyan,Dalcha Lungiambula,Red,Middleweight
+12/10/2022,Chris Curtis,Joaquin Buckley,Red,Middleweight
+12/10/2022,Billy Quarantillo,Alexander Hernandez,Red,Featherweight
+12/10/2022,TJ Brown,Erik Silva,Red,Featherweight
+12/10/2022,Cameron Saaiman,Steven Koslow,Red,Bantamweight
+12/03/2022,Stephen Thompson,Kevin Holland,Red,Welterweight
+12/03/2022,Bryan Barberena,Rafael Dos Anjos,Blue,Welterweight
+12/03/2022,Matheus Nicolau,Matt Schnell,Red,Flyweight
+12/03/2022,Tai Tuivasa,Sergei Pavlovich,Blue,Heavyweight
+12/03/2022,Jack Hermansson,Roman Dolidze,Blue,Middleweight
+12/03/2022,Eryk Anders,Kyle Daukaus,Red,Middleweight
+12/03/2022,Niko Price,Phil Rowe,Blue,Welterweight
+12/03/2022,Angela Hill,Emily Ducote,Red,Women's Strawweight
+12/03/2022,Clay Guida,Scott Holtzman,Red,Lightweight
+12/03/2022,Michael Johnson,Marc Diakiese,Red,Lightweight
+12/03/2022,Darren Elkins,Jonathan Pearce,Blue,Featherweight
+12/03/2022,Natan Levy,Genaro Valdez,Red,Lightweight
+12/03/2022,Marcelo Rojo,Francis Marshall,Blue,Featherweight
+12/03/2022,Yazmin Jauregui,Istela Nunes,Red,Women's Strawweight
+11/19/2022,Kennedy Nzechukwu,Ion Cutelaba,Red,Light Heavyweight
+11/19/2022,Chase Sherman,Waldo Cortes-Acosta,Blue,Heavyweight
+11/19/2022,Andre Fialho,Muslim Salikhov,Blue,Welterweight
+11/19/2022,Jack Della Maddalena,Danny Roberts,Red,Welterweight
+11/19/2022,Charles Johnson,Zhalgas Zhumagulov,Red,Flyweight
+11/19/2022,Jennifer Maia,Maryna Moroz,Red,Women's Flyweight
+11/19/2022,Vince Morales,Miles Johns,Blue,Bantamweight
+11/19/2022,Ricky Turcios,Kevin Natividad,Red,Bantamweight
+11/19/2022,Vanessa Demopoulos,Maria Oliveira,Red,Women's Strawweight
+11/19/2022,Brady Hiestand,Fernie Garcia,Red,Bantamweight
+11/19/2022,Natalia Silva,Tereza Bleda,Red,Women's Flyweight
+11/12/2022,Israel Adesanya,Alex Pereira,Blue,UFC Middleweight Title
+11/12/2022,Carla Esparza,Zhang Weili,Blue,UFC Women's Strawweight Title
+11/12/2022,Dustin Poirier,Michael Chandler,Red,Lightweight
+11/12/2022,Frankie Edgar,Chris Gutierrez,Blue,Bantamweight
+11/12/2022,Dan Hooker,Claudio Puelles,Red,Lightweight
+11/12/2022,Brad Riddell,Renato Moicano,Blue,Lightweight
+11/12/2022,Dominick Reyes,Ryan Spann,Blue,Light Heavyweight
+11/12/2022,Erin Blanchfield,Molly McCann,Red,Women's Flyweight
+11/12/2022,Andre Petroski,Wellington Turman,Red,Middleweight
+11/12/2022,Matt Frevola,Ottman Azaitar,Red,Lightweight
+11/12/2022,Karolina Kowalkiewicz,Silvana Gomez Juarez,Red,Women's Strawweight
+11/12/2022,Michael Trizano,SeungWoo Choi,Red,Featherweight
+11/12/2022,Julio Arce,Montel Jackson,Blue,Bantamweight
+11/12/2022,Carlos Ulberg,Nicolae Negumereanu,Red,Light Heavyweight
+11/05/2022,Marina Rodriguez,Amanda Lemos,Blue,Women's Strawweight
+11/05/2022,Neil Magny,Daniel Rodriguez,Red,Welterweight
+11/05/2022,Darrick Minner,Shayilan Nuerdanbieke,Blue,Featherweight
+11/05/2022,Tagir Ulanbekov,Nate Maness,Red,Flyweight
+11/05/2022,Grant Dawson,Mark Madsen,Red,Lightweight
+11/05/2022,Miranda Maverick,Shanna Young,Red,Women's Flyweight
+11/05/2022,Mario Bautista,Benito Lopez,Red,Bantamweight
+11/05/2022,Polyana Viana,Jinh Yu Frey,Red,Women's Strawweight
+11/05/2022,Liudvik Sholinian,Johnny Munoz,Blue,Bantamweight
+11/05/2022,Carlos Candelario,Jake Hadley,Blue,Flyweight
+11/05/2022,Tamires Vidal,Ramona Pascual,Red,Women's Bantamweight
+10/29/2022,Calvin Kattar,Arnold Allen,Blue,Featherweight
+10/29/2022,Tim Means,Max Griffin,Blue,Welterweight
+10/29/2022,Waldo Cortes-Acosta,Jared Vanderaa,Red,Heavyweight
+10/29/2022,Josh Fremd,Tresean Gore,Blue,Middleweight
+10/29/2022,Dustin Jacoby,Khalil Rountree Jr.,Blue,Light Heavyweight
+10/29/2022,Phil Hawes,Roman Dolidze,Blue,Middleweight
+10/29/2022,Andrei Arlovski,Marcos Rogerio de Lima,Blue,Heavyweight
+10/29/2022,Joseph Holmes,JunYong Park,Blue,Middleweight
+10/29/2022,Chase Hooper,Steve Garcia,Blue,Featherweight
+10/29/2022,Cody Durden,Carlos Mota,Red,Flyweight
+10/29/2022,Christian Rodriguez,Joshua Weems,Red,Bantamweight
+10/22/2022,Charles Oliveira,Islam Makhachev,Blue,UFC Lightweight Title
+10/22/2022,Aljamain Sterling,TJ Dillashaw,Red,UFC Bantamweight Title
+10/22/2022,Petr Yan,Sean O'Malley,Blue,Bantamweight
+10/22/2022,Beneil Dariush,Mateusz Gamrot,Red,Lightweight
+10/22/2022,Katlyn Cerminara,Manon Fiorot,Blue,Women's Flyweight
+10/22/2022,Belal Muhammad,Sean Brady,Red,Welterweight
+10/22/2022,Makhmud Muradov,Caio Borralho,Blue,Middleweight
+10/22/2022,Volkan Oezdemir,Nikita Krylov,Blue,Light Heavyweight
+10/22/2022,Abubakar Nurmagomedov,Gadzhi Omargadzhiev,Red,Welterweight
+10/22/2022,Armen Petrosyan,AJ Dobson,Red,Middleweight
+10/22/2022,Muhammad Mokaev,Malcolm Gordon,Red,Flyweight
+10/22/2022,Karol Rosa,Lina Lansberg,Red,Women's Bantamweight
+10/15/2022,Alexa Grasso,Viviane Araujo,Red,Women's Flyweight
+10/15/2022,Cub Swanson,Jonathan Martinez,Blue,Bantamweight
+10/15/2022,Jordan Wright,Dusko Todorovic,Blue,Middleweight
+10/15/2022,Raphael Assuncao,Victor Henry,Red,Bantamweight
+10/15/2022,Misha Cirkunov,Alonzo Menifield,Blue,Light Heavyweight
+10/15/2022,Mana Martinez,Brandon Davis,Red,Bantamweight
+10/15/2022,Nick Maximov,Jacob Malkoun,Blue,Middleweight
+10/15/2022,Joanderson Brito,Lucas Alexander,Red,Featherweight
+10/15/2022,Piera Rodriguez,Sam Hughes,Red,Women's Strawweight
+10/15/2022,Tatsuro Taira,CJ Vergara,Red,Flyweight
+10/15/2022,Mike Jackson,Pete Rodriguez,Blue,Welterweight
+10/01/2022,Mackenzie Dern,Yan Xiaonan,Blue,Women's Strawweight
+10/01/2022,Randy Brown,Francisco Trinaldo,Red,Welterweight
+10/01/2022,Raoni Barcelos,Trevin Jones,Red,Bantamweight
+10/01/2022,Sodiq Yusuff,Don Shainis,Red,Featherweight
+10/01/2022,Mike Davis,Viacheslav Borshchev,Red,Lightweight
+10/01/2022,John Castaneda,Daniel Santos,Blue,Catch Weight
+10/01/2022,Ilir Latifi,Aleksei Oleinik,Red,Heavyweight
+10/01/2022,Joaquim Silva,Jesse Ronson,Red,Lightweight
+10/01/2022,Krzysztof Jotko,Brendan Allen,Blue,Middleweight
+10/01/2022,Julija Stoliarenko,Chelsea Chandler,Blue,Catch Weight
+10/01/2022,Guido Cannetti,Randy Costa,Red,Bantamweight
+09/17/2022,Cory Sandhagen,Song Yadong,Red,Bantamweight
+09/17/2022,Chidi Njokuani,Gregory Rodrigues,Blue,Middleweight
+09/17/2022,Andre Fili,Bill Algeo,Red,Featherweight
+09/17/2022,Joe Pyfer,Alen Amedovski,Red,Middleweight
+09/17/2022,Tanner Boser,Rodrigo Nascimento,Blue,Heavyweight
+09/17/2022,Anthony Hernandez,Marc-Andre Barriault,Red,Middleweight
+09/17/2022,Damon Jackson,Pat Sabatini,Red,Featherweight
+09/17/2022,Trevin Giles,Louis Cosce,Red,Welterweight
+09/17/2022,Denise Gomes,Loma Lookboonmee,Blue,Women's Strawweight
+09/17/2022,Trey Ogden,Daniel Zellhuber,Red,Lightweight
+09/17/2022,Mariya Agapova,Gillian Robertson,Blue,Women's Flyweight
+09/17/2022,Tony Gravely,Javid Basharat,Blue,Bantamweight
+09/17/2022,Nikolas Motta,Cameron VanCamp,Red,Lightweight
+09/10/2022,Nate Diaz,Tony Ferguson,Red,Welterweight
+09/10/2022,Khamzat Chimaev,Kevin Holland,Red,Catch Weight
+09/10/2022,Li Jingliang,Daniel Rodriguez,Blue,Catch Weight
+09/10/2022,Irene Aldana,Macy Chiasson,Red,Catch Weight
+09/10/2022,Johnny Walker,Ion Cutelaba,Red,Light Heavyweight
+09/10/2022,Hakeem Dawodu,Julian Erosa,Blue,Featherweight
+09/10/2022,Jailton Almeida,Anton Turkalj,Red,Catch Weight
+09/10/2022,Denis Tiuliulin,Jamie Pickett,Red,Middleweight
+09/10/2022,Jake Collier,Chris Barnett,Blue,Heavyweight
+09/10/2022,Norma Dumont,Danyelle Wolf,Red,Women's Featherweight
+09/10/2022,Chad Anheliger,Alatengheili,Blue,Bantamweight
+09/10/2022,Melissa Martinez,Elise Reed,Blue,Women's Strawweight
+09/10/2022,Darian Weeks,Yohan Lainesse,Blue,Welterweight
+09/03/2022,Ciryl Gane,Tai Tuivasa,Red,Heavyweight
+09/03/2022,Robert Whittaker,Marvin Vettori,Red,Middleweight
+09/03/2022,Nassourdine Imavov,Joaquin Buckley,Red,Middleweight
+09/03/2022,Alessio Di Chirico,Roman Kopylov,Blue,Middleweight
+09/03/2022,William Gomis,Jarno Errens,Red,Featherweight
+09/03/2022,Charles Jourdain,Nathaniel Wood,Blue,Featherweight
+09/03/2022,Abus Magomedov,Dustin Stoltzfus,Red,Middleweight
+09/03/2022,John Makdessi,Nasrat Haqparast,Blue,Lightweight
+09/03/2022,Fares Ziam,Michal Figlak,Red,Lightweight
+09/03/2022,Benoit Saint Denis,Gabriel Miranda,Red,Lightweight
+09/03/2022,Khalid Taha,Cristian Quinonez,Blue,Bantamweight
+09/03/2022,Stephanie Egger,Ailin Perez,Red,Women's Featherweight
+08/20/2022,Kamaru Usman,Leon Edwards,Blue,UFC Welterweight Title
+08/20/2022,Paulo Costa,Luke Rockhold,Red,Middleweight
+08/20/2022,Jose Aldo,Merab Dvalishvili,Blue,Bantamweight
+08/20/2022,Wu Yanan,Lucie Pudilova,Blue,Women's Bantamweight
+08/20/2022,Tyson Pedro,Harry Hunsucker,Red,Light Heavyweight
+08/20/2022,Marcin Tybura,Alexandr Romanov,Red,Heavyweight
+08/20/2022,Leonardo Santos,Jared Gordon,Blue,Lightweight
+08/20/2022,AJ Fletcher,Ange Loosa,Blue,Welterweight
+08/20/2022,Amir Albazi,Francisco Figueiredo,Red,Flyweight
+08/20/2022,Aoriqileng,Jay Perrin,Red,Bantamweight
+08/20/2022,Daniel Lacerda,Victor Altamirano,Blue,Flyweight
+08/13/2022,Marlon Vera,Dominick Cruz,Red,Bantamweight
+08/13/2022,Nate Landwehr,David Onama,Red,Featherweight
+08/13/2022,Yazmin Jauregui,Iasmin Lucindo,Red,Women's Strawweight
+08/13/2022,Devin Clark,Azamat Murzakanov,Blue,Light Heavyweight
+08/13/2022,Priscila Cachoeira,Ariane Lipski,Red,Women's Bantamweight
+08/13/2022,Bruno Silva,Gerald Meerschaert,Blue,Middleweight
+08/13/2022,Angela Hill,Loopy Godinez,Red,Catch Weight
+08/13/2022,Martin Buday,Lukasz Brzeski,Red,Heavyweight
+08/13/2022,Cynthia Calvillo,Nina Nunes,Blue,Women's Flyweight
+08/13/2022,Gabriel Benitez,Charlie Ontiveros,Red,Lightweight
+08/13/2022,Ode Osbourne,Tyson Nam,Blue,Flyweight
+08/13/2022,Jason Witt,Josh Quinlan,Blue,Catch Weight
+08/06/2022,Thiago Santos,Jamahal Hill,Blue,Light Heavyweight
+08/06/2022,Vicente Luque,Geoff Neal,Blue,Welterweight
+08/06/2022,Mohammed Usman,Zac Pauga,Red,Heavyweight
+08/06/2022,Brogan Walker,Juliana Miller,Blue,Women's Flyweight
+08/06/2022,Augusto Sakai,Serghei Spivac,Blue,Heavyweight
+08/06/2022,Terrance McKinney,Erick Gonzalez,Red,Lightweight
+08/06/2022,Sam Alvey,Michal Oleksiejczuk,Blue,Middleweight
+08/06/2022,Bryan Battle,Takashi Sato,Red,Welterweight
+08/06/2022,Cory McKenna,Miranda Granger,Red,Women's Strawweight
+08/06/2022,Mayra Bueno Silva,Stephanie Egger,Red,Women's Bantamweight
+07/30/2022,Julianna Pena,Amanda Nunes,Blue,UFC Women's Bantamweight Title
+07/30/2022,Brandon Moreno,Kai Kara-France,Red,UFC Interim Flyweight Title
+07/30/2022,Derrick Lewis,Sergei Pavlovich,Blue,Heavyweight
+07/30/2022,Alexandre Pantoja,Alex Perez,Red,Flyweight
+07/30/2022,Magomed Ankalaev,Anthony Smith,Red,Light Heavyweight
+07/30/2022,Alex Morono,Matthew Semelsberger,Red,Welterweight
+07/30/2022,Drew Dober,Rafael Alves,Red,Lightweight
+07/30/2022,Drakkar Klose,Rafa Garcia,Red,Lightweight
+07/30/2022,Michael Morales,Adam Fugitt,Red,Welterweight
+07/30/2022,Joselyne Edwards,Ji Yeon Kim,Red,Women's Bantamweight
+07/30/2022,Nicolae Negumereanu,Ihor Potieria,Red,Light Heavyweight
+07/30/2022,Orion Cosce,Blood Diamond,Red,Welterweight
+07/23/2022,Curtis Blaydes,Tom Aspinall,Red,Heavyweight
+07/23/2022,Jack Hermansson,Chris Curtis,Red,Middleweight
+07/23/2022,Paddy Pimblett,Jordan Leavitt,Red,Lightweight
+07/23/2022,Nikita Krylov,Alexander Gustafsson,Red,Light Heavyweight
+07/23/2022,Molly McCann,Hannah Goldy,Red,Women's Flyweight
+07/23/2022,Paul Craig,Volkan Oezdemir,Blue,Light Heavyweight
+07/23/2022,Mason Jones,Ludovit Klein,Blue,Lightweight
+07/23/2022,Marc Diakiese,Damir Hadzovic,Red,Lightweight
+07/23/2022,Nathaniel Wood,Charles Rosa,Red,Featherweight
+07/23/2022,Makwan Amirkhani,Jonathan Pearce,Blue,Featherweight
+07/23/2022,Muhammad Mokaev,Charles Johnson,Red,Flyweight
+07/23/2022,Jai Herbert,Kyle Nelson,Red,Lightweight
+07/23/2022,Mandy Bohm,Victoria Leonardo,Blue,Women's Flyweight
+07/23/2022,Claudio Silva,Nicolas Dalby,Blue,Welterweight
+07/16/2022,Brian Ortega,Yair Rodriguez,Blue,Featherweight
+07/16/2022,Michelle Waterson-Gomez,Amanda Lemos,Blue,Women's Strawweight
+07/16/2022,Li Jingliang,Muslim Salikhov,Red,Welterweight
+07/16/2022,Matt Schnell,Sumudaerji,Red,Flyweight
+07/16/2022,Shane Burgos,Charles Jourdain,Red,Featherweight
+07/16/2022,Lauren Murphy,Miesha Tate,Red,Women's Flyweight
+07/16/2022,Punahele Soriano,Dalcha Lungiambula,Red,Middleweight
+07/16/2022,Ricky Simon,Jack Shore,Red,Bantamweight
+07/16/2022,Bill Algeo,Herbert Burns,Red,Featherweight
+07/16/2022,Dustin Jacoby,Da Woon Jung,Red,Light Heavyweight
+07/16/2022,Dwight Grant,Dustin Stoltzfus,Blue,Middleweight
+07/16/2022,Jessica Penne,Emily Ducote,Blue,Women's Strawweight
+07/09/2022,Rafael Dos Anjos,Rafael Fiziev,Blue,Lightweight
+07/09/2022,Caio Borralho,Armen Petrosyan,Red,Middleweight
+07/09/2022,Douglas Silva de Andrade,Said Nurmagomedov,Blue,Bantamweight
+07/09/2022,Jared Vanderaa,Chase Sherman,Blue,Heavyweight
+07/09/2022,Aiemann Zahabi,Ricky Turcios,Red,Bantamweight
+07/09/2022,Michael Johnson,Jamie Mullarkey,Blue,Lightweight
+07/09/2022,Cody Brundage,Tresean Gore,Red,Middleweight
+07/09/2022,Antonina Shevchenko,Cortney Casey,Red,Women's Flyweight
+07/09/2022,David Onama,Garrett Armfield,Red,Featherweight
+07/09/2022,Kennedy Nzechukwu,Karl Roberson,Red,Light Heavyweight
+07/09/2022,Ronnie Lawrence,Saidyokub Kakhramonov,Blue,Bantamweight
+07/02/2022,Israel Adesanya,Jared Cannonier,Red,UFC Middleweight Title
+07/02/2022,Alexander Volkanovski,Max Holloway,Red,UFC Featherweight Title
+07/02/2022,Sean Strickland,Alex Pereira,Blue,Middleweight
+07/02/2022,Robbie Lawler,Bryan Barberena,Blue,Welterweight
+07/02/2022,Brad Riddell,Jalin Turner,Blue,Lightweight
+07/02/2022,Jim Miller,Donald Cerrone,Red,Welterweight
+07/02/2022,Ian Machado Garry,Gabe Green,Red,Welterweight
+07/02/2022,Brad Tavares,Dricus Du Plessis,Blue,Middleweight
+07/02/2022,Uriah Hall,Andre Muniz,Blue,Middleweight
+07/02/2022,Jessica Eye,Maycee Barber,Blue,Women's Flyweight
+07/02/2022,Jessica-Rose Clark,Julija Stoliarenko,Blue,Women's Bantamweight
+06/25/2022,Arman Tsarukyan,Mateusz Gamrot,Blue,Lightweight
+06/25/2022,Neil Magny,Shavkat Rakhmonov,Blue,Welterweight
+06/25/2022,Josh Parisian,Alan Baudot,Red,Heavyweight
+06/25/2022,Thiago Moises,Christos Giagos,Red,Lightweight
+06/25/2022,Nate Maness,Umar Nurmagomedov,Blue,Bantamweight
+06/25/2022,Chris Curtis,Rodolfo Vieira,Red,Middleweight
+06/25/2022,Carlos Ulberg,Tafon Nchukwi,Red,Light Heavyweight
+06/25/2022,Shayilan Nuerdanbieke,TJ Brown,Red,Featherweight
+06/25/2022,Raulian Paiva,Sergey Morozov,Blue,Bantamweight
+06/25/2022,JP Buys,Cody Durden,Blue,Flyweight
+06/25/2022,Brian Kelleher,Mario Bautista,Blue,Bantamweight
+06/25/2022,Vanessa Demopoulos,Jinh Yu Frey,Red,Women's Strawweight
+06/18/2022,Calvin Kattar,Josh Emmett,Blue,Featherweight
+06/18/2022,Tim Means,Kevin Holland,Blue,Welterweight
+06/18/2022,Joaquin Buckley,Albert Duraev,Red,Middleweight
+06/18/2022,Damir Ismagulov,Guram Kutateladze,Red,Lightweight
+06/18/2022,Julian Marquez,Gregory Rodrigues,Blue,Middleweight
+06/18/2022,Adrian Yanez,Tony Kelley,Red,Bantamweight
+06/18/2022,Jasmine Jasudavicius,Natalia Silva,Blue,Women's Flyweight
+06/18/2022,Court McGee,Jeremiah Wells,Blue,Welterweight
+06/18/2022,Ricardo Ramos,Danny Chavez,Red,Featherweight
+06/18/2022,Maria Oliveira,Gloria de Paula,Red,Women's Strawweight
+06/18/2022,Eddie Wineland,Cody Stamann,Blue,Bantamweight
+06/18/2022,Phil Hawes,Deron Winn,Red,Middleweight
+06/18/2022,Roman Dolidze,Kyle Daukaus,Red,Middleweight
+06/11/2022,Glover Teixeira,Jiri Prochazka,Blue,UFC Light Heavyweight Title
+06/11/2022,Valentina Shevchenko,Taila Santos,Red,UFC Women's Flyweight Title
+06/11/2022,Zhang Weili,Joanna Jedrzejczyk,Red,Women's Strawweight
+06/11/2022,Andre Fialho,Jake Matthews,Blue,Welterweight
+06/11/2022,Jack Della Maddalena,Ramazan Emeev,Red,Welterweight
+06/11/2022,SeungWoo Choi,Josh Culibao,Blue,Featherweight
+06/11/2022,Maheshate,Steve Garcia,Red,Lightweight
+06/11/2022,Brendan Allen,Jacob Malkoun,Red,Middleweight
+06/11/2022,Kyung Ho Kang,Batgerel Danaa,Red,Bantamweight
+06/11/2022,Liang Na,Silvana Gomez Juarez,Blue,Women's Strawweight
+06/11/2022,Ramona Pascual,Joselyne Edwards,Blue,Women's Featherweight
+06/04/2022,Alexander Volkov,Jairzinho Rozenstruik,Red,Heavyweight
+06/04/2022,Dan Ige,Movsar Evloev,Blue,Featherweight
+06/04/2022,Michael Trizano,Lucas Almeida,Blue,Featherweight
+06/04/2022,Karine Silva,Poliana Botelho,Red,Women's Flyweight
+06/04/2022,Ode Osbourne,Zarrukh Adashev,Red,Flyweight
+06/04/2022,Alonzo Menifield,Askar Mozharov,Red,Light Heavyweight
+06/04/2022,Felice Herrig,Karolina Kowalkiewicz,Blue,Women's Strawweight
+06/04/2022,Joe Solecki,Alex Da Silva,Red,Lightweight
+06/04/2022,Damon Jackson,Dan Argueta,Red,Featherweight
+06/04/2022,Niklas Stolze,Benoit Saint Denis,Blue,Lightweight
+06/04/2022,Johnny Munoz,Tony Gravely,Blue,Bantamweight
+06/04/2022,Jeff Molina,Zhalgas Zhumagulov,Red,Flyweight
+06/04/2022,Rinat Fakhretdinov,Andreas Michailidis,Red,Welterweight
+06/04/2022,Erin Blanchfield,JJ Aldrich,Red,Women's Flyweight
+05/21/2022,Holly Holm,Ketlen Vieira,Blue,Women's Bantamweight
+05/21/2022,Santiago Ponzinibbio,Michel Pereira,Blue,Welterweight
+05/21/2022,Chidi Njokuani,Dusko Todorovic,Red,Middleweight
+05/21/2022,Polyana Viana,Tabatha Ricci,Blue,Women's Strawweight
+05/21/2022,Eryk Anders,JunYong Park,Blue,Middleweight
+05/21/2022,Joseph Holmes,Alen Amedovski,Red,Middleweight
+05/21/2022,Jailton Almeida,Parker Porter,Red,Heavyweight
+05/21/2022,Omar Morales,Uros Medic,Blue,Lightweight
+05/21/2022,Jonathan Martinez,Vince Morales,Red,Bantamweight
+05/21/2022,Chase Hooper,Felipe Colares,Red,Featherweight
+05/21/2022,Elise Reed,Sam Hughes,Blue,Women's Strawweight
+05/14/2022,Jan Blachowicz,Aleksandar Rakic,Red,Light Heavyweight
+05/14/2022,Ryan Spann,Ion Cutelaba,Red,Light Heavyweight
+05/14/2022,Davey Grant,Louis Smolka,Red,Bantamweight
+05/14/2022,Katlyn Cerminara,Amanda Ribas,Red,Women's Flyweight
+05/14/2022,Frank Camacho,Manuel Torres,Blue,Lightweight
+05/14/2022,Jake Hadley,Allan Nascimento,Blue,Flyweight
+05/14/2022,Viviane Araujo,Andrea Lee,Red,Women's Flyweight
+05/14/2022,Michael Johnson,Alan Patrick,Red,Lightweight
+05/14/2022,Virna Jandiroba,Angela Hill,Red,Women's Strawweight
+05/14/2022,Tatsuro Taira,Carlos Candelario,Red,Flyweight
+05/14/2022,Nick Maximov,Andre Petroski,Blue,Middleweight
+05/07/2022,Charles Oliveira,Justin Gaethje,Red,Lightweight
+05/07/2022,Rose Namajunas,Carla Esparza,Blue,UFC Women's Strawweight Title
+05/07/2022,Michael Chandler,Tony Ferguson,Red,Lightweight
+05/07/2022,Mauricio Rua,Ovince Saint Preux,Blue,Light Heavyweight
+05/07/2022,Randy Brown,Khaos Williams,Red,Welterweight
+05/07/2022,Francisco Trinaldo,Danny Roberts,Red,Welterweight
+05/07/2022,Macy Chiasson,Norma Dumont,Red,Women's Featherweight
+05/07/2022,Brandon Royval,Matt Schnell,Red,Flyweight
+05/07/2022,Blagoy Ivanov,Marcos Rogerio de Lima,Red,Heavyweight
+05/07/2022,Andre Fialho,Cameron VanCamp,Red,Welterweight
+05/07/2022,Tracy Cortez,Melissa Gatto,Red,Women's Flyweight
+05/07/2022,Kleydson Rodrigues,CJ Vergara,Blue,Flyweight
+05/07/2022,Ariane Carnelossi,Loopy Godinez,Blue,Women's Strawweight
+05/07/2022,Journey Newson,Fernie Garcia,Red,Bantamweight
+04/30/2022,Rob Font,Marlon Vera,Blue,Bantamweight
+04/30/2022,Andrei Arlovski,Jake Collier,Red,Heavyweight
+04/30/2022,Andre Fili,Joanderson Brito,Blue,Featherweight
+04/30/2022,Jared Gordon,Grant Dawson,Blue,Lightweight
+04/30/2022,Darren Elkins,Tristan Connelly,Red,Featherweight
+04/30/2022,Krzysztof Jotko,Gerald Meerschaert,Red,Middleweight
+04/30/2022,Alexandr Romanov,Chase Sherman,Red,Heavyweight
+04/30/2022,Daniel Lacerda,Francisco Figueiredo,Blue,Flyweight
+04/30/2022,Gabe Green,Yohan Lainesse,Red,Welterweight
+04/30/2022,Natan Levy,Mike Breeden,Red,Lightweight
+04/30/2022,Gina Mazany,Shanna Young,Blue,Women's Flyweight
+04/23/2022,Amanda Lemos,Jessica Andrade,Blue,Women's Strawweight
+04/23/2022,Clay Guida,Claudio Puelles,Blue,Lightweight
+04/23/2022,Maycee Barber,Montana De La Rosa,Red,Women's Flyweight
+04/23/2022,Lando Vannata,Charles Jourdain,Blue,Featherweight
+04/23/2022,Jordan Wright,Marc-Andre Barriault,Blue,Catch Weight
+04/23/2022,Dwight Grant,Sergey Khandozhko,Blue,Welterweight
+04/23/2022,Tyson Pedro,Ike Villanueva,Red,Light Heavyweight
+04/23/2022,Aoriqileng,Cameron Else,Red,Bantamweight
+04/23/2022,Preston Parsons,Evan Elder,Red,Welterweight
+04/23/2022,Marcin Prachnio,Philipe Lins,Blue,Light Heavyweight
+04/23/2022,Dean Barry,Mike Jackson,Blue,Welterweight
+04/16/2022,Vicente Luque,Belal Muhammad,Blue,Welterweight
+04/16/2022,Caio Borralho,Gadzhi Omargadzhiev,Red,Middleweight
+04/16/2022,Miguel Baeza,Andre Fialho,Blue,Welterweight
+04/16/2022,Mayra Bueno Silva,Wu Yanan,Red,Women's Bantamweight
+04/16/2022,Pat Sabatini,TJ Laramie,Red,Featherweight
+04/16/2022,Mounir Lazzez,Ange Loosa,Red,Welterweight
+04/16/2022,Devin Clark,William Knight,Red,Heavyweight
+04/16/2022,Lina Lansberg,Pannie Kianzad,Blue,Women's Bantamweight
+04/16/2022,Drakkar Klose,Brandon Jenkins,Red,Lightweight
+04/16/2022,Rafa Garcia,Jesse Ronson,Red,Lightweight
+04/16/2022,Chris Barnett,Martin Buday,Blue,Heavyweight
+04/16/2022,Jordan Leavitt,Trey Ogden,Red,Lightweight
+04/16/2022,Istela Nunes,Sam Hughes,Blue,Women's Strawweight
+04/16/2022,Alatengheili,Kevin Croom,Red,Bantamweight
+04/09/2022,Alexander Volkanovski,Chan Sung Jung,Red,UFC Featherweight Title
+04/09/2022,Aljamain Sterling,Petr Yan,Red,UFC Bantamweight Title
+04/09/2022,Gilbert Burns,Khamzat Chimaev,Blue,Welterweight
+04/09/2022,Mackenzie Dern,Tecia Torres,Red,Women's Strawweight
+04/09/2022,Vinc Pichel,Mark Madsen,Blue,Lightweight
+04/09/2022,Ian Machado Garry,Darian Weeks,Red,Welterweight
+04/09/2022,Anthony Hernandez,Josh Fremd,Red,Middleweight
+04/09/2022,Aspen Ladd,Raquel Pennington,Blue,Women's Bantamweight
+04/09/2022,Mickey Gall,Mike Malott,Blue,Welterweight
+04/09/2022,Aleksei Oleinik,Jared Vanderaa,Red,Heavyweight
+04/09/2022,Piera Rodriguez,Kay Hansen,Red,Women's Strawweight
+04/09/2022,Julio Arce,Daniel Santos,Red,Bantamweight
+03/26/2022,Curtis Blaydes,Chris Daukaus,Red,Heavyweight
+03/26/2022,Joanne Wood,Alexa Grasso,Blue,Women's Flyweight
+03/26/2022,Matt Brown,Bryan Barberena,Blue,Welterweight
+03/26/2022,Askar Askarov,Kai Kara-France,Blue,Flyweight
+03/26/2022,Neil Magny,Max Griffin,Red,Welterweight
+03/26/2022,Marc Diakiese,Viacheslav Borshchev,Red,Lightweight
+03/26/2022,Sara McMann,Karol Rosa,Red,Women's Bantamweight
+03/26/2022,Chris Gutierrez,Batgerel Danaa,Red,Bantamweight
+03/26/2022,Aliaskhab Khizriev,Denis Tiuliulin,Red,Middleweight
+03/26/2022,Jennifer Maia,Manon Fiorot,Blue,Women's Flyweight
+03/26/2022,Matheus Nicolau,David Dvorak,Red,Flyweight
+03/26/2022,Luis Saldana,Bruno Souza,Red,Featherweight
+03/19/2022,Alexander Volkov,Tom Aspinall,Blue,Heavyweight
+03/19/2022,Arnold Allen,Dan Hooker,Red,Featherweight
+03/19/2022,Paddy Pimblett,Kazula Vargas,Red,Lightweight
+03/19/2022,Gunnar Nelson,Takashi Sato,Red,Welterweight
+03/19/2022,Molly McCann,Luana Carolina,Red,Women's Flyweight
+03/19/2022,Jai Herbert,Ilia Topuria,Blue,Lightweight
+03/19/2022,Mike Grundy,Makwan Amirkhani,Blue,Featherweight
+03/19/2022,Shamil Abdurakhimov,Sergei Pavlovich,Blue,Heavyweight
+03/19/2022,Nikita Krylov,Paul Craig,Blue,Light Heavyweight
+03/19/2022,Jack Shore,Timur Valiev,Red,Bantamweight
+03/19/2022,Cory McKenna,Elise Reed,Blue,Women's Strawweight
+03/19/2022,Muhammad Mokaev,Cody Durden,Red,Flyweight
+03/12/2022,Thiago Santos,Magomed Ankalaev,Blue,Light Heavyweight
+03/12/2022,Marlon Moraes,Song Yadong,Blue,Bantamweight
+03/12/2022,Sodiq Yusuff,Alex Caceres,Red,Featherweight
+03/12/2022,Khalil Rountree Jr.,Karl Roberson,Red,Light Heavyweight
+03/12/2022,Drew Dober,Terrance McKinney,Red,Lightweight
+03/12/2022,Alex Pereira,Bruno Silva,Red,Middleweight
+03/12/2022,Matthew Semelsberger,AJ Fletcher,Red,Welterweight
+03/12/2022,JJ Aldrich,Gillian Robertson,Red,Women's Flyweight
+03/12/2022,Trevin Jones,Javid Basharat,Blue,Bantamweight
+03/12/2022,Damon Jackson,Kamuela Kirk,Red,Featherweight
+03/12/2022,Sabina Mazo,Miranda Maverick,Blue,Women's Flyweight
+03/12/2022,Dalcha Lungiambula,Cody Brundage,Blue,Middleweight
+03/12/2022,Kris Moutinho,Guido Cannetti,Blue,Bantamweight
+03/12/2022,Tafon Nchukwi,Azamat Murzakanov,Blue,Light Heavyweight
+03/05/2022,Colby Covington,Jorge Masvidal,Red,Welterweight
+03/05/2022,Rafael Dos Anjos,Renato Moicano,Red,Catch Weight
+03/05/2022,Edson Barboza,Bryce Mitchell,Blue,Featherweight
+03/05/2022,Kevin Holland,Alex Oliveira,Red,Welterweight
+03/05/2022,Serghei Spivac,Greg Hardy,Red,Heavyweight
+03/05/2022,Jalin Turner,Jamie Mullarkey,Red,Lightweight
+03/05/2022,Marina Rodriguez,Yan Xiaonan,Red,Women's Strawweight
+03/05/2022,Nicolae Negumereanu,Kennedy Nzechukwu,Red,Light Heavyweight
+03/05/2022,Maryna Moroz,Mariya Agapova,Red,Women's Flyweight
+03/05/2022,Brian Kelleher,Umar Nurmagomedov,Blue,Featherweight
+03/05/2022,Tim Elliott,Tagir Ulanbekov,Red,Flyweight
+03/05/2022,Devonte Smith,Ludovit Klein,Blue,Lightweight
+03/05/2022,Dustin Jacoby,Michal Oleksiejczuk,Red,Light Heavyweight
+02/26/2022,Islam Makhachev,Bobby Green,Red,Catch Weight
+02/26/2022,Misha Cirkunov,Wellington Turman,Blue,Middleweight
+02/26/2022,Ji Yeon Kim,Priscila Cachoeira,Blue,Women's Flyweight
+02/26/2022,Arman Tsarukyan,Joel Alvarez,Red,Lightweight
+02/26/2022,Armen Petrosyan,Gregory Rodrigues,Red,Middleweight
+02/26/2022,Rongzhu,Ignacio Bahamondes,Blue,Lightweight
+02/26/2022,Josiane Nunes,Ramona Pascual,Red,Women's Featherweight
+02/26/2022,Terrance McKinney,Fares Ziam,Red,Lightweight
+02/26/2022,Alejandro Perez,Jonathan Martinez,Blue,Featherweight
+02/26/2022,Ramiz Brahimaj,Micheal Gillmore,Red,Welterweight
+02/26/2022,Victor Altamirano,Carlos Hernandez,Blue,Flyweight
+02/19/2022,Johnny Walker,Jamahal Hill,Blue,Light Heavyweight
+02/19/2022,Kyle Daukaus,Jamie Pickett,Red,Catch Weight
+02/19/2022,Parker Porter,Alan Baudot,Red,Heavyweight
+02/19/2022,Jim Miller,Nikolas Motta,Red,Lightweight
+02/19/2022,Joaquin Buckley,Abdul Razak Alhassan,Red,Middleweight
+02/19/2022,Gabriel Benitez,David Onama,Blue,Featherweight
+02/19/2022,Jessica-Rose Clark,Stephanie Egger,Blue,Women's Bantamweight
+02/19/2022,Chas Skelly,Mark Striegl,Red,Featherweight
+02/19/2022,Diana Belbita,Gloria de Paula,Blue,Women's Strawweight
+02/19/2022,Chad Anheliger,Jesse Strader,Red,Bantamweight
+02/19/2022,Jonathan Pearce,Christian Rodriguez,Red,Featherweight
+02/19/2022,Mario Bautista,Jay Perrin,Red,Bantamweight
+02/12/2022,Israel Adesanya,Robert Whittaker,Red,UFC Middleweight Title
+02/12/2022,Derrick Lewis,Tai Tuivasa,Blue,Heavyweight
+02/12/2022,Jared Cannonier,Derek Brunson,Red,Middleweight
+02/12/2022,Alexander Hernandez,Renato Moicano,Blue,Lightweight
+02/12/2022,Bobby Green,Nasrat Haqparast,Red,Lightweight
+02/12/2022,Andrei Arlovski,Jared Vanderaa,Red,Heavyweight
+02/12/2022,Roxanne Modafferi,Casey O'Neill,Blue,Women's Flyweight
+02/12/2022,Kyler Phillips,Marcelo Rojo,Red,Bantamweight
+02/12/2022,Carlos Ulberg,Fabio Cherant,Red,Light Heavyweight
+02/12/2022,Mana Martinez,Ronnie Lawrence,Blue,Bantamweight
+02/12/2022,AJ Dobson,Jacob Malkoun,Blue,Middleweight
+02/12/2022,Douglas Silva de Andrade,Sergey Morozov,Red,Bantamweight
+02/12/2022,Jeremiah Wells,Blood Diamond,Red,Welterweight
+02/12/2022,William Knight,Maxim Grishin,Blue,Heavyweight
+02/05/2022,Jack Hermansson,Sean Strickland,Blue,Middleweight
+02/05/2022,Punahele Soriano,Nick Maximov,Blue,Middleweight
+02/05/2022,Shavkat Rakhmonov,Carlston Harris,Red,Welterweight
+02/05/2022,Sam Alvey,Brendan Allen,Blue,Light Heavyweight
+02/05/2022,Tresean Gore,Bryan Battle,Blue,Middleweight
+02/05/2022,Julian Erosa,Steven Peterson,Red,Featherweight
+02/05/2022,Miles Johns,John Castaneda,Blue,Bantamweight
+02/05/2022,Hakeem Dawodu,Michael Trizano,Red,Featherweight
+02/05/2022,Chidi Njokuani,Marc-Andre Barriault,Red,Middleweight
+02/05/2022,Alexis Davis,Julija Stoliarenko,Red,Women's Bantamweight
+02/05/2022,Jailton Almeida,Danilo Marques,Red,Light Heavyweight
+02/05/2022,Jason Witt,Phil Rowe,Blue,Welterweight
+02/05/2022,Malcolm Gordon,Denys Bondar,Red,Flyweight
+01/22/2022,Francis Ngannou,Ciryl Gane,Red,UFC Heavyweight Title
+01/22/2022,Brandon Moreno,Deiveson Figueiredo,Blue,UFC Flyweight Title
+01/22/2022,Michel Pereira,Andre Fialho,Red,Welterweight
+01/22/2022,Cody Stamann,Said Nurmagomedov,Blue,Bantamweight
+01/22/2022,Michael Morales,Trevin Giles,Red,Welterweight
+01/22/2022,Raoni Barcelos,Victor Henry,Blue,Bantamweight
+01/22/2022,Jack Della Maddalena,Pete Rodriguez,Red,Welterweight
+01/22/2022,Tony Gravely,Saimon Oliveira,Red,Bantamweight
+01/22/2022,Matt Frevola,Genaro Valdez,Red,Lightweight
+01/22/2022,Silvana Gomez Juarez,Vanessa Demopoulos,Blue,Women's Strawweight
+01/22/2022,Kay Hansen,Jasmine Jasudavicius,Blue,Women's Flyweight
+01/15/2022,Calvin Kattar,Giga Chikadze,Red,Featherweight
+01/15/2022,Jake Collier,Chase Sherman,Red,Heavyweight
+01/15/2022,Brandon Royval,Rogerio Bontorin,Red,Flyweight
+01/15/2022,Katlyn Cerminara,Jennifer Maia,Red,Women's Flyweight
+01/15/2022,Dakota Bush,Viacheslav Borshchev,Blue,Lightweight
+01/15/2022,Bill Algeo,Joanderson Brito,Red,Featherweight
+01/15/2022,Jamie Pickett,Joseph Holmes,Red,Middleweight
+01/15/2022,Court McGee,Ramiz Brahimaj,Red,Welterweight
+01/15/2022,Brian Kelleher,Kevin Croom,Red,Featherweight
+01/15/2022,TJ Brown,Charles Rosa,Red,Lightweight
+12/18/2021,Derrick Lewis,Chris Daukaus,Red,Heavyweight
+12/18/2021,Stephen Thompson,Belal Muhammad,Blue,Welterweight
+12/18/2021,Amanda Lemos,Angela Hill,Red,Women's Strawweight
+12/18/2021,Raphael Assuncao,Ricky Simon,Blue,Bantamweight
+12/18/2021,Diego Ferreira,Mateusz Gamrot,Blue,Lightweight
+12/18/2021,Cub Swanson,Darren Elkins,Red,Featherweight
+12/18/2021,Dustin Stoltzfus,Gerald Meerschaert,Blue,Middleweight
+12/18/2021,Justin Tafa,Harry Hunsucker,Red,Heavyweight
+12/18/2021,Sijara Eubanks,Melissa Gatto,Blue,Women's Flyweight
+12/18/2021,Charles Jourdain,Andre Ewell,Red,Featherweight
+12/18/2021,Raquel Pennington,Macy Chiasson,Red,Women's Featherweight
+12/18/2021,Don'Tale Mayes,Josh Parisian,Red,Heavyweight
+12/18/2021,Jordan Leavitt,Matt Sayles,Red,Lightweight
+12/11/2021,Charles Oliveira,Dustin Poirier,Red,UFC Lightweight Title
+12/11/2021,Amanda Nunes,Julianna Pena,Blue,UFC Women's Bantamweight Title
+12/11/2021,Geoff Neal,Santiago Ponzinibbio,Red,Welterweight
+12/11/2021,Kai Kara-France,Cody Garbrandt,Red,Flyweight
+12/11/2021,Raulian Paiva,Sean O'Malley,Blue,Bantamweight
+12/11/2021,Josh Emmett,Dan Ige,Red,Featherweight
+12/11/2021,Pedro Munhoz,Dominick Cruz,Blue,Bantamweight
+12/11/2021,Augusto Sakai,Tai Tuivasa,Blue,Heavyweight
+12/11/2021,Jordan Wright,Bruno Silva,Blue,Middleweight
+12/11/2021,Andre Muniz,Eryk Anders,Red,Middleweight
+12/11/2021,Miranda Maverick,Erin Blanchfield,Blue,Women's Flyweight
+12/11/2021,Ryan Hall,Darrick Minner,Red,Featherweight
+12/11/2021,Randy Costa,Tony Kelley,Blue,Bantamweight
+12/11/2021,Gillian Robertson,Priscila Cachoeira,Red,Women's Flyweight
+12/04/2021,Rob Font,Jose Aldo,Blue,Bantamweight
+12/04/2021,Brad Riddell,Rafael Fiziev,Blue,Lightweight
+12/04/2021,Jimmy Crute,Jamahal Hill,Blue,Light Heavyweight
+12/04/2021,Clay Guida,Leonardo Santos,Red,Lightweight
+12/04/2021,Brendan Allen,Chris Curtis,Blue,Middleweight
+12/04/2021,Alex Morono,Mickey Gall,Red,Welterweight
+12/04/2021,Maki Pitolo,Dusko Todorovic,Blue,Middleweight
+12/04/2021,Manel Kape,Zhalgas Zhumagulov,Red,Flyweight
+12/04/2021,Bryan Barberena,Darian Weeks,Red,Welterweight
+12/04/2021,Cheyanne Vlismas,Mallory Martin,Red,Women's Strawweight
+12/04/2021,Alonzo Menifield,William Knight,Blue,Light Heavyweight
+12/04/2021,Claudio Puelles,Chris Gruetzemacher,Red,Lightweight
+12/04/2021,Louis Smolka,Vince Morales,Blue,Bantamweight
+11/20/2021,Ketlen Vieira,Miesha Tate,Red,Women's Bantamweight
+11/20/2021,Michael Chiesa,Sean Brady,Blue,Welterweight
+11/20/2021,Joanne Wood,Taila Santos,Blue,Women's Flyweight
+11/20/2021,Rani Yahya,Kyung Ho Kang,Red,Bantamweight
+11/20/2021,Davey Grant,Adrian Yanez,Blue,Bantamweight
+11/20/2021,Pat Sabatini,Tucker Lutz,Red,Featherweight
+11/20/2021,Rafa Garcia,Natan Levy,Red,Lightweight
+11/20/2021,Loma Lookboonmee,Loopy Godinez,Blue,Women's Strawweight
+11/20/2021,Cody Durden,Aoriqileng,Red,Flyweight
+11/20/2021,Shayilan Nuerdanbieke,Sean Soriano,Red,Featherweight
+11/20/2021,Luana Pinheiro,Sam Hughes,Red,Women's Strawweight
+11/13/2021,Max Holloway,Yair Rodriguez,Red,Featherweight
+11/13/2021,Ben Rothwell,Marcos Rogerio de Lima,Blue,Heavyweight
+11/13/2021,Felicia Spencer,Leah Letson,Red,Women's Featherweight
+11/13/2021,Miguel Baeza,Khaos Williams,Blue,Welterweight
+11/13/2021,Song Yadong,Julio Arce,Red,Bantamweight
+11/13/2021,Thiago Moises,Joel Alvarez,Blue,Lightweight
+11/13/2021,Cynthia Calvillo,Andrea Lee,Blue,Women's Flyweight
+11/13/2021,Sean Woodson,Collin Anglin,Red,Featherweight
+11/13/2021,Cortney Casey,Liana Jojua,Red,Women's Flyweight
+11/13/2021,Marc Diakiese,Rafael Alves,Blue,Lightweight
+11/13/2021,Kennedy Nzechukwu,Da Woon Jung,Blue,Light Heavyweight
+11/06/2021,Kamaru Usman,Colby Covington,Red,UFC Welterweight Title
+11/06/2021,Rose Namajunas,Zhang Weili,Red,UFC Women's Strawweight Title
+11/06/2021,Frankie Edgar,Marlon Vera,Blue,Bantamweight
+11/06/2021,Shane Burgos,Billy Quarantillo,Red,Featherweight
+11/06/2021,Justin Gaethje,Michael Chandler,Red,Lightweight
+11/06/2021,Alex Pereira,Andreas Michailidis,Red,Middleweight
+11/06/2021,Al Iaquinta,Bobby Green,Blue,Lightweight
+11/06/2021,Phil Hawes,Chris Curtis,Blue,Middleweight
+11/06/2021,Edmen Shahbazyan,Nassourdine Imavov,Blue,Middleweight
+11/06/2021,Ian Machado Garry,Jordan Williams,Red,Welterweight
+11/06/2021,Gian Villante,Chris Barnett,Blue,Heavyweight
+11/06/2021,Dustin Jacoby,John Allan,Red,Light Heavyweight
+11/06/2021,Melsik Baghdasaryan,Bruno Souza,Red,Featherweight
+11/06/2021,CJ Vergara,Ode Osbourne,Blue,Flyweight
+10/30/2021,Jan Blachowicz,Glover Teixeira,Blue,UFC Light Heavyweight Title
+10/30/2021,Petr Yan,Cory Sandhagen,Red,UFC Interim Bantamweight Title
+10/30/2021,Islam Makhachev,Dan Hooker,Red,Lightweight
+10/30/2021,Alexander Volkov,Marcin Tybura,Red,Heavyweight
+10/30/2021,Li Jingliang,Khamzat Chimaev,Blue,Welterweight
+10/30/2021,Magomed Ankalaev,Volkan Oezdemir,Red,Light Heavyweight
+10/30/2021,Amanda Ribas,Virna Jandiroba,Red,Women's Strawweight
+10/30/2021,Ricardo Ramos,Zubaira Tukhugov,Blue,Featherweight
+10/30/2021,Albert Duraev,Roman Kopylov,Red,Middleweight
+10/30/2021,Elizeu Zaleski dos Santos,Benoit Saint Denis,Red,Welterweight
+10/30/2021,Shamil Gamzatov,Michal Oleksiejczuk,Blue,Light Heavyweight
+10/30/2021,Makwan Amirkhani,Lerone Murphy,Blue,Featherweight
+10/30/2021,Hu Yaozong,Andre Petroski,Blue,Middleweight
+10/30/2021,Tagir Ulanbekov,Allan Nascimento,Red,Flyweight
+10/23/2021,Paulo Costa,Marvin Vettori,Blue,Light Heavyweight
+10/23/2021,Jessica-Rose Clark,Joselyne Edwards,Red,Women's Bantamweight
+10/23/2021,Alex Caceres,SeungWoo Choi,Red,Featherweight
+10/23/2021,Francisco Trinaldo,Dwight Grant,Red,Welterweight
+10/23/2021,Nicolae Negumereanu,Ike Villanueva,Red,Light Heavyweight
+10/23/2021,JunYong Park,Gregory Rodrigues,Blue,Middleweight
+10/23/2021,Mason Jones,David Onama,Red,Lightweight
+10/23/2021,Tabatha Ricci,Maria Oliveira,Red,Women's Strawweight
+10/23/2021,Jamie Pickett,Laureano Staropoli,Red,Middleweight
+10/23/2021,Khama Worthy,Jai Herbert,Blue,Lightweight
+10/23/2021,Jeff Molina,Daniel Lacerda,Red,Flyweight
+10/23/2021,Livinha Souza,Randa Markos,Blue,Women's Strawweight
+10/23/2021,Jonathan Martinez,Zviad Lazishvili,Red,Bantamweight
+10/16/2021,Aspen Ladd,Norma Dumont,Blue,Women's Featherweight
+10/16/2021,Andrei Arlovski,Carlos Felipe,Red,Heavyweight
+10/16/2021,Jim Miller,Erick Gonzalez,Red,Lightweight
+10/16/2021,Manon Fiorot,Mayra Bueno Silva,Red,Women's Flyweight
+10/16/2021,Nate Landwehr,Ludovit Klein,Red,Featherweight
+10/16/2021,Andrew Sanchez,Bruno Silva,Blue,Middleweight
+10/16/2021,Danny Roberts,Ramazan Emeev,Red,Welterweight
+10/16/2021,Loopy Godinez,Luana Carolina,Blue,Women's Flyweight
+10/16/2021,Batgerel Danaa,Brandon Davis,Red,Bantamweight
+10/16/2021,Istela Nunes,Ariane Carnelossi,Blue,Women's Strawweight
+10/09/2021,Mackenzie Dern,Marina Rodriguez,Blue,Women's Strawweight
+10/09/2021,Randy Brown,Jared Gooden,Red,Welterweight
+10/09/2021,Tim Elliott,Matheus Nicolau,Blue,Flyweight
+10/09/2021,Sabina Mazo,Mariya Agapova,Blue,Women's Flyweight
+10/09/2021,Chris Gutierrez,Felipe Colares,Red,Bantamweight
+10/09/2021,Alexandr Romanov,Jared Vanderaa,Red,Heavyweight
+10/09/2021,Charles Rosa,Damon Jackson,Blue,Featherweight
+10/09/2021,Loopy Godinez,Silvana Gomez Juarez,Red,Women's Strawweight
+10/09/2021,Steve Garcia,Charlie Ontiveros,Red,Lightweight
+10/02/2021,Thiago Santos,Johnny Walker,Red,Light Heavyweight
+10/02/2021,Alex Oliveira,Niko Price,Blue,Welterweight
+10/02/2021,Misha Cirkunov,Krzysztof Jotko,Blue,Middleweight
+10/02/2021,Alexander Hernandez,Mike Breeden,Red,Lightweight
+10/02/2021,Joe Solecki,Jared Gordon,Blue,Lightweight
+10/02/2021,Antonina Shevchenko,Casey O'Neill,Blue,Women's Flyweight
+10/02/2021,Bethe Correia,Karol Rosa,Blue,Women's Bantamweight
+10/02/2021,Devonte Smith,Jamie Mullarkey,Blue,Lightweight
+10/02/2021,Douglas Silva de Andrade,Gaetano Pirrello,Red,Bantamweight
+10/02/2021,Stephanie Egger,Shanna Young,Red,Women's Bantamweight
+10/02/2021,Alejandro Perez,Johnny Eduardo,Red,Bantamweight
+09/25/2021,Alexander Volkanovski,Brian Ortega,Red,UFC Featherweight Title
+09/25/2021,Valentina Shevchenko,Lauren Murphy,Red,UFC Women's Flyweight Title
+09/25/2021,Nick Diaz,Robbie Lawler,Blue,Middleweight
+09/25/2021,Curtis Blaydes,Jairzinho Rozenstruik,Red,Heavyweight
+09/25/2021,Jessica Andrade,Cynthia Calvillo,Red,Women's Flyweight
+09/25/2021,Marlon Moraes,Merab Dvalishvili,Blue,Bantamweight
+09/25/2021,Dan Hooker,Nasrat Haqparast,Red,Lightweight
+09/25/2021,Shamil Abdurakhimov,Chris Daukaus,Blue,Heavyweight
+09/25/2021,Roxanne Modafferi,Taila Santos,Blue,Women's Flyweight
+09/25/2021,Uros Medic,Jalin Turner,Blue,Lightweight
+09/25/2021,Cody Brundage,Nick Maximov,Blue,Middleweight
+09/25/2021,Matthew Semelsberger,Martin Sano,Red,Welterweight
+09/25/2021,Jonathan Pearce,Omar Morales,Red,Featherweight
+09/18/2021,Anthony Smith,Ryan Spann,Red,Light Heavyweight
+09/18/2021,Ion Cutelaba,Devin Clark,Red,Light Heavyweight
+09/18/2021,Ariane Lipski,Mandy Bohm,Red,Women's Flyweight
+09/18/2021,Arman Tsarukyan,Christos Giagos,Red,Lightweight
+09/18/2021,Nate Maness,Tony Gravely,Red,Bantamweight
+09/18/2021,Joaquin Buckley,Antonio Arroyo,Red,Middleweight
+09/18/2021,Mike Rodriguez,Tafon Nchukwi,Blue,Light Heavyweight
+09/18/2021,Pannie Kianzad,Raquel Pennington,Blue,Women's Bantamweight
+09/18/2021,Rongzhu,Brandon Jenkins,Red,Lightweight
+09/18/2021,Montel Jackson,JP Buys,Red,Bantamweight
+09/18/2021,Erin Blanchfield,Sarah Alpar,Red,Women's Flyweight
+09/18/2021,Impa Kasanganay,Carlston Harris,Blue,Welterweight
+09/18/2021,Emily Whitmire,Hannah Goldy,Blue,Women's Flyweight
+09/04/2021,Derek Brunson,Darren Till,Red,Middleweight
+09/04/2021,Tom Aspinall,Serghei Spivac,Red,Heavyweight
+09/04/2021,Alex Morono,David Zawada,Red,Welterweight
+09/04/2021,Modestas Bukauskas,Khalil Rountree Jr.,Blue,Light Heavyweight
+09/04/2021,Paddy Pimblett,Luigi Vendramini,Red,Lightweight
+09/04/2021,Molly McCann,Ji Yeon Kim,Red,Women's Flyweight
+09/04/2021,Jack Shore,Liudvik Sholinian,Red,Bantamweight
+09/04/2021,Julian Erosa,Charles Jourdain,Red,Catch Weight
+09/04/2021,Dalcha Lungiambula,Marc-Andre Barriault,Blue,Middleweight
+08/28/2021,Edson Barboza,Giga Chikadze,Blue,Featherweight
+08/28/2021,Bryan Battle,Gilbert Urbina,Red,Middleweight
+08/28/2021,Ricky Turcios,Brady Hiestand,Red,Bantamweight
+08/28/2021,Kevin Lee,Daniel Rodriguez,Blue,Welterweight
+08/28/2021,Andre Petroski,Micheal Gillmore,Red,Middleweight
+08/28/2021,Makhmud Muradov,Gerald Meerschaert,Blue,Middleweight
+08/28/2021,Alessio Di Chirico,Abdul Razak Alhassan,Blue,Middleweight
+08/28/2021,Sam Alvey,Wellington Turman,Blue,Middleweight
+08/28/2021,Dustin Jacoby,Darren Stewart,Red,Light Heavyweight
+08/28/2021,JJ Aldrich,Vanessa Demopoulos,Red,Women's Flyweight
+08/28/2021,Jamall Emmers,Pat Sabatini,Blue,Featherweight
+08/28/2021,Mana Martinez,Guido Cannetti,Red,Bantamweight
+08/21/2021,Jared Cannonier,Kelvin Gastelum,Red,Middleweight
+08/21/2021,Clay Guida,Mark Madsen,Blue,Lightweight
+08/21/2021,Parker Porter,Chase Sherman,Red,Heavyweight
+08/21/2021,Trevin Jones,Saidyokub Kakhramonov,Blue,Bantamweight
+08/21/2021,Vinc Pichel,Austin Hubbard,Red,Lightweight
+08/21/2021,Alexandre Pantoja,Brandon Royval,Red,Flyweight
+08/21/2021,Austin Lingo,Luis Saldana,Red,Featherweight
+08/21/2021,Brian Kelleher,Domingo Pilarte,Red,Bantamweight
+08/21/2021,Bea Malecki,Josiane Nunes,Blue,Women's Bantamweight
+08/21/2021,William Knight,Fabio Cherant,Red,Light Heavyweight
+08/21/2021,Roosevelt Roberts,Ignacio Bahamondes,Blue,Lightweight
+08/21/2021,Sasha Palatnikov,Ramiz Brahimaj,Blue,Welterweight
+08/07/2021,Derrick Lewis,Ciryl Gane,Blue,UFC Interim Heavyweight Title
+08/07/2021,Jose Aldo,Pedro Munhoz,Red,Bantamweight
+08/07/2021,Michael Chiesa,Vicente Luque,Blue,Welterweight
+08/07/2021,Tecia Torres,Angela Hill,Red,Women's Strawweight
+08/07/2021,Song Yadong,Casey Kenney,Red,Bantamweight
+08/07/2021,Bobby Green,Rafael Fiziev,Blue,Lightweight
+08/07/2021,Vince Morales,Drako Rodriguez,Red,Bantamweight
+08/07/2021,Alonzo Menifield,Ed Herman,Red,Light Heavyweight
+08/07/2021,Karolina Kowalkiewicz,Jessica Penne,Blue,Women's Strawweight
+08/07/2021,Manel Kape,Ode Osbourne,Red,Flyweight
+08/07/2021,Miles Johns,Anderson Dos Santos,Red,Bantamweight
+08/07/2021,Victoria Leonardo,Melissa Gatto,Blue,Women's Flyweight
+08/07/2021,Johnny Munoz,Jamey Simmons,Red,Bantamweight
+07/31/2021,Uriah Hall,Sean Strickland,Blue,Middleweight
+07/31/2021,Cheyanne Vlismas,Gloria de Paula,Red,Women's Strawweight
+07/31/2021,Niklas Stolze,Jared Gooden,Blue,Welterweight
+07/31/2021,Collin Anglin,Melsik Baghdasaryan,Blue,Featherweight
+07/31/2021,Bryan Barberena,Jason Witt,Blue,Welterweight
+07/31/2021,Chris Gruetzemacher,Rafa Garcia,Red,Lightweight
+07/31/2021,Jinh Yu Frey,Ashley Yoder,Red,Women's Strawweight
+07/31/2021,Ryan Benoit,Zarrukh Adashev,Blue,Flyweight
+07/31/2021,Phil Rowe,Orion Cosce,Red,Welterweight
+07/24/2021,Cory Sandhagen,TJ Dillashaw,Blue,Bantamweight
+07/24/2021,Kyler Phillips,Raulian Paiva,Blue,Bantamweight
+07/24/2021,Darren Elkins,Darrick Minner,Red,Featherweight
+07/24/2021,Miranda Maverick,Maycee Barber,Blue,Women's Flyweight
+07/24/2021,Adrian Yanez,Randy Costa,Red,Bantamweight
+07/24/2021,Punahele Soriano,Brendan Allen,Blue,Middleweight
+07/24/2021,Nassourdine Imavov,Ian Heinisch,Red,Middleweight
+07/24/2021,Mickey Gall,Jordan Williams,Red,Welterweight
+07/24/2021,Julio Arce,Andre Ewell,Red,Bantamweight
+07/24/2021,Sijara Eubanks,Elise Reed,Red,Women's Flyweight
+07/24/2021,Diana Belbita,Hannah Goldy,Red,Women's Strawweight
+07/17/2021,Islam Makhachev,Thiago Moises,Red,Lightweight
+07/17/2021,Marion Reneau,Miesha Tate,Blue,Women's Bantamweight
+07/17/2021,Jeremy Stephens,Mateusz Gamrot,Blue,Lightweight
+07/17/2021,Rodolfo Vieira,Dustin Stoltzfus,Red,Middleweight
+07/17/2021,Gabriel Benitez,Billy Quarantillo,Blue,Featherweight
+07/17/2021,Daniel Rodriguez,Preston Parsons,Red,Welterweight
+07/17/2021,Amanda Lemos,Montserrat Conejo Ruiz,Red,Women's Strawweight
+07/17/2021,Khalid Taha,Sergey Morozov,Blue,Bantamweight
+07/17/2021,Francisco Figueiredo,Malcolm Gordon,Blue,Flyweight
+07/10/2021,Dustin Poirier,Conor McGregor,Red,Lightweight
+07/10/2021,Gilbert Burns,Stephen Thompson,Red,Welterweight
+07/10/2021,Tai Tuivasa,Greg Hardy,Red,Heavyweight
+07/10/2021,Irene Aldana,Yana Santos,Red,Women's Bantamweight
+07/10/2021,Sean O'Malley,Kris Moutinho,Red,Bantamweight
+07/10/2021,Carlos Condit,Max Griffin,Blue,Welterweight
+07/10/2021,Niko Price,Michel Pereira,Blue,Welterweight
+07/10/2021,Ryan Hall,Ilia Topuria,Blue,Featherweight
+07/10/2021,Trevin Giles,Dricus Du Plessis,Blue,Middleweight
+07/10/2021,Jennifer Maia,Jessica Eye,Red,Women's Flyweight
+07/10/2021,Omari Akhmedov,Brad Tavares,Blue,Middleweight
+07/10/2021,Zhalgas Zhumagulov,Jerome Rivera,Red,Flyweight
+06/26/2021,Ciryl Gane,Alexander Volkov,Red,Heavyweight
+06/26/2021,Tanner Boser,Ovince Saint Preux,Red,Heavyweight
+06/26/2021,Raoni Barcelos,Timur Valiev,Blue,Bantamweight
+06/26/2021,Tim Means,Nicolas Dalby,Red,Welterweight
+06/26/2021,Renato Moicano,Jai Herbert,Red,Lightweight
+06/26/2021,Kennedy Nzechukwu,Danilo Marques,Red,Light Heavyweight
+06/26/2021,Shavkat Rakhmonov,Michel Prazeres,Red,Welterweight
+06/26/2021,Warlley Alves,Jeremiah Wells,Blue,Welterweight
+06/26/2021,Marcin Prachnio,Ike Villanueva,Red,Light Heavyweight
+06/26/2021,Julia Avila,Julija Stoliarenko,Red,Women's Bantamweight
+06/26/2021,Charles Rosa,Justin Jaynes,Red,Featherweight
+06/26/2021,Yancy Medeiros,Damir Hadzovic,Blue,Lightweight
+06/19/2021,Chan Sung Jung,Dan Ige,Red,Featherweight
+06/19/2021,Aleksei Oleinik,Serghei Spivac,Blue,Heavyweight
+06/19/2021,Marlon Vera,Davey Grant,Red,Bantamweight
+06/19/2021,Julian Erosa,SeungWoo Choi,Blue,Featherweight
+06/19/2021,Wellington Turman,Bruno Silva,Blue,Middleweight
+06/19/2021,Matt Brown,Dhiego Lima,Red,Welterweight
+06/19/2021,Aleksa Camur,Nicolae Negumereanu,Blue,Light Heavyweight
+06/19/2021,Kanako Murata,Virna Jandiroba,Blue,Women's Strawweight
+06/19/2021,Khaos Williams,Matthew Semelsberger,Red,Welterweight
+06/19/2021,Josh Parisian,Roque Martinez,Red,Heavyweight
+06/19/2021,Joaquim Silva,Ricky Glenn,Blue,Lightweight
+06/19/2021,Casey O'Neill,Lara Procopio,Red,Women's Flyweight
+06/12/2021,Israel Adesanya,Marvin Vettori,Red,UFC Middleweight Title
+06/12/2021,Deiveson Figueiredo,Brandon Moreno,Blue,UFC Flyweight Title
+06/12/2021,Leon Edwards,Nate Diaz,Red,Welterweight
+06/12/2021,Demian Maia,Belal Muhammad,Blue,Welterweight
+06/12/2021,Paul Craig,Jamahal Hill,Red,Light Heavyweight
+06/12/2021,Drew Dober,Brad Riddell,Blue,Lightweight
+06/12/2021,Eryk Anders,Darren Stewart,Red,Light Heavyweight
+06/12/2021,Lauren Murphy,Joanne Wood,Red,Women's Flyweight
+06/12/2021,Movsar Evloev,Hakeem Dawodu,Red,Featherweight
+06/12/2021,Pannie Kianzad,Alexis Davis,Red,Women's Bantamweight
+06/12/2021,Matt Frevola,Terrance McKinney,Blue,Lightweight
+06/12/2021,Chase Hooper,Steven Peterson,Blue,Featherweight
+06/12/2021,Fares Ziam,Luigi Vendramini,Red,Lightweight
+06/12/2021,Carlos Felipe,Jake Collier,Red,Heavyweight
+06/05/2021,Jairzinho Rozenstruik,Augusto Sakai,Red,Heavyweight
+06/05/2021,Walt Harris,Marcin Tybura,Blue,Heavyweight
+06/05/2021,Roman Dolidze,Laureano Staropoli,Red,Middleweight
+06/05/2021,Santiago Ponzinibbio,Miguel Baeza,Red,Welterweight
+06/05/2021,Dusko Todorovic,Gregory Rodrigues,Blue,Middleweight
+06/05/2021,Montana De La Rosa,Ariane Lipski,Red,Women's Flyweight
+06/05/2021,Tanner Boser,Ilir Latifi,Blue,Heavyweight
+06/05/2021,Francisco Trinaldo,Muslim Salikhov,Blue,Welterweight
+06/05/2021,Makwan Amirkhani,Kamuela Kirk,Blue,Featherweight
+06/05/2021,Manon Fiorot,Tabatha Ricci,Red,Women's Flyweight
+06/05/2021,Sean Woodson,Youssef Zalal,Red,Featherweight
+06/05/2021,Claudio Puelles,Jordan Leavitt,Red,Lightweight
+05/22/2021,Rob Font,Cody Garbrandt,Red,Bantamweight
+05/22/2021,Yan Xiaonan,Carla Esparza,Blue,Women's Strawweight
+05/22/2021,Justin Tafa,Jared Vanderaa,Blue,Heavyweight
+05/22/2021,Felicia Spencer,Norma Dumont,Blue,Women's Featherweight
+05/22/2021,Ricardo Ramos,Bill Algeo,Red,Featherweight
+05/22/2021,Jack Hermansson,Edmen Shahbazyan,Red,Middleweight
+05/22/2021,Ben Rothwell,Chris Barnett,Red,Heavyweight
+05/22/2021,Court McGee,Claudio Silva,Red,Welterweight
+05/22/2021,Bruno Silva,Victor Rodriguez,Red,Flyweight
+05/22/2021,Josh Culibao,Shayilan Nuerdanbieke,Red,Featherweight
+05/22/2021,David Dvorak,Juancamilo Ronderos,Red,Flyweight
+05/22/2021,Rafael Alves,Damir Ismagulov,Blue,Lightweight
+05/15/2021,Charles Oliveira,Michael Chandler,Red,UFC Lightweight Title
+05/15/2021,Tony Ferguson,Beneil Dariush,Blue,Lightweight
+05/15/2021,Katlyn Cerminara,Viviane Araujo,Red,Women's Flyweight
+05/15/2021,Shane Burgos,Edson Barboza,Blue,Featherweight
+05/15/2021,Jacare Souza,Andre Muniz,Blue,Middleweight
+05/15/2021,Lando Vannata,Mike Grundy,Red,Featherweight
+05/15/2021,Jordan Wright,Jamie Pickett,Red,Middleweight
+05/15/2021,Andrea Lee,Antonina Shevchenko,Red,Women's Flyweight
+05/15/2021,Gina Mazany,Priscila Cachoeira,Blue,Women's Flyweight
+05/15/2021,Kevin Aguilar,Tucker Lutz,Blue,Featherweight
+05/15/2021,Christos Giagos,Sean Soriano,Red,Lightweight
+05/08/2021,Marina Rodriguez,Michelle Waterson-Gomez,Red,Women's Flyweight
+05/08/2021,Donald Cerrone,Alex Morono,Blue,Welterweight
+05/08/2021,Neil Magny,Geoff Neal,Red,Welterweight
+05/08/2021,Maurice Greene,Marcos Rogerio de Lima,Blue,Heavyweight
+05/08/2021,Diego Ferreira,Gregor Gillespie,Blue,Lightweight
+05/08/2021,Phil Hawes,Kyle Daukaus,Red,Middleweight
+05/08/2021,Ludovit Klein,Michael Trizano,Blue,Featherweight
+05/08/2021,JunYong Park,Tafon Nchukwi,Red,Middleweight
+05/08/2021,Christian Aguilera,Carlston Harris,Blue,Welterweight
+05/01/2021,Dominick Reyes,Jiri Prochazka,Blue,Light Heavyweight
+05/01/2021,Giga Chikadze,Cub Swanson,Red,Featherweight
+05/01/2021,Sean Strickland,Krzysztof Jotko,Red,Middleweight
+05/01/2021,Merab Dvalishvili,Cody Stamann,Red,Bantamweight
+05/01/2021,Randa Markos,Luana Pinheiro,Blue,Women's Strawweight
+05/01/2021,Kai Kamaka,TJ Brown,Blue,Featherweight
+05/01/2021,Poliana Botelho,Luana Carolina,Blue,Women's Flyweight
+05/01/2021,Loma Lookboonmee,Sam Hughes,Red,Women's Strawweight
+05/01/2021,Andreas Michailidis,KB Bhullar,Red,Middleweight
+05/01/2021,Luke Sanders,Felipe Colares,Blue,Featherweight
+04/24/2021,Kamaru Usman,Jorge Masvidal,Red,UFC Welterweight Title
+04/24/2021,Zhang Weili,Rose Namajunas,Blue,UFC Women's Strawweight Title
+04/24/2021,Valentina Shevchenko,Jessica Andrade,Red,UFC Women's Flyweight Title
+04/24/2021,Uriah Hall,Chris Weidman,Red,Middleweight
+04/24/2021,Anthony Smith,Jimmy Crute,Red,Light Heavyweight
+04/24/2021,Alex Oliveira,Randy Brown,Blue,Welterweight
+04/24/2021,Dwight Grant,Stefan Sekulic,Red,Welterweight
+04/24/2021,Karl Roberson,Brendan Allen,Blue,Middleweight
+04/24/2021,Pat Sabatini,Tristan Connelly,Red,Featherweight
+04/24/2021,Batgerel Danaa,Kevin Natividad,Red,Bantamweight
+04/24/2021,Kazula Vargas,Rongzhu,Red,Lightweight
+04/24/2021,Aoriqileng,Jeff Molina,Blue,Flyweight
+04/24/2021,Liang Na,Ariane Carnelossi,Blue,Women's Strawweight
+04/17/2021,Robert Whittaker,Kelvin Gastelum,Red,Middleweight
+04/17/2021,Andrei Arlovski,Chase Sherman,Red,Heavyweight
+04/17/2021,Abdul Razak Alhassan,Jacob Malkoun,Blue,Middleweight
+04/17/2021,Tracy Cortez,Justine Kish,Red,Women's Flyweight
+04/17/2021,Luis Pena,Alexander Munoz,Red,Lightweight
+04/17/2021,Alexandr Romanov,Juan Espino,Red,Heavyweight
+04/17/2021,Jessica Penne,Loopy Godinez,Red,Women's Strawweight
+04/17/2021,Bartosz Fabinski,Gerald Meerschaert,Blue,Middleweight
+04/17/2021,Austin Hubbard,Dakota Bush,Red,Lightweight
+04/17/2021,Tony Gravely,Anthony Birchak,Red,Bantamweight
+04/10/2021,Marvin Vettori,Kevin Holland,Red,Middleweight
+04/10/2021,Arnold Allen,Sodiq Yusuff,Red,Featherweight
+04/10/2021,Sam Alvey,Julian Marquez,Blue,Middleweight
+04/10/2021,Nina Nunes,Mackenzie Dern,Blue,Women's Strawweight
+04/10/2021,Mike Perry,Daniel Rodriguez,Blue,Welterweight
+04/10/2021,Jim Miller,Joe Solecki,Blue,Lightweight
+04/10/2021,Scott Holtzman,Mateusz Gamrot,Blue,Lightweight
+04/10/2021,John Makdessi,Ignacio Bahamondes,Red,Lightweight
+04/10/2021,Yorgan De Castro,Jarjis Danho,Blue,Heavyweight
+04/10/2021,Hunter Azure,Jack Shore,Blue,Bantamweight
+04/10/2021,Luis Saldana,Jordan Griffin,Red,Featherweight
+04/10/2021,Da Woon Jung,William Knight,Red,Light Heavyweight
+04/10/2021,Impa Kasanganay,Sasha Palatnikov,Red,Welterweight
+03/27/2021,Stipe Miocic,Francis Ngannou,Blue,UFC Heavyweight Title
+03/27/2021,Tyron Woodley,Vicente Luque,Blue,Welterweight
+03/27/2021,Sean O'Malley,Thomas Almeida,Red,Bantamweight
+03/27/2021,Gillian Robertson,Miranda Maverick,Blue,Women's Flyweight
+03/27/2021,Jamie Mullarkey,Khama Worthy,Red,Lightweight
+03/27/2021,Alonzo Menifield,Fabio Cherant,Red,Light Heavyweight
+03/27/2021,Jared Gooden,Abubakar Nurmagomedov,Blue,Welterweight
+03/27/2021,Modestas Bukauskas,Michal Oleksiejczuk,Blue,Light Heavyweight
+03/27/2021,Shane Young,Omar Morales,Blue,Featherweight
+03/27/2021,Marc-Andre Barriault,Abu Azaitar,Red,Middleweight
+03/20/2021,Derek Brunson,Kevin Holland,Red,Middleweight
+03/20/2021,Song Kenan,Max Griffin,Blue,Welterweight
+03/20/2021,Cheyanne Vlismas,Montserrat Conejo Ruiz,Blue,Women's Strawweight
+03/20/2021,Adrian Yanez,Gustavo Lopez,Red,Bantamweight
+03/20/2021,Tai Tuivasa,Harry Hunsucker,Red,Heavyweight
+03/20/2021,Marion Reneau,Macy Chiasson,Blue,Women's Bantamweight
+03/20/2021,Leonardo Santos,Grant Dawson,Blue,Lightweight
+03/20/2021,Trevin Giles,Roman Dolidze,Red,Middleweight
+03/20/2021,Montel Jackson,Jesse Strader,Red,Bantamweight
+03/20/2021,Bruno Silva,JP Buys,Red,Flyweight
+03/13/2021,Misha Cirkunov,Ryan Spann,Blue,Light Heavyweight
+03/13/2021,Dan Ige,Gavin Tucker,Red,Featherweight
+03/13/2021,Jonathan Martinez,Davey Grant,Blue,Bantamweight
+03/13/2021,Manel Kape,Matheus Nicolau,Blue,Flyweight
+03/13/2021,Angela Hill,Ashley Yoder,Red,Women's Strawweight
+03/13/2021,Charles Jourdain,Marcelo Rojo,Red,Featherweight
+03/13/2021,Rani Yahya,Ray Rodriguez,Red,Bantamweight
+03/13/2021,Nasrat Haqparast,Rafa Garcia,Red,Lightweight
+03/13/2021,Cortney Casey,JJ Aldrich,Blue,Women's Flyweight
+03/13/2021,Gloria de Paula,Jinh Yu Frey,Blue,Women's Strawweight
+03/13/2021,Matthew Semelsberger,Jason Witt,Red,Welterweight
+03/06/2021,Jan Blachowicz,Israel Adesanya,Red,UFC Light Heavyweight Title
+03/06/2021,Amanda Nunes,Megan Anderson,Red,UFC Women's Featherweight Title
+03/06/2021,Petr Yan,Aljamain Sterling,Blue,UFC Bantamweight Title
+03/06/2021,Islam Makhachev,Drew Dober,Red,Lightweight
+03/06/2021,Thiago Santos,Aleksandar Rakic,Blue,Light Heavyweight
+03/06/2021,Dominick Cruz,Casey Kenney,Red,Bantamweight
+03/06/2021,Song Yadong,Kyler Phillips,Blue,Bantamweight
+03/06/2021,Joseph Benavidez,Askar Askarov,Blue,Flyweight
+03/06/2021,Rogerio Bontorin,Kai Kara-France,Blue,Flyweight
+03/06/2021,Tim Elliott,Jordan Espinosa,Red,Flyweight
+03/06/2021,Kennedy Nzechukwu,Carlos Ulberg,Red,Light Heavyweight
+03/06/2021,Sean Brady,Jake Matthews,Red,Welterweight
+03/06/2021,Livinha Souza,Amanda Lemos,Blue,Women's Strawweight
+03/06/2021,Uros Medic,Aalon Cruz,Red,Lightweight
+03/06/2021,Mario Bautista,Trevin Jones,Blue,Bantamweight
+02/27/2021,Jairzinho Rozenstruik,Ciryl Gane,Blue,Heavyweight
+02/27/2021,Nikita Krylov,Magomed Ankalaev,Blue,Light Heavyweight
+02/27/2021,Pedro Munhoz,Jimmie Rivera,Red,Bantamweight
+02/27/2021,Alex Caceres,Kevin Croom,Red,Featherweight
+02/27/2021,Alexander Hernandez,Thiago Moises,Blue,Lightweight
+02/27/2021,Alexis Davis,Sabina Mazo,Red,Women's Bantamweight
+02/27/2021,Vince Cachero,Ronnie Lawrence,Blue,Bantamweight
+02/27/2021,Dustin Jacoby,Maxim Grishin,Red,Light Heavyweight
+02/20/2021,Curtis Blaydes,Derrick Lewis,Blue,Heavyweight
+02/20/2021,Ketlen Vieira,Yana Santos,Blue,Women's Bantamweight
+02/20/2021,Charles Rosa,Darrick Minner,Blue,Featherweight
+02/20/2021,Aleksei Oleinik,Chris Daukaus,Blue,Heavyweight
+02/20/2021,Phil Hawes,Nassourdine Imavov,Red,Middleweight
+02/20/2021,Andrei Arlovski,Tom Aspinall,Blue,Heavyweight
+02/20/2021,Jared Gordon,Danny Chavez,Red,Featherweight
+02/20/2021,Eddie Wineland,John Castaneda,Blue,Bantamweight
+02/20/2021,Nate Landwehr,Julian Erosa,Blue,Featherweight
+02/20/2021,Shana Dobson,Casey O'Neill,Blue,Women's Flyweight
+02/20/2021,Aiemann Zahabi,Drako Rodriguez,Red,Bantamweight
+02/20/2021,Serghei Spivac,Jared Vanderaa,Red,Heavyweight
+02/13/2021,Kamaru Usman,Gilbert Burns,Red,UFC Welterweight Title
+02/13/2021,Maycee Barber,Alexa Grasso,Blue,Women's Flyweight
+02/13/2021,Kelvin Gastelum,Ian Heinisch,Red,Middleweight
+02/13/2021,Ricky Simon,Brian Kelleher,Red,Featherweight
+02/13/2021,Maki Pitolo,Julian Marquez,Blue,Middleweight
+02/13/2021,Rodolfo Vieira,Anthony Hernandez,Blue,Middleweight
+02/13/2021,Belal Muhammad,Dhiego Lima,Red,Welterweight
+02/13/2021,Polyana Viana,Mallory Martin,Red,Women's Strawweight
+02/13/2021,Andre Ewell,Chris Gutierrez,Blue,Catch Weight
+02/13/2021,Gabe Green,Phil Rowe,Red,Welterweight
+02/06/2021,Alistair Overeem,Alexander Volkov,Blue,Heavyweight
+02/06/2021,Cory Sandhagen,Frankie Edgar,Red,Bantamweight
+02/06/2021,Michael Johnson,Clay Guida,Blue,Lightweight
+02/06/2021,Alexandre Pantoja,Manel Kape,Red,Flyweight
+02/06/2021,Diego Ferreira,Beneil Dariush,Blue,Lightweight
+02/06/2021,Mike Rodriguez,Danilo Marques,Blue,Light Heavyweight
+02/06/2021,Devonte Smith,Justin Jaynes,Red,Catch Weight
+02/06/2021,Karol Rosa,Joselyne Edwards,Red,Women's Bantamweight
+02/06/2021,Molly McCann,Lara Procopio,Blue,Women's Flyweight
+02/06/2021,SeungWoo Choi,Youssef Zalal,Red,Featherweight
+02/06/2021,Timur Valiev,Martin Day,Red,Featherweight
+02/06/2021,Ode Osbourne,Jerome Rivera,Red,Featherweight
+01/23/2021,Dustin Poirier,Conor McGregor,Red,Lightweight
+01/23/2021,Dan Hooker,Michael Chandler,Blue,Lightweight
+01/23/2021,Jessica Eye,Joanne Wood,Blue,Women's Flyweight
+01/23/2021,Andrew Sanchez,Makhmud Muradov,Blue,Middleweight
+01/23/2021,Marina Rodriguez,Amanda Ribas,Red,Women's Strawweight
+01/23/2021,Arman Tsarukyan,Matt Frevola,Red,Lightweight
+01/23/2021,Brad Tavares,Antonio Carlos Junior,Red,Middleweight
+01/23/2021,Julianna Pena,Sara McMann,Red,Women's Bantamweight
+01/23/2021,Khalil Rountree Jr.,Marcin Prachnio,Blue,Light Heavyweight
+01/23/2021,Nik Lentz,Movsar Evloev,Blue,Catch Weight
+01/23/2021,Amir Albazi,Zhalgas Zhumagulov,Red,Flyweight
+01/20/2021,Michael Chiesa,Neil Magny,Red,Welterweight
+01/20/2021,Warlley Alves,Mounir Lazzez,Red,Welterweight
+01/20/2021,Ike Villanueva,Vinicius Moreira,Red,Light Heavyweight
+01/20/2021,Roxanne Modafferi,Viviane Araujo,Blue,Women's Flyweight
+01/20/2021,Matt Schnell,Tyson Nam,Red,Flyweight
+01/20/2021,Lerone Murphy,Douglas Silva de Andrade,Red,Featherweight
+01/20/2021,Omari Akhmedov,Tom Breese,Red,Middleweight
+01/20/2021,Ricky Simon,Gaetano Pirrello,Red,Bantamweight
+01/20/2021,Sumudaerji,Zarrukh Adashev,Red,Flyweight
+01/20/2021,Dalcha Lungiambula,Markus Perez,Red,Middleweight
+01/20/2021,Francisco Figueiredo,Jerome Rivera,Red,Flyweight
+01/20/2021,Mike Davis,Mason Jones,Red,Lightweight
+01/20/2021,Umar Nurmagomedov,Sergey Morozov,Red,Bantamweight
+01/20/2021,Victoria Leonardo,Manon Fiorot,Blue,Women's Flyweight
+01/16/2021,Max Holloway,Calvin Kattar,Red,Featherweight
+01/16/2021,Carlos Condit,Matt Brown,Red,Welterweight
+01/16/2021,Santiago Ponzinibbio,Li Jingliang,Blue,Welterweight
+01/16/2021,Joaquin Buckley,Alessio Di Chirico,Blue,Middleweight
+01/16/2021,Punahele Soriano,Dusko Todorovic,Red,Middleweight
+01/16/2021,Wu Yanan,Joselyne Edwards,Blue,Women's Bantamweight
+01/16/2021,Carlos Felipe,Justin Tafa,Red,Heavyweight
+01/16/2021,David Zawada,Ramazan Emeev,Blue,Welterweight
+01/16/2021,Sarah Moras,Vanessa Melo,Blue,Women's Bantamweight
+01/16/2021,Jacob Kilburn,Austin Lingo,Blue,Featherweight
+12/19/2020,Stephen Thompson,Geoff Neal,Red,Welterweight
+12/19/2020,Jose Aldo,Marlon Vera,Red,Bantamweight
+12/19/2020,Michel Pereira,Khaos Williams,Red,Welterweight
+12/19/2020,Marlon Moraes,Rob Font,Blue,Bantamweight
+12/19/2020,Marcin Tybura,Greg Hardy,Red,Heavyweight
+12/19/2020,Anthony Pettis,Alex Morono,Red,Welterweight
+12/19/2020,Sijara Eubanks,Pannie Kianzad,Blue,Women's Bantamweight
+12/19/2020,Deron Winn,Antonio Arroyo,Red,Catch Weight
+12/19/2020,Gillian Robertson,Taila Santos,Blue,Women's Flyweight
+12/19/2020,Tafon Nchukwi,Jamie Pickett,Red,Middleweight
+12/19/2020,Jimmy Flick,Cody Durden,Red,Flyweight
+12/19/2020,Christos Giagos,Carlton Minus,Red,Catch Weight
+12/12/2020,Tony Ferguson,Charles Oliveira,Blue,Lightweight
+12/12/2020,Mackenzie Dern,Virna Jandiroba,Red,Women's Strawweight
+12/12/2020,Kevin Holland,Jacare Souza,Red,Middleweight
+12/12/2020,Junior Dos Santos,Ciryl Gane,Blue,Heavyweight
+12/12/2020,Cub Swanson,Daniel Pineda,Red,Featherweight
+12/12/2020,Renato Moicano,Rafael Fiziev,Blue,Lightweight
+12/12/2020,Gavin Tucker,Billy Quarantillo,Red,Featherweight
+12/12/2020,Tecia Torres,Sam Hughes,Red,Women's Strawweight
+12/12/2020,Chase Hooper,Peter Barrett,Red,Featherweight
+12/05/2020,Jack Hermansson,Marvin Vettori,Blue,Middleweight
+12/05/2020,Ovince Saint Preux,Jamahal Hill,Blue,Light Heavyweight
+12/05/2020,Gabriel Benitez,Justin Jaynes,Red,Lightweight
+12/05/2020,Roman Dolidze,John Allan,Red,Light Heavyweight
+12/05/2020,Matt Wiman,Jordan Leavitt,Blue,Lightweight
+12/05/2020,Louis Smolka,Jose Quinonez,Red,Bantamweight
+12/05/2020,Ilia Topuria,Damon Jackson,Red,Featherweight
+12/05/2020,Gian Villante,Jake Collier,Blue,Heavyweight
+11/28/2020,Anthony Smith,Devin Clark,Red,Light Heavyweight
+11/28/2020,Miguel Baeza,Takashi Sato,Red,Welterweight
+11/28/2020,Josh Parisian,Parker Porter,Blue,Heavyweight
+11/28/2020,Spike Carlyle,Bill Algeo,Blue,Featherweight
+11/28/2020,Ashlee Evans-Smith,Norma Dumont,Blue,Women's Bantamweight
+11/28/2020,Jonathan Pearce,Kai Kamaka,Red,Featherweight
+11/28/2020,Martin Day,Anderson Dos Santos,Blue,Bantamweight
+11/28/2020,Gina Mazany,Rachael Ostovich,Red,Women's Flyweight
+11/28/2020,Sumudaerji,Malcolm Gordon,Red,Flyweight
+11/28/2020,Luke Sanders,Nate Maness,Blue,Catch Weight
+11/21/2020,Deiveson Figueiredo,Alex Perez,Red,UFC Flyweight Title
+11/21/2020,Valentina Shevchenko,Jennifer Maia,Red,UFC Women's Flyweight Title
+11/21/2020,Mike Perry,Tim Means,Blue,Welterweight
+11/21/2020,Katlyn Cerminara,Cynthia Calvillo,Red,Women's Flyweight
+11/21/2020,Mauricio Rua,Paul Craig,Blue,Light Heavyweight
+11/21/2020,Brandon Moreno,Brandon Royval,Red,Flyweight
+11/21/2020,Joaquin Buckley,Jordan Wright,Red,Middleweight
+11/21/2020,Antonina Shevchenko,Ariane Lipski,Red,Women's Flyweight
+11/21/2020,Daniel Rodriguez,Nicolas Dalby,Blue,Welterweight
+11/21/2020,Alan Jouban,Jared Gooden,Red,Welterweight
+11/21/2020,Kyle Daukaus,Dustin Stoltzfus,Red,Middleweight
+11/21/2020,Louis Cosce,Sasha Palatnikov,Blue,Welterweight
+11/14/2020,Paul Felder,Rafael Dos Anjos,Blue,Lightweight
+11/14/2020,Abdul Razak Alhassan,Khaos Williams,Blue,Welterweight
+11/14/2020,Ashley Yoder,Miranda Granger,Red,Women's Strawweight
+11/14/2020,Brendan Allen,Sean Strickland,Blue,Catch Weight
+11/14/2020,Kay Hansen,Cory McKenna,Blue,Women's Strawweight
+11/14/2020,Randa Markos,Kanako Murata,Blue,Women's Strawweight
+11/14/2020,Geraldo de Freitas,Tony Gravely,Blue,Bantamweight
+11/14/2020,Alex Morono,Rhys McKee,Red,Welterweight
+11/14/2020,Don'Tale Mayes,Roque Martinez,Red,Heavyweight
+11/07/2020,Thiago Santos,Glover Teixeira,Blue,Light Heavyweight
+11/07/2020,Andrei Arlovski,Tanner Boser,Red,Heavyweight
+11/07/2020,Raoni Barcelos,Khalid Taha,Red,Bantamweight
+11/07/2020,Giga Chikadze,Jamey Simmons,Red,Featherweight
+11/07/2020,Claudia Gadelha,Yan Xiaonan,Blue,Women's Strawweight
+11/07/2020,Trevin Giles,Bevon Lewis,Red,Middleweight
+11/07/2020,Alexandr Romanov,Marcos Rogerio de Lima,Red,Heavyweight
+11/07/2020,Darren Elkins,Eduardo Garagorri,Red,Featherweight
+11/07/2020,Max Griffin,Ramiz Brahimaj,Red,Welterweight
+11/07/2020,Gustavo Lopez,Anthony Birchak,Red,Bantamweight
+10/31/2020,Uriah Hall,Anderson Silva,Red,Middleweight
+10/31/2020,Bryce Mitchell,Andre Fili,Red,Featherweight
+10/31/2020,Maurice Greene,Greg Hardy,Blue,Heavyweight
+10/31/2020,Kevin Holland,Charlie Ontiveros,Red,Middleweight
+10/31/2020,Bobby Green,Thiago Moises,Blue,Lightweight
+10/31/2020,Chris Gruetzemacher,Alexander Hernandez,Blue,Lightweight
+10/31/2020,Adrian Yanez,Victor Rodriguez,Red,Bantamweight
+10/31/2020,Sean Strickland,Jack Marshman,Red,Middleweight
+10/31/2020,Cole Williams,Jason Witt,Blue,Welterweight
+10/31/2020,Dustin Jacoby,Justin Ledet,Red,Light Heavyweight
+10/31/2020,Miles Johns,Kevin Natividad,Red,Bantamweight
+10/24/2020,Khabib Nurmagomedov,Justin Gaethje,Red,UFC Lightweight Title
+10/24/2020,Robert Whittaker,Jared Cannonier,Red,Middleweight
+10/24/2020,Alexander Volkov,Walt Harris,Red,Heavyweight
+10/24/2020,Jacob Malkoun,Phil Hawes,Blue,Middleweight
+10/24/2020,Lauren Murphy,Liliya Shakirova,Red,Women's Flyweight
+10/24/2020,Magomed Ankalaev,Ion Cutelaba,Red,Light Heavyweight
+10/24/2020,Stefan Struve,Tai Tuivasa,Blue,Heavyweight
+10/24/2020,Nathaniel Wood,Casey Kenney,Blue,Catch Weight
+10/24/2020,Alex Oliveira,Shavkat Rakhmonov,Blue,Welterweight
+10/24/2020,Liana Jojua,Miranda Maverick,Blue,Women's Flyweight
+10/24/2020,Joel Alvarez,Alexander Yakovlev,Red,Lightweight
+10/17/2020,Brian Ortega,Chan Sung Jung,Red,Featherweight
+10/17/2020,Katlyn Cerminara,Jessica Andrade,Blue,Women's Flyweight
+10/17/2020,Jimmy Crute,Modestas Bukauskas,Red,Light Heavyweight
+10/17/2020,Claudio Silva,James Krause,Blue,Welterweight
+10/17/2020,Thomas Almeida,Jonathan Martinez,Blue,Featherweight
+10/17/2020,Mateusz Gamrot,Guram Kutateladze,Blue,Lightweight
+10/17/2020,Gillian Robertson,Poliana Botelho,Red,Women's Flyweight
+10/17/2020,JunYong Park,John Phillips,Red,Middleweight
+10/17/2020,Jamie Mullarkey,Fares Ziam,Blue,Lightweight
+10/17/2020,Gadzhimurad Antigulov,Maxim Grishin,Blue,Light Heavyweight
+10/17/2020,Said Nurmagomedov,Mark Striegl,Red,Bantamweight
+10/10/2020,Marlon Moraes,Cory Sandhagen,Blue,Bantamweight
+10/10/2020,Edson Barboza,Makwan Amirkhani,Red,Featherweight
+10/10/2020,Ben Rothwell,Marcin Tybura,Blue,Heavyweight
+10/10/2020,Markus Perez,Dricus Du Plessis,Blue,Middleweight
+10/10/2020,Tom Aspinall,Alan Baudot,Red,Heavyweight
+10/10/2020,Youssef Zalal,Ilia Topuria,Blue,Featherweight
+10/10/2020,Tom Breese,KB Bhullar,Red,Middleweight
+10/10/2020,Chris Daukaus,Rodrigo Nascimento,Red,Heavyweight
+10/10/2020,Impa Kasanganay,Joaquin Buckley,Blue,Middleweight
+10/10/2020,Ali AlQaisi,Tony Kelley,Blue,Bantamweight
+10/10/2020,Giga Chikadze,Omar Morales,Red,Featherweight
+10/10/2020,Tracy Cortez,Stephanie Egger,Red,Women's Bantamweight
+10/10/2020,Bruno Silva,Tagir Ulanbekov,Blue,Flyweight
+10/03/2020,Holly Holm,Irene Aldana,Red,Women's Bantamweight
+10/03/2020,Yorgan De Castro,Carlos Felipe,Blue,Heavyweight
+10/03/2020,Germaine de Randamie,Julianna Pena,Red,Women's Bantamweight
+10/03/2020,Kyler Phillips,Cameron Else,Red,Bantamweight
+10/03/2020,Dequan Townsend,Dusko Todorovic,Blue,Middleweight
+10/03/2020,Carlos Condit,Court McGee,Red,Welterweight
+10/03/2020,Jordan Williams,Nassourdine Imavov,Blue,Middleweight
+10/03/2020,Loma Lookboonmee,Jinh Yu Frey,Red,Women's Strawweight
+10/03/2020,Casey Kenney,Alatengheili,Red,Bantamweight
+10/03/2020,Luigi Vendramini,Jessin Ayari,Red,Lightweight
+09/26/2020,Israel Adesanya,Paulo Costa,Red,UFC Middleweight Title
+09/26/2020,Dominick Reyes,Jan Blachowicz,Blue,UFC Light Heavyweight Title
+09/26/2020,Kai Kara-France,Brandon Royval,Blue,Flyweight
+09/26/2020,Ketlen Vieira,Sijara Eubanks,Red,Women's Bantamweight
+09/26/2020,Hakeem Dawodu,Zubaira Tukhugov,Red,Featherweight
+09/26/2020,Brad Riddell,Alex Da Silva,Red,Lightweight
+09/26/2020,Diego Sanchez,Jake Matthews,Blue,Welterweight
+09/26/2020,Shane Young,Ludovit Klein,Blue,Featherweight
+09/26/2020,William Knight,Aleksa Camur,Red,Light Heavyweight
+09/26/2020,Juan Espino,Jeff Hughes,Red,Heavyweight
+09/26/2020,Khadis Ibragimov,Danilo Marques,Blue,Light Heavyweight
+09/19/2020,Colby Covington,Tyron Woodley,Red,Welterweight
+09/19/2020,Khamzat Chimaev,Gerald Meerschaert,Red,Middleweight
+09/19/2020,Johnny Walker,Ryan Spann,Red,Light Heavyweight
+09/19/2020,Mackenzie Dern,Randa Markos,Red,Women's Strawweight
+09/19/2020,Kevin Holland,Darren Stewart,Red,Middleweight
+09/19/2020,Jordan Espinosa,David Dvorak,Blue,Flyweight
+09/19/2020,Mirsad Bektic,Damon Jackson,Blue,Featherweight
+09/19/2020,Mayra Bueno Silva,Mara Romero Borella,Red,Women's Flyweight
+09/19/2020,Jessica-Rose Clark,Sarah Alpar,Red,Women's Bantamweight
+09/19/2020,Darrick Minner,TJ Laramie,Red,Featherweight
+09/19/2020,Journey Newson,Randy Costa,Blue,Bantamweight
+09/19/2020,Andre Ewell,Irwin Rivera,Red,Bantamweight
+09/19/2020,Tyson Nam,Jerome Rivera,Red,Bantamweight
+09/12/2020,Michelle Waterson-Gomez,Angela Hill,Red,Women's Strawweight
+09/12/2020,Ottman Azaitar,Khama Worthy,Red,Lightweight
+09/12/2020,Roxanne Modafferi,Andrea Lee,Red,Women's Flyweight
+09/12/2020,Ed Herman,Mike Rodriguez,Red,Light Heavyweight
+09/12/2020,Bobby Green,Alan Patrick,Red,Lightweight
+09/12/2020,Billy Quarantillo,Kyle Nelson,Red,Featherweight
+09/12/2020,Julia Avila,Sijara Eubanks,Blue,Women's Bantamweight
+09/12/2020,Alexandr Romanov,Roque Martinez,Red,Heavyweight
+09/12/2020,Brok Weaver,Jalin Turner,Blue,Catch Weight
+09/12/2020,Bryan Barberena,Anthony Ivy,Red,Welterweight
+09/12/2020,Sabina Mazo,Justine Kish,Red,Women's Flyweight
+09/05/2020,Alistair Overeem,Augusto Sakai,Red,Heavyweight
+09/05/2020,Ovince Saint Preux,Alonzo Menifield,Red,Light Heavyweight
+09/05/2020,Michel Pereira,Zelim Imadaev,Red,Welterweight
+09/05/2020,Andre Muniz,Bartosz Fabinski,Red,Middleweight
+09/05/2020,Brian Kelleher,Ray Rodriguez,Red,Featherweight
+09/05/2020,Viviane Araujo,Montana De La Rosa,Red,Women's Flyweight
+09/05/2020,Cole Smith,Hunter Azure,Blue,Bantamweight
+08/29/2020,Anthony Smith,Aleksandar Rakic,Blue,Light Heavyweight
+08/29/2020,Robbie Lawler,Neil Magny,Blue,Welterweight
+08/29/2020,Ji Yeon Kim,Alexa Grasso,Blue,Women's Flyweight
+08/29/2020,Ricardo Lamas,Bill Algeo,Red,Featherweight
+08/29/2020,Maki Pitolo,Impa Kasanganay,Blue,Middleweight
+08/29/2020,Alessio Di Chirico,Zak Cummings,Blue,Middleweight
+08/29/2020,Alex Caceres,Austin Springer,Red,Featherweight
+08/29/2020,Sean Brady,Christian Aguilera,Red,Welterweight
+08/29/2020,Polyana Viana,Emily Whitmire,Red,Women's Strawweight
+08/29/2020,Mallory Martin,Hannah Cifers,Red,Women's Strawweight
+08/22/2020,Pedro Munhoz,Frankie Edgar,Blue,Bantamweight
+08/22/2020,Marcin Prachnio,Mike Rodriguez,Blue,Light Heavyweight
+08/22/2020,Austin Hubbard,Joe Solecki,Blue,Lightweight
+08/22/2020,Mariya Agapova,Shana Dobson,Blue,Women's Flyweight
+08/22/2020,Daniel Rodriguez,Dwight Grant,Red,Welterweight
+08/22/2020,Amanda Lemos,Mizuki,Red,Women's Strawweight
+08/22/2020,Ike Villanueva,Jordan Wright,Blue,Light Heavyweight
+08/22/2020,Carlton Minus,Matthew Semelsberger,Blue,Welterweight
+08/15/2020,Stipe Miocic,Daniel Cormier,Red,UFC Heavyweight Title
+08/15/2020,Sean O'Malley,Marlon Vera,Blue,Bantamweight
+08/15/2020,Junior Dos Santos,Jairzinho Rozenstruik,Blue,Heavyweight
+08/15/2020,Herbert Burns,Daniel Pineda,Blue,Featherweight
+08/15/2020,John Dodson,Merab Dvalishvili,Blue,Bantamweight
+08/15/2020,Jim Miller,Vinc Pichel,Blue,Lightweight
+08/15/2020,Felice Herrig,Virna Jandiroba,Blue,Women's Strawweight
+08/15/2020,TJ Brown,Danny Chavez,Blue,Featherweight
+08/15/2020,Ashley Yoder,Livinha Souza,Blue,Women's Strawweight
+08/15/2020,Chris Daukaus,Parker Porter,Red,Heavyweight
+08/15/2020,Kai Kamaka,Tony Kelley,Red,Featherweight
+08/08/2020,Derrick Lewis,Aleksei Oleinik,Red,Heavyweight
+08/08/2020,Omari Akhmedov,Chris Weidman,Blue,Middleweight
+08/08/2020,Maki Pitolo,Darren Stewart,Blue,Middleweight
+08/08/2020,Yana Santos,Julija Stoliarenko,Red,Women's Bantamweight
+08/08/2020,Beneil Dariush,Scott Holtzman,Red,Lightweight
+08/08/2020,Tim Means,Laureano Staropoli,Red,Welterweight
+08/08/2020,Kevin Holland,Joaquin Buckley,Red,Middleweight
+08/08/2020,Nasrat Haqparast,Alexander Munoz,Red,Lightweight
+08/08/2020,Andrew Sanchez,Wellington Turman,Red,Middleweight
+08/08/2020,Gavin Tucker,Justin Jaynes,Red,Featherweight
+08/08/2020,Youssef Zalal,Peter Barrett,Red,Featherweight
+08/08/2020,Irwin Rivera,Ali AlQaisi,Red,Bantamweight
+08/01/2020,Derek Brunson,Edmen Shahbazyan,Red,Middleweight
+08/01/2020,Joanne Wood,Jennifer Maia,Blue,Women's Flyweight
+08/01/2020,Vicente Luque,Randy Brown,Red,Welterweight
+08/01/2020,Lando Vannata,Bobby Green,Blue,Lightweight
+08/01/2020,Frankie Saenz,Jonathan Martinez,Blue,Bantamweight
+08/01/2020,Johnny Munoz,Nate Maness,Blue,Featherweight
+08/01/2020,Jamall Emmers,Vince Cachero,Red,Featherweight
+07/25/2020,Robert Whittaker,Darren Till,Red,Middleweight
+07/25/2020,Mauricio Rua,Rogerio Nogueira,Red,Light Heavyweight
+07/25/2020,Fabricio Werdum,Alexander Gustafsson,Red,Heavyweight
+07/25/2020,Carla Esparza,Marina Rodriguez,Red,Women's Strawweight
+07/25/2020,Paul Craig,Gadzhimurad Antigulov,Red,Light Heavyweight
+07/25/2020,Alex Oliveira,Peter Sobotta,Red,Welterweight
+07/25/2020,Khamzat Chimaev,Rhys McKee,Red,Welterweight
+07/25/2020,Francisco Trinaldo,Jai Herbert,Red,Lightweight
+07/25/2020,Tom Aspinall,Jake Collier,Red,Heavyweight
+07/25/2020,Movsar Evloev,Mike Grundy,Red,Featherweight
+07/25/2020,Tanner Boser,Raphael Pessoa,Red,Heavyweight
+07/25/2020,Bethe Correia,Pannie Kianzad,Blue,Women's Bantamweight
+07/25/2020,Ramazan Emeev,Niklas Stolze,Red,Welterweight
+07/25/2020,Nathaniel Wood,John Castaneda,Red,Bantamweight
+07/18/2020,Deiveson Figueiredo,Joseph Benavidez,Red,UFC Flyweight Title
+07/18/2020,Jack Hermansson,Kelvin Gastelum,Red,Middleweight
+07/18/2020,Marc Diakiese,Rafael Fiziev,Blue,Lightweight
+07/18/2020,Ariane Lipski,Luana Carolina,Red,Women's Flyweight
+07/18/2020,Alexandre Pantoja,Askar Askarov,Blue,Flyweight
+07/18/2020,Roman Dolidze,Khadis Ibragimov,Red,Light Heavyweight
+07/18/2020,Grant Dawson,Nad Narimani,Red,Catch Weight
+07/18/2020,Joe Duffy,Joel Alvarez,Blue,Lightweight
+07/18/2020,Brett Johns,Montel Jackson,Red,Bantamweight
+07/18/2020,Malcolm Gordon,Amir Albazi,Blue,Bantamweight
+07/18/2020,Davi Ramos,Arman Tsarukyan,Blue,Lightweight
+07/18/2020,Carlos Felipe,Serghei Spivac,Blue,Heavyweight
+07/15/2020,Calvin Kattar,Dan Ige,Red,Featherweight
+07/15/2020,Tim Elliott,Ryan Benoit,Red,Flyweight
+07/15/2020,Jimmie Rivera,Cody Stamann,Red,Featherweight
+07/15/2020,Molly McCann,Taila Santos,Blue,Women's Flyweight
+07/15/2020,Abdul Razak Alhassan,Mounir Lazzez,Blue,Welterweight
+07/15/2020,John Phillips,Khamzat Chimaev,Blue,Middleweight
+07/15/2020,Ricardo Ramos,Lerone Murphy,Blue,Featherweight
+07/15/2020,Modestas Bukauskas,Andreas Michailidis,Red,Light Heavyweight
+07/15/2020,Jared Gordon,Chris Fishgold,Red,Featherweight
+07/15/2020,Diana Belbita,Liana Jojua,Blue,Women's Flyweight
+07/15/2020,Jack Shore,Aaron Phillips,Red,Bantamweight
+07/11/2020,Kamaru Usman,Jorge Masvidal,Red,UFC Welterweight Title
+07/11/2020,Alexander Volkanovski,Max Holloway,Red,UFC Featherweight Title
+07/11/2020,Petr Yan,Jose Aldo,Red,UFC Bantamweight Title
+07/11/2020,Jessica Andrade,Rose Namajunas,Blue,Women's Strawweight
+07/11/2020,Amanda Ribas,Paige VanZant,Red,Women's Flyweight
+07/11/2020,Volkan Oezdemir,Jiri Prochazka,Blue,Light Heavyweight
+07/11/2020,Elizeu Zaleski dos Santos,Muslim Salikhov,Blue,Welterweight
+07/11/2020,Makwan Amirkhani,Danny Henry,Red,Featherweight
+07/11/2020,Leonardo Santos,Roman Bogatov,Red,Lightweight
+07/11/2020,Marcin Tybura,Maxim Grishin,Red,Heavyweight
+07/11/2020,Raulian Paiva,Zhalgas Zhumagulov,Red,Flyweight
+07/11/2020,Karol Rosa,Vanessa Melo,Red,Women's Bantamweight
+07/11/2020,Martin Day,Davey Grant,Blue,Bantamweight
+06/27/2020,Dustin Poirier,Dan Hooker,Red,Lightweight
+06/27/2020,Mike Perry,Mickey Gall,Red,Welterweight
+06/27/2020,Gian Villante,Maurice Greene,Blue,Heavyweight
+06/27/2020,Brendan Allen,Kyle Daukaus,Red,Middleweight
+06/27/2020,Takashi Sato,Jason Witt,Red,Welterweight
+06/27/2020,Sean Woodson,Julian Erosa,Blue,Catch Weight
+06/27/2020,Luis Pena,Khama Worthy,Blue,Lightweight
+06/27/2020,Philipe Lins,Tanner Boser,Blue,Heavyweight
+06/27/2020,Kay Hansen,Jinh Yu Frey,Red,Women's Strawweight
+06/27/2020,Jordan Griffin,Youssef Zalal,Blue,Featherweight
+06/20/2020,Curtis Blaydes,Alexander Volkov,Red,Heavyweight
+06/20/2020,Josh Emmett,Shane Burgos,Red,Featherweight
+06/20/2020,Raquel Pennington,Marion Reneau,Red,Women's Bantamweight
+06/20/2020,Belal Muhammad,Lyman Good,Red,Welterweight
+06/20/2020,Jim Miller,Roosevelt Roberts,Red,Catch Weight
+06/20/2020,Clay Guida,Bobby Green,Blue,Lightweight
+06/20/2020,Tecia Torres,Brianna Fortino,Red,Women's Strawweight
+06/20/2020,Cortney Casey,Gillian Robertson,Blue,Women's Flyweight
+06/20/2020,Frank Camacho,Justin Jaynes,Blue,Lightweight
+06/20/2020,Roxanne Modafferi,Lauren Murphy,Blue,Women's Flyweight
+06/20/2020,Austin Hubbard,Max Rohskopf,Red,Lightweight
+06/13/2020,Jessica Eye,Cynthia Calvillo,Blue,Women's Flyweight
+06/13/2020,Karl Roberson,Marvin Vettori,Blue,Middleweight
+06/13/2020,Charles Rosa,Kevin Aguilar,Red,Lightweight
+06/13/2020,Andre Fili,Charles Jourdain,Red,Featherweight
+06/13/2020,Jordan Espinosa,Mark De La Rosa,Red,Bantamweight
+06/13/2020,Mariya Agapova,Hannah Cifers,Red,Women's Flyweight
+06/13/2020,Merab Dvalishvili,Gustavo Lopez,Red,Catch Weight
+06/13/2020,Julia Avila,Gina Mazany,Red,Women's Bantamweight
+06/13/2020,Tyson Nam,Zarrukh Adashev,Red,Bantamweight
+06/13/2020,Anthony Ivy,Christian Aguilera,Blue,Welterweight
+06/06/2020,Amanda Nunes,Felicia Spencer,Red,UFC Women's Featherweight Title
+06/06/2020,Raphael Assuncao,Cody Garbrandt,Blue,Bantamweight
+06/06/2020,Aljamain Sterling,Cory Sandhagen,Red,Bantamweight
+06/06/2020,Neil Magny,Anthony Rocco Martin,Red,Welterweight
+06/06/2020,Eddie Wineland,Sean O'Malley,Blue,Bantamweight
+06/06/2020,Alex Caceres,Chase Hooper,Red,Featherweight
+06/06/2020,Ian Heinisch,Gerald Meerschaert,Red,Middleweight
+06/06/2020,Cody Stamann,Brian Kelleher,Red,Featherweight
+06/06/2020,Charles Byrd,Maki Pitolo,Blue,Middleweight
+06/06/2020,Jussier Formiga,Alex Perez,Blue,Flyweight
+06/06/2020,Alonzo Menifield,Devin Clark,Blue,Light Heavyweight
+06/06/2020,Evan Dunham,Herbert Burns,Blue,Catch Weight
+05/30/2020,Tyron Woodley,Gilbert Burns,Blue,Welterweight
+05/30/2020,Blagoy Ivanov,Augusto Sakai,Blue,Heavyweight
+05/30/2020,Billy Quarantillo,Spike Carlyle,Red,Catch Weight
+05/30/2020,Roosevelt Roberts,Brok Weaver,Red,Lightweight
+05/30/2020,Mackenzie Dern,Hannah Cifers,Red,Women's Strawweight
+05/30/2020,Katlyn Cerminara,Antonina Shevchenko,Red,Women's Flyweight
+05/30/2020,Daniel Rodriguez,Gabe Green,Red,Welterweight
+05/30/2020,Tim Elliott,Brandon Royval,Blue,Flyweight
+05/30/2020,Louis Smolka,Casey Kenney,Blue,Bantamweight
+05/30/2020,Chris Gutierrez,Vince Morales,Red,Featherweight
+05/16/2020,Alistair Overeem,Walt Harris,Red,Heavyweight
+05/16/2020,Claudia Gadelha,Angela Hill,Red,Women's Strawweight
+05/16/2020,Dan Ige,Edson Barboza,Red,Featherweight
+05/16/2020,Eryk Anders,Krzysztof Jotko,Blue,Middleweight
+05/16/2020,Song Yadong,Marlon Vera,Red,Featherweight
+05/16/2020,Matt Brown,Miguel Baeza,Blue,Welterweight
+05/16/2020,Anthony Hernandez,Kevin Holland,Blue,Middleweight
+05/16/2020,Giga Chikadze,Irwin Rivera,Red,Featherweight
+05/16/2020,Darren Elkins,Nate Landwehr,Blue,Featherweight
+05/16/2020,Cortney Casey,Mara Romero Borella,Red,Women's Flyweight
+05/16/2020,Rodrigo Nascimento,Don'Tale Mayes,Red,Heavyweight
+05/13/2020,Anthony Smith,Glover Teixeira,Blue,Light Heavyweight
+05/13/2020,Ben Rothwell,Ovince Saint Preux,Red,Heavyweight
+05/13/2020,Alexander Hernandez,Drew Dober,Blue,Lightweight
+05/13/2020,Ricky Simon,Ray Borg,Red,Bantamweight
+05/13/2020,Andrei Arlovski,Philipe Lins,Red,Heavyweight
+05/13/2020,Michael Johnson,Thiago Moises,Blue,Lightweight
+05/13/2020,Sijara Eubanks,Sarah Moras,Red,Women's Bantamweight
+05/13/2020,Gabriel Benitez,Omar Morales,Blue,Lightweight
+05/13/2020,Hunter Azure,Brian Kelleher,Blue,Featherweight
+05/13/2020,Chase Sherman,Ike Villanueva,Red,Heavyweight
+05/09/2020,Tony Ferguson,Justin Gaethje,Blue,UFC Interim Lightweight Title
+05/09/2020,Henry Cejudo,Dominick Cruz,Red,UFC Bantamweight Title
+05/09/2020,Francis Ngannou,Jairzinho Rozenstruik,Red,Heavyweight
+05/09/2020,Jeremy Stephens,Calvin Kattar,Blue,Featherweight
+05/09/2020,Greg Hardy,Yorgan De Castro,Red,Heavyweight
+05/09/2020,Anthony Pettis,Donald Cerrone,Red,Welterweight
+05/09/2020,Aleksei Oleinik,Fabricio Werdum,Red,Heavyweight
+05/09/2020,Carla Esparza,Michelle Waterson-Gomez,Red,Women's Strawweight
+05/09/2020,Vicente Luque,Niko Price,Red,Welterweight
+05/09/2020,Bryce Mitchell,Charles Rosa,Red,Featherweight
+05/09/2020,Ryan Spann,Sam Alvey,Red,Light Heavyweight
+03/14/2020,Kevin Lee,Charles Oliveira,Blue,Lightweight
+03/14/2020,Demian Maia,Gilbert Burns,Blue,Welterweight
+03/14/2020,Renato Moicano,Damir Hadzovic,Red,Lightweight
+03/14/2020,Johnny Walker,Nikita Krylov,Blue,Light Heavyweight
+03/14/2020,Francisco Trinaldo,John Makdessi,Red,Lightweight
+03/14/2020,Jussier Formiga,Brandon Moreno,Blue,Flyweight
+03/14/2020,Amanda Ribas,Randa Markos,Red,Women's Strawweight
+03/14/2020,Elizeu Zaleski dos Santos,Aleksei Kunchenko,Red,Welterweight
+03/14/2020,Mayra Bueno Silva,Maryna Moroz,Blue,Women's Flyweight
+03/14/2020,Bruno Silva,David Dvorak,Blue,Flyweight
+03/14/2020,Veronica Hardy,Bea Malecki,Blue,Women's Bantamweight
+03/07/2020,Israel Adesanya,Yoel Romero,Red,UFC Middleweight Title
+03/07/2020,Zhang Weili,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+03/07/2020,Beneil Dariush,Drakkar Klose,Red,Lightweight
+03/07/2020,Neil Magny,Li Jingliang,Red,Welterweight
+03/07/2020,Alex Oliveira,Max Griffin,Red,Welterweight
+03/07/2020,Sean O'Malley,Jose Quinonez,Red,Bantamweight
+03/07/2020,Mark Madsen,Austin Hubbard,Red,Lightweight
+03/07/2020,Rodolfo Vieira,Saparbeg Safarov,Red,Middleweight
+03/07/2020,Gerald Meerschaert,Deron Winn,Red,Middleweight
+03/07/2020,Giga Chikadze,Jamall Emmers,Red,Featherweight
+03/07/2020,Batgerel Danaa,Guido Cannetti,Red,Bantamweight
+02/29/2020,Joseph Benavidez,Deiveson Figueiredo,Blue,Flyweight
+02/29/2020,Felicia Spencer,Zarah Fairn,Red,Women's Featherweight
+02/29/2020,Ion Cutelaba,Magomed Ankalaev,Blue,Light Heavyweight
+02/29/2020,Megan Anderson,Norma Dumont,Red,Women's Featherweight
+02/29/2020,Grant Dawson,Darrick Minner,Red,Featherweight
+02/29/2020,Gabriel Silva,Kyler Phillips,Blue,Bantamweight
+02/29/2020,Brendan Allen,Tom Breese,Red,Middleweight
+02/29/2020,Marcin Tybura,Serghei Spivac,Red,Heavyweight
+02/29/2020,Luis Pena,Steve Garcia,Red,Lightweight
+02/29/2020,Jordan Griffin,TJ Brown,Red,Featherweight
+02/29/2020,Aalon Cruz,Spike Carlyle,Blue,Featherweight
+02/29/2020,Sean Brady,Ismail Naurdiev,Red,Welterweight
+02/22/2020,Paul Felder,Dan Hooker,Blue,Lightweight
+02/22/2020,Jimmy Crute,Michal Oleksiejczuk,Red,Light Heavyweight
+02/22/2020,Karolina Kowalkiewicz,Yan Xiaonan,Blue,Women's Strawweight
+02/22/2020,Ben Sosoli,Marcos Rogerio de Lima,Blue,Heavyweight
+02/22/2020,Brad Riddell,Magomed Mustafaev,Red,Lightweight
+02/22/2020,Kevin Aguilar,Zubaira Tukhugov,Blue,Featherweight
+02/22/2020,Jalin Turner,Josh Culibao,Red,Lightweight
+02/22/2020,Jake Matthews,Emil Meek,Red,Welterweight
+02/22/2020,Callan Potter,Song Kenan,Blue,Welterweight
+02/22/2020,Kai Kara-France,Tyson Nam,Red,Flyweight
+02/22/2020,Loma Lookboonmee,Angela Hill,Blue,Women's Strawweight
+02/22/2020,Priscila Cachoeira,Shana Dobson,Red,Women's Flyweight
+02/15/2020,Corey Anderson,Jan Blachowicz,Blue,Light Heavyweight
+02/15/2020,Diego Sanchez,Michel Pereira,Red,Welterweight
+02/15/2020,Montana De La Rosa,Mara Romero Borella,Red,Women's Flyweight
+02/15/2020,Brok Weaver,Kazula Vargas,Red,Lightweight
+02/15/2020,Rogerio Bontorin,Ray Borg,Blue,Flyweight
+02/15/2020,Lando Vannata,Yancy Medeiros,Red,Lightweight
+02/15/2020,Tim Means,Daniel Rodriguez,Blue,Welterweight
+02/15/2020,John Dodson,Nathaniel Wood,Red,Bantamweight
+02/15/2020,Jim Miller,Scott Holtzman,Blue,Lightweight
+02/15/2020,Devin Clark,Dequan Townsend,Red,Light Heavyweight
+02/15/2020,Casey Kenney,Merab Dvalishvili,Blue,Bantamweight
+02/15/2020,Macy Chiasson,Shanna Young,Red,Women's Bantamweight
+02/15/2020,Mark De La Rosa,Raulian Paiva,Blue,Flyweight
+02/08/2020,Jon Jones,Dominick Reyes,Red,UFC Light Heavyweight Title
+02/08/2020,Valentina Shevchenko,Katlyn Cerminara,Red,UFC Women's Flyweight Title
+02/08/2020,Juan Adams,Justin Tafa,Blue,Heavyweight
+02/08/2020,Mirsad Bektic,Dan Ige,Blue,Featherweight
+02/08/2020,Derrick Lewis,Ilir Latifi,Red,Heavyweight
+02/08/2020,Trevin Giles,James Krause,Red,Middleweight
+02/08/2020,Lauren Murphy,Andrea Lee,Red,Women's Flyweight
+02/08/2020,Alex Morono,Khaos Williams,Blue,Welterweight
+02/08/2020,Miles Johns,Mario Bautista,Blue,Bantamweight
+02/08/2020,Andre Ewell,Jonathan Martinez,Red,Bantamweight
+02/08/2020,Austin Lingo,Youssef Zalal,Blue,Featherweight
+01/25/2020,Curtis Blaydes,Junior Dos Santos,Red,Heavyweight
+01/25/2020,Rafael Dos Anjos,Michael Chiesa,Blue,Welterweight
+01/25/2020,Jordan Espinosa,Alex Perez,Blue,Flyweight
+01/25/2020,Hannah Cifers,Angela Hill,Blue,Women's Strawweight
+01/25/2020,Jamahal Hill,Darko Stosic,Red,Light Heavyweight
+01/25/2020,Bevon Lewis,Dequan Townsend,Red,Middleweight
+01/25/2020,Arnold Allen,Nik Lentz,Red,Featherweight
+01/25/2020,Justine Kish,Lucie Pudilova,Red,Women's Flyweight
+01/25/2020,Montel Jackson,Felipe Colares,Red,Bantamweight
+01/25/2020,Sara McMann,Lina Lansberg,Red,Women's Bantamweight
+01/25/2020,Brett Johns,Tony Gravely,Red,Bantamweight
+01/25/2020,Herbert Burns,Nate Landwehr,Red,Featherweight
+01/18/2020,Conor McGregor,Donald Cerrone,Red,Welterweight
+01/18/2020,Holly Holm,Raquel Pennington,Red,Women's Bantamweight
+01/18/2020,Aleksei Oleinik,Maurice Greene,Red,Heavyweight
+01/18/2020,Brian Kelleher,Ode Osbourne,Red,Bantamweight
+01/18/2020,Anthony Pettis,Diego Ferreira,Blue,Lightweight
+01/18/2020,Roxanne Modafferi,Maycee Barber,Red,Women's Flyweight
+01/18/2020,Andre Fili,Sodiq Yusuff,Blue,Featherweight
+01/18/2020,Tim Elliott,Askar Askarov,Blue,Flyweight
+01/18/2020,Drew Dober,Nasrat Haqparast,Red,Lightweight
+01/18/2020,Aleksa Camur,Justin Ledet,Red,Light Heavyweight
+01/18/2020,Sabina Mazo,JJ Aldrich,Red,Women's Flyweight
+12/21/2019,Frankie Edgar,Chan Sung Jung,Blue,Featherweight
+12/21/2019,Volkan Oezdemir,Aleksandar Rakic,Red,Light Heavyweight
+12/21/2019,Dooho Choi,Charles Jourdain,Blue,Featherweight
+12/21/2019,Da Woon Jung,Mike Rodriguez,Red,Light Heavyweight
+12/21/2019,JunYong Park,Marc-Andre Barriault,Red,Middleweight
+12/21/2019,Kyung Ho Kang,Pingyuan Liu,Red,Bantamweight
+12/21/2019,Ciryl Gane,Tanner Boser,Red,Heavyweight
+12/21/2019,SeungWoo Choi,Suman Mokhtarian,Red,Featherweight
+12/21/2019,Dong Hyun Ma,Omar Morales,Blue,Lightweight
+12/21/2019,Alexandre Pantoja,Matt Schnell,Red,Flyweight
+12/21/2019,Raoni Barcelos,Said Nurmagomedov,Red,Bantamweight
+12/21/2019,Miranda Granger,Amanda Lemos,Blue,Women's Strawweight
+12/21/2019,Alatengheili,Ryan Benoit,Red,Bantamweight
+12/14/2019,Kamaru Usman,Colby Covington,Red,UFC Welterweight Title
+12/14/2019,Max Holloway,Alexander Volkanovski,Blue,UFC Featherweight Title
+12/14/2019,Amanda Nunes,Germaine de Randamie,Red,UFC Women's Bantamweight Title
+12/14/2019,Marlon Moraes,Jose Aldo,Red,Bantamweight
+12/14/2019,Petr Yan,Urijah Faber,Red,Bantamweight
+12/14/2019,Geoff Neal,Mike Perry,Red,Welterweight
+12/14/2019,Ketlen Vieira,Irene Aldana,Blue,Women's Bantamweight
+12/14/2019,Ian Heinisch,Omari Akhmedov,Blue,Middleweight
+12/14/2019,Matt Brown,Ben Saunders,Red,Welterweight
+12/14/2019,Chase Hooper,Daniel Teymur,Red,Featherweight
+12/14/2019,Brandon Moreno,Kai Kara-France,Red,Flyweight
+12/14/2019,Jessica Eye,Viviane Araujo,Red,Women's Flyweight
+12/14/2019,Punahele Soriano,Oskar Piechota,Red,Middleweight
+12/07/2019,Alistair Overeem,Jairzinho Rozenstruik,Blue,Heavyweight
+12/07/2019,Stefan Struve,Ben Rothwell,Blue,Heavyweight
+12/07/2019,Aspen Ladd,Yana Santos,Red,Women's Bantamweight
+12/07/2019,Rob Font,Ricky Simon,Red,Bantamweight
+12/07/2019,Thiago Alves,Tim Means,Blue,Welterweight
+12/07/2019,Billy Quarantillo,Jacob Kilburn,Red,Featherweight
+12/07/2019,Bryce Mitchell,Matt Sayles,Red,Featherweight
+12/07/2019,Joe Solecki,Matt Wiman,Red,Lightweight
+12/07/2019,Virna Jandiroba,Mallory Martin,Red,Women's Strawweight
+12/07/2019,Makhmud Muradov,Trevor Smith,Red,Middleweight
+11/16/2019,Jan Blachowicz,Jacare Souza,Red,Light Heavyweight
+11/16/2019,Charles Oliveira,Jared Gordon,Red,Lightweight
+11/16/2019,Antonio Arroyo,Andre Muniz,Blue,Middleweight
+11/16/2019,Markus Perez,Wellington Turman,Blue,Middleweight
+11/16/2019,Sergio Moraes,James Krause,Blue,Welterweight
+11/16/2019,Ricardo Ramos,Eduardo Garagorri,Red,Featherweight
+11/16/2019,Francisco Trinaldo,Bobby Green,Red,Lightweight
+11/16/2019,Warlley Alves,Randy Brown,Blue,Welterweight
+11/16/2019,Douglas Silva de Andrade,Renan Barao,Red,Featherweight
+11/16/2019,Ariane Lipski,Isabela de Padua,Red,Women's Flyweight
+11/16/2019,Vanessa Melo,Tracy Cortez,Blue,Women's Bantamweight
+11/09/2019,Zabit Magomedsharipov,Calvin Kattar,Red,Featherweight
+11/09/2019,Alexander Volkov,Greg Hardy,Red,Heavyweight
+11/09/2019,Zelim Imadaev,Danny Roberts,Blue,Welterweight
+11/09/2019,Khadis Ibragimov,Ed Herman,Blue,Light Heavyweight
+11/09/2019,Ramazan Emeev,Anthony Rocco Martin,Blue,Welterweight
+11/09/2019,Shamil Gamzatov,Klidson Abreu,Red,Light Heavyweight
+11/09/2019,Magomed Ankalaev,Dalcha Lungiambula,Red,Light Heavyweight
+11/09/2019,Rustam Khabilov,Sergey Khandozhko,Red,Welterweight
+11/09/2019,Roman Kopylov,Karl Roberson,Blue,Middleweight
+11/09/2019,Abubakar Nurmagomedov,David Zawada,Blue,Welterweight
+11/09/2019,Alexander Yakovlev,Roosevelt Roberts,Blue,Lightweight
+11/09/2019,Jessica-Rose Clark,Pannie Kianzad,Blue,Women's Bantamweight
+11/09/2019,Grigory Popov,Davey Grant,Blue,Bantamweight
+11/02/2019,Jorge Masvidal,Nate Diaz,Red,Welterweight
+11/02/2019,Kelvin Gastelum,Darren Till,Blue,Middleweight
+11/02/2019,Stephen Thompson,Vicente Luque,Red,Welterweight
+11/02/2019,Derrick Lewis,Blagoy Ivanov,Red,Heavyweight
+11/02/2019,Kevin Lee,Gregor Gillespie,Red,Lightweight
+11/02/2019,Corey Anderson,Johnny Walker,Red,Light Heavyweight
+11/02/2019,Shane Burgos,Makwan Amirkhani,Red,Featherweight
+11/02/2019,Brad Tavares,Edmen Shahbazyan,Blue,Middleweight
+11/02/2019,Andrei Arlovski,Jairzinho Rozenstruik,Blue,Heavyweight
+11/02/2019,Katlyn Cerminara,Jennifer Maia,Red,Women's Flyweight
+11/02/2019,Lyman Good,Chance Rencountre,Red,Welterweight
+11/02/2019,Julio Arce,Hakeem Dawodu,Blue,Featherweight
+10/26/2019,Demian Maia,Ben Askren,Red,Welterweight
+10/26/2019,Michael Johnson,Stevie Ray,Blue,Lightweight
+10/26/2019,Frank Camacho,Beneil Dariush,Blue,Lightweight
+10/26/2019,Ciryl Gane,Don'Tale Mayes,Red,Heavyweight
+10/26/2019,Muslim Salikhov,Laureano Staropoli,Red,Welterweight
+10/26/2019,Randa Markos,Ashley Yoder,Red,Women's Strawweight
+10/26/2019,Alex White,Rafael Fiziev,Blue,Lightweight
+10/26/2019,Enrique Barzola,Movsar Evloev,Blue,Featherweight
+10/26/2019,Maurice Greene,Sergei Pavlovich,Blue,Heavyweight
+10/26/2019,Loma Lookboonmee,Aleksandra Albu,Red,Women's Strawweight
+10/26/2019,Raphael Pessoa,Jeff Hughes,Red,Heavyweight
+10/18/2019,Dominick Reyes,Chris Weidman,Red,Light Heavyweight
+10/18/2019,Yair Rodriguez,Jeremy Stephens,Red,Featherweight
+10/18/2019,Joe Lauzon,Jonathan Pearce,Red,Lightweight
+10/18/2019,Maycee Barber,Gillian Robertson,Red,Women's Flyweight
+10/18/2019,Deron Winn,Darren Stewart,Blue,Middleweight
+10/18/2019,Charles Rosa,Manny Bermudez,Red,Featherweight
+10/18/2019,Molly McCann,Diana Belbita,Red,Women's Flyweight
+10/18/2019,Kyle Bochniak,Sean Woodson,Blue,Featherweight
+10/18/2019,Randy Costa,Boston Salmon,Red,Bantamweight
+10/18/2019,Court McGee,Sean Brady,Blue,Welterweight
+10/18/2019,Brendan Allen,Kevin Holland,Red,Middleweight
+10/18/2019,Daniel Spitz,Tanner Boser,Blue,Heavyweight
+10/12/2019,Joanna Jedrzejczyk,Michelle Waterson-Gomez,Red,Women's Strawweight
+10/12/2019,Cub Swanson,Kron Gracie,Red,Featherweight
+10/12/2019,Niko Price,James Vick,Red,Welterweight
+10/12/2019,Mackenzie Dern,Amanda Ribas,Blue,Women's Strawweight
+10/12/2019,Matt Frevola,Luis Pena,Red,Lightweight
+10/12/2019,Eryk Anders,Gerald Meerschaert,Red,Middleweight
+10/12/2019,Ryan Spann,Devin Clark,Red,Light Heavyweight
+10/12/2019,Mike Davis,Thomas Gifford,Red,Lightweight
+10/12/2019,Max Griffin,Alex Morono,Blue,Welterweight
+10/12/2019,Deiveson Figueiredo,Tim Elliott,Red,Flyweight
+10/12/2019,Marlon Vera,Andre Ewell,Red,Bantamweight
+10/12/2019,Miguel Baeza,Hector Aldana,Red,Welterweight
+10/12/2019,Marvin Vettori,Andrew Sanchez,Red,Middleweight
+10/12/2019,JJ Aldrich,Lauren Mueller,Red,Women's Flyweight
+10/05/2019,Robert Whittaker,Israel Adesanya,Blue,UFC Middleweight Title
+10/05/2019,Al Iaquinta,Dan Hooker,Blue,Lightweight
+10/05/2019,Tai Tuivasa,Serghei Spivac,Blue,Heavyweight
+10/05/2019,Luke Jumeau,Dhiego Lima,Blue,Welterweight
+10/05/2019,Justin Tafa,Yorgan De Castro,Blue,Heavyweight
+10/05/2019,Jake Matthews,Rostem Akman,Red,Welterweight
+10/05/2019,Callan Potter,Maki Pitolo,Red,Welterweight
+10/05/2019,Brad Riddell,Jamie Mullarkey,Red,Lightweight
+10/05/2019,Megan Anderson,Zarah Fairn,Red,Women's Featherweight
+10/05/2019,Nadia Kassem,Ji Yeon Kim,Blue,Women's Flyweight
+09/28/2019,Jack Hermansson,Jared Cannonier,Blue,Middleweight
+09/28/2019,Mark Madsen,Danilo Belluardo,Red,Lightweight
+09/28/2019,Gunnar Nelson,Gilbert Burns,Blue,Welterweight
+09/28/2019,Ion Cutelaba,Khalil Rountree Jr.,Red,Light Heavyweight
+09/28/2019,Michal Oleksiejczuk,Ovince Saint Preux,Blue,Light Heavyweight
+09/28/2019,Nicolas Dalby,Alex Oliveira,Red,Welterweight
+09/28/2019,Alen Amedovski,John Phillips,Blue,Middleweight
+09/28/2019,Alessio Di Chirico,Makhmud Muradov,Blue,Middleweight
+09/28/2019,Siyar Bahadurzada,Ismail Naurdiev,Blue,Welterweight
+09/28/2019,Brandon Davis,Giga Chikadze,Blue,Featherweight
+09/28/2019,Macy Chiasson,Lina Lansberg,Blue,Women's Bantamweight
+09/28/2019,Marc Diakiese,Lando Vannata,Red,Lightweight
+09/28/2019,Jack Shore,Nohelin Hernandez,Red,Bantamweight
+09/21/2019,Carla Esparza,Alexa Grasso,Red,Women's Strawweight
+09/21/2019,Irene Aldana,Vanessa Melo,Red,Women's Bantamweight
+09/21/2019,Martin Bravo,Steven Peterson,Blue,Featherweight
+09/21/2019,Jose Quinonez,Carlos Huachin,Red,Bantamweight
+09/21/2019,Marco Polo Reyes,Kyle Nelson,Blue,Featherweight
+09/21/2019,Ariane Carnelossi,Angela Hill,Blue,Women's Strawweight
+09/21/2019,Sergio Pettis,Tyson Nam,Red,Flyweight
+09/21/2019,Vinicius Moreira,Paul Craig,Blue,Light Heavyweight
+09/21/2019,Sijara Eubanks,Bethe Correia,Blue,Women's Bantamweight
+09/21/2019,Claudio Puelles,Marcos Mariano,Red,Lightweight
+09/14/2019,Donald Cerrone,Justin Gaethje,Blue,Lightweight
+09/14/2019,Glover Teixeira,Nikita Krylov,Red,Light Heavyweight
+09/14/2019,Michel Pereira,Tristan Connelly,Blue,Welterweight
+09/14/2019,Uriah Hall,Antonio Carlos Junior,Red,Middleweight
+09/14/2019,Misha Cirkunov,Jimmy Crute,Red,Light Heavyweight
+09/14/2019,Marcin Tybura,Augusto Sakai,Blue,Heavyweight
+09/14/2019,Cole Smith,Miles Johns,Blue,Bantamweight
+09/14/2019,Brad Katona,Hunter Azure,Blue,Bantamweight
+09/14/2019,Chas Skelly,Jordan Griffin,Red,Featherweight
+09/14/2019,Louis Smolka,Ryan MacDonald,Red,Bantamweight
+09/14/2019,Kyle Prepolec,Austin Hubbard,Blue,Lightweight
+09/07/2019,Khabib Nurmagomedov,Dustin Poirier,Red,UFC Lightweight Title
+09/07/2019,Edson Barboza,Paul Felder,Blue,Lightweight
+09/07/2019,Islam Makhachev,Davi Ramos,Red,Lightweight
+09/07/2019,Curtis Blaydes,Shamil Abdurakhimov,Red,Heavyweight
+09/07/2019,Mairbek Taisumov,Diego Ferreira,Blue,Lightweight
+09/07/2019,Joanne Wood,Andrea Lee,Red,Women's Flyweight
+09/07/2019,Liana Jojua,Sarah Moras,Blue,Women's Bantamweight
+09/07/2019,Ottman Azaitar,Teemu Packalen,Red,Lightweight
+09/07/2019,Belal Muhammad,Takashi Sato,Red,Welterweight
+09/07/2019,Nordine Taleb,Muslim Salikhov,Blue,Welterweight
+09/07/2019,Omari Akhmedov,Zak Cummings,Red,Middleweight
+09/07/2019,Don Madge,Fares Ziam,Red,Lightweight
+08/31/2019,Jessica Andrade,Zhang Weili,Blue,UFC Women's Strawweight Title
+08/31/2019,Li Jingliang,Elizeu Zaleski dos Santos,Red,Welterweight
+08/31/2019,Kai Kara-France,Mark De La Rosa,Red,Flyweight
+08/31/2019,Song Kenan,Derrick Krantz,Red,Welterweight
+08/31/2019,Wu Yanan,Mizuki,Blue,Women's Flyweight
+08/31/2019,JunYong Park,Anthony Hernandez,Blue,Middleweight
+08/31/2019,Sumudaerji,Andre Soukhamthath,Red,Bantamweight
+08/31/2019,Da Woon Jung,Khadis Ibragimov,Red,Light Heavyweight
+08/31/2019,Damir Ismagulov,Thiago Moises,Red,Lightweight
+08/31/2019,Alatengheili,Batgerel Danaa,Red,Bantamweight
+08/31/2019,Karol Rosa,Lara Procopio,Red,Women's Bantamweight
+08/17/2019,Daniel Cormier,Stipe Miocic,Blue,UFC Heavyweight Title
+08/17/2019,Anthony Pettis,Nate Diaz,Blue,Welterweight
+08/17/2019,Yoel Romero,Paulo Costa,Blue,Middleweight
+08/17/2019,Gabriel Benitez,Sodiq Yusuff,Blue,Featherweight
+08/17/2019,Derek Brunson,Ian Heinisch,Red,Middleweight
+08/17/2019,Devonte Smith,Khama Worthy,Blue,Lightweight
+08/17/2019,Raphael Assuncao,Cory Sandhagen,Blue,Bantamweight
+08/17/2019,Christos Giagos,Drakkar Klose,Blue,Lightweight
+08/17/2019,Manny Bermudez,Casey Kenney,Blue,Catch Weight
+08/17/2019,Hannah Cifers,Jodie Esquibel,Red,Women's Strawweight
+08/17/2019,Kyung Ho Kang,Brandon Davis,Red,Bantamweight
+08/17/2019,Sabina Mazo,Shana Dobson,Red,Women's Flyweight
+08/10/2019,Valentina Shevchenko,Liz Carmouche,Red,UFC Women's Flyweight Title
+08/10/2019,Vicente Luque,Mike Perry,Red,Welterweight
+08/10/2019,Eduardo Garagorri,Humberto Bandenay,Red,Featherweight
+08/10/2019,Volkan Oezdemir,Ilir Latifi,Red,Light Heavyweight
+08/10/2019,Rodolfo Vieira,Oskar Piechota,Red,Middleweight
+08/10/2019,Enrique Barzola,Bobby Moffett,Red,Featherweight
+08/10/2019,Gilbert Burns,Aleksei Kunchenko,Red,Welterweight
+08/10/2019,Ciryl Gane,Raphael Pessoa,Red,Heavyweight
+08/10/2019,Tecia Torres,Marina Rodriguez,Blue,Women's Strawweight
+08/10/2019,Rogerio Bontorin,Raulian Paiva,Red,Flyweight
+08/10/2019,Geraldo de Freitas,Chris Gutierrez,Blue,Bantamweight
+08/10/2019,Kazula Vargas,Alex Da Silva,Blue,Lightweight
+08/10/2019,Veronica Hardy,Polyana Viana,Red,Women's Flyweight
+08/03/2019,Colby Covington,Robbie Lawler,Red,Welterweight
+08/03/2019,Jim Miller,Clay Guida,Red,Lightweight
+08/03/2019,Joaquim Silva,Nasrat Haqparast,Blue,Lightweight
+08/03/2019,Trevin Giles,Gerald Meerschaert,Blue,Middleweight
+08/03/2019,Scott Holtzman,Dong Hyun Ma,Red,Lightweight
+08/03/2019,Darko Stosic,Kennedy Nzechukwu,Blue,Light Heavyweight
+08/03/2019,Mickey Gall,Salim Touahri,Red,Welterweight
+08/03/2019,Antonina Shevchenko,Lucie Pudilova,Red,Women's Flyweight
+08/03/2019,Jordan Espinosa,Matt Schnell,Blue,Flyweight
+08/03/2019,Lauren Murphy,Mara Romero Borella,Red,Women's Flyweight
+08/03/2019,Claudio Silva,Cole Williams,Red,Welterweight
+08/03/2019,Miranda Granger,Hannah Goldy,Red,Women's Flyweight
+07/27/2019,Max Holloway,Frankie Edgar,Red,UFC Featherweight Title
+07/27/2019,Cristiane Justino,Felicia Spencer,Red,Women's Featherweight
+07/27/2019,Geoff Neal,Niko Price,Red,Welterweight
+07/27/2019,Olivier Aubin-Mercier,Arman Tsarukyan,Blue,Lightweight
+07/27/2019,Marc-Andre Barriault,Krzysztof Jotko,Blue,Middleweight
+07/27/2019,Alexis Davis,Viviane Araujo,Blue,Women's Flyweight
+07/27/2019,Hakeem Dawodu,Yoshinori Horie,Red,Featherweight
+07/27/2019,Gavin Tucker,SeungWoo Choi,Red,Featherweight
+07/27/2019,Alexandre Pantoja,Deiveson Figueiredo,Blue,Flyweight
+07/27/2019,Gillian Robertson,Sarah Frota,Red,Women's Flyweight
+07/27/2019,Erik Koch,Kyle Stewart,Red,Welterweight
+07/20/2019,Rafael Dos Anjos,Leon Edwards,Blue,Welterweight
+07/20/2019,Aleksei Oleinik,Walt Harris,Blue,Heavyweight
+07/20/2019,Greg Hardy,Juan Adams,Red,Heavyweight
+07/20/2019,James Vick,Dan Hooker,Blue,Lightweight
+07/20/2019,Alexander Hernandez,Francisco Trinaldo,Red,Lightweight
+07/20/2019,Andrei Arlovski,Ben Rothwell,Red,Heavyweight
+07/20/2019,Alex Caceres,Steven Peterson,Red,Featherweight
+07/20/2019,Raquel Pennington,Irene Aldana,Red,Women's Bantamweight
+07/20/2019,Sam Alvey,Klidson Abreu,Blue,Light Heavyweight
+07/20/2019,Roxanne Modafferi,Jennifer Maia,Blue,Women's Flyweight
+07/20/2019,Ray Borg,Gabriel Silva,Red,Bantamweight
+07/20/2019,Mario Bautista,Jin Soo Son,Red,Bantamweight
+07/20/2019,Domingo Pilarte,Felipe Colares,Blue,Bantamweight
+07/13/2019,Germaine de Randamie,Aspen Ladd,Red,Women's Bantamweight
+07/13/2019,Urijah Faber,Ricky Simon,Red,Bantamweight
+07/13/2019,Josh Emmett,Mirsad Bektic,Red,Featherweight
+07/13/2019,Karl Roberson,Wellington Turman,Red,Middleweight
+07/13/2019,Marvin Vettori,Cezar Ferreira,Red,Middleweight
+07/13/2019,Andre Fili,Sheymon Moraes,Red,Featherweight
+07/13/2019,Julianna Pena,Nicco Montano,Red,Women's Bantamweight
+07/13/2019,Darren Elkins,Ryan Hall,Blue,Featherweight
+07/13/2019,Pingyuan Liu,Jonathan Martinez,Blue,Bantamweight
+07/13/2019,Livinha Souza,Brianna Fortino,Blue,Women's Strawweight
+07/13/2019,Benito Lopez,Vince Morales,Red,Bantamweight
+07/06/2019,Jon Jones,Thiago Santos,Red,UFC Light Heavyweight Title
+07/06/2019,Amanda Nunes,Holly Holm,Red,UFC Women's Bantamweight Title
+07/06/2019,Jorge Masvidal,Ben Askren,Red,Welterweight
+07/06/2019,Jan Blachowicz,Luke Rockhold,Red,Light Heavyweight
+07/06/2019,Diego Sanchez,Michael Chiesa,Blue,Welterweight
+07/06/2019,Gilbert Melendez,Arnold Allen,Blue,Featherweight
+07/06/2019,Marlon Vera,Nohelin Hernandez,Red,Bantamweight
+07/06/2019,Claudia Gadelha,Randa Markos,Red,Women's Strawweight
+07/06/2019,Alejandro Perez,Song Yadong,Blue,Bantamweight
+07/06/2019,Edmen Shahbazyan,Jack Marshman,Red,Middleweight
+07/06/2019,Ismail Naurdiev,Chance Rencountre,Blue,Welterweight
+07/06/2019,Julia Avila,Pannie Kianzad,Red,Women's Bantamweight
+06/29/2019,Francis Ngannou,Junior Dos Santos,Red,Heavyweight
+06/29/2019,Jussier Formiga,Joseph Benavidez,Blue,Flyweight
+06/29/2019,Demian Maia,Anthony Rocco Martin,Red,Welterweight
+06/29/2019,Roosevelt Roberts,Vinc Pichel,Blue,Lightweight
+06/29/2019,Drew Dober,Marco Polo Reyes,Red,Lightweight
+06/29/2019,Alonzo Menifield,Paul Craig,Red,Light Heavyweight
+06/29/2019,Ricardo Ramos,Journey Newson,Red,Bantamweight
+06/29/2019,Eryk Anders,Vinicius Moreira,Red,Light Heavyweight
+06/29/2019,Jared Gordon,Dan Moret,Red,Lightweight
+06/29/2019,Dalcha Lungiambula,Dequan Townsend,Red,Light Heavyweight
+06/29/2019,Emily Whitmire,Amanda Ribas,Blue,Women's Strawweight
+06/29/2019,Maurice Greene,Junior Albini,Red,Heavyweight
+06/22/2019,Renato Moicano,Chan Sung Jung,Blue,Featherweight
+06/22/2019,Bryan Barberena,Randy Brown,Blue,Welterweight
+06/22/2019,Andre Ewell,Anderson Dos Santos,Red,Bantamweight
+06/22/2019,Andrea Lee,Montana De La Rosa,Red,Women's Flyweight
+06/22/2019,Kevin Holland,Alessio Di Chirico,Red,Middleweight
+06/22/2019,Dan Ige,Kevin Aguilar,Red,Featherweight
+06/22/2019,Ashley Yoder,Syuri Kondo,Red,Women's Strawweight
+06/22/2019,Matt Wiman,Luis Pena,Blue,Lightweight
+06/22/2019,Allen Crowder,Jairzinho Rozenstruik,Blue,Heavyweight
+06/22/2019,Ariane Lipski,Molly McCann,Blue,Women's Flyweight
+06/22/2019,Deron Winn,Eric Spicely,Red,Middleweight
+06/08/2019,Henry Cejudo,Marlon Moraes,Red,UFC Bantamweight Title
+06/08/2019,Valentina Shevchenko,Jessica Eye,Red,UFC Women's Flyweight Title
+06/08/2019,Tony Ferguson,Donald Cerrone,Red,Lightweight
+06/08/2019,Jimmie Rivera,Petr Yan,Blue,Bantamweight
+06/08/2019,Tai Tuivasa,Blagoy Ivanov,Blue,Heavyweight
+06/08/2019,Tatiana Suarez,Nina Nunes,Red,Women's Strawweight
+06/08/2019,Aljamain Sterling,Pedro Munhoz,Red,Bantamweight
+06/08/2019,Karolina Kowalkiewicz,Alexa Grasso,Blue,Women's Strawweight
+06/08/2019,Ricardo Lamas,Calvin Kattar,Blue,Featherweight
+06/08/2019,Yan Xiaonan,Angela Hill,Red,Women's Strawweight
+06/08/2019,Bevon Lewis,Darren Stewart,Blue,Middleweight
+06/08/2019,Eddie Wineland,Grigory Popov,Red,Bantamweight
+06/08/2019,Katlyn Cerminara,Joanne Wood,Red,Women's Flyweight
+06/01/2019,Alexander Gustafsson,Anthony Smith,Blue,Light Heavyweight
+06/01/2019,Jimi Manuwa,Aleksandar Rakic,Blue,Light Heavyweight
+06/01/2019,Makwan Amirkhani,Chris Fishgold,Red,Featherweight
+06/01/2019,Damir Hadzovic,Christos Giagos,Blue,Lightweight
+06/01/2019,Daniel Teymur,Sung Bin Jo,Red,Featherweight
+06/01/2019,Rostem Akman,Sergey Khandozhko,Blue,Welterweight
+06/01/2019,Tonya Evinger,Lina Lansberg,Blue,Women's Bantamweight
+06/01/2019,Stevie Ray,Leonardo Santos,Blue,Lightweight
+06/01/2019,Nick Hein,Frank Camacho,Blue,Lightweight
+06/01/2019,Bea Malecki,Duda Santana,Red,Women's Bantamweight
+06/01/2019,Darko Stosic,Devin Clark,Blue,Light Heavyweight
+06/01/2019,Joel Alvarez,Danilo Belluardo,Red,Lightweight
+05/18/2019,Rafael Dos Anjos,Kevin Lee,Red,Welterweight
+05/18/2019,Antonio Carlos Junior,Ian Heinisch,Blue,Middleweight
+05/18/2019,Megan Anderson,Felicia Spencer,Blue,Women's Featherweight
+05/18/2019,Vicente Luque,Derrick Krantz,Red,Welterweight
+05/18/2019,Charles Oliveira,Nik Lentz,Red,Lightweight
+05/18/2019,Davi Ramos,Austin Hubbard,Red,Lightweight
+05/18/2019,Aspen Ladd,Sijara Eubanks,Red,Women's Bantamweight
+05/18/2019,Desmond Green,Charles Jourdain,Red,Lightweight
+05/18/2019,Danny Roberts,Michel Pereira,Blue,Welterweight
+05/18/2019,Michael Trizano,Grant Dawson,Blue,Featherweight
+05/18/2019,Patrick Cummins,Ed Herman,Blue,Light Heavyweight
+05/18/2019,Zak Cummings,Trevin Giles,Red,Middleweight
+05/18/2019,Julio Arce,Julian Erosa,Red,Featherweight
+05/11/2019,Rose Namajunas,Jessica Andrade,Blue,UFC Women's Strawweight Title
+05/11/2019,Jared Cannonier,Anderson Silva,Red,Middleweight
+05/11/2019,Jose Aldo,Alexander Volkanovski,Blue,Featherweight
+05/11/2019,Thiago Alves,Laureano Staropoli,Blue,Welterweight
+05/11/2019,Irene Aldana,Bethe Correia,Red,Women's Bantamweight
+05/11/2019,Rogerio Nogueira,Ryan Spann,Blue,Light Heavyweight
+05/11/2019,Thiago Moises,Kurt Holobaugh,Red,Lightweight
+05/11/2019,Warlley Alves,Sergio Moraes,Red,Welterweight
+05/11/2019,BJ Penn,Clay Guida,Blue,Lightweight
+05/11/2019,Luana Carolina,Priscila Cachoeira,Red,Women's Flyweight
+05/11/2019,Raoni Barcelos,Carlos Huachin,Red,Bantamweight
+05/11/2019,Talita Bernardo,Viviane Araujo,Blue,Women's Bantamweight
+05/04/2019,Al Iaquinta,Donald Cerrone,Blue,Lightweight
+05/04/2019,Derek Brunson,Elias Theodorou,Red,Middleweight
+05/04/2019,Cub Swanson,Shane Burgos,Blue,Featherweight
+05/04/2019,Brad Katona,Merab Dvalishvili,Blue,Bantamweight
+05/04/2019,Walt Harris,Serghei Spivac,Red,Heavyweight
+05/04/2019,Marc-Andre Barriault,Andrew Sanchez,Blue,Middleweight
+05/04/2019,Macy Chiasson,Sarah Moras,Red,Women's Bantamweight
+05/04/2019,Aiemann Zahabi,Vince Morales,Blue,Bantamweight
+05/04/2019,Nordine Taleb,Kyle Prepolec,Red,Welterweight
+05/04/2019,Kyle Nelson,Matt Sayles,Blue,Featherweight
+05/04/2019,Arjan Bhullar,Juan Adams,Red,Heavyweight
+05/04/2019,Mitch Gagnon,Cole Smith,Blue,Bantamweight
+04/27/2019,Jacare Souza,Jack Hermansson,Blue,Middleweight
+04/27/2019,Greg Hardy,Dmitrii Smoliakov,Red,Heavyweight
+04/27/2019,Alex Oliveira,Mike Perry,Blue,Welterweight
+04/27/2019,Glover Teixeira,Ion Cutelaba,Red,Light Heavyweight
+04/27/2019,John Lineker,Cory Sandhagen,Blue,Bantamweight
+04/27/2019,Roosevelt Roberts,Thomas Gifford,Red,Lightweight
+04/27/2019,Ben Saunders,Takashi Sato,Blue,Welterweight
+04/27/2019,Andrei Arlovski,Augusto Sakai,Blue,Heavyweight
+04/27/2019,Carla Esparza,Virna Jandiroba,Red,Women's Strawweight
+04/27/2019,Gilbert Burns,Mike Davis,Red,Lightweight
+04/27/2019,Jim Miller,Jason Gonzalez,Red,Lightweight
+04/27/2019,Angela Hill,Jodie Esquibel,Red,Women's Strawweight
+04/27/2019,Court McGee,Dhiego Lima,Blue,Welterweight
+04/20/2019,Alistair Overeem,Aleksei Oleinik,Red,Heavyweight
+04/20/2019,Islam Makhachev,Arman Tsarukyan,Red,Lightweight
+04/20/2019,Sergei Pavlovich,Marcelo Golm,Red,Heavyweight
+04/20/2019,Roxanne Modafferi,Antonina Shevchenko,Red,Women's Flyweight
+04/20/2019,Krzysztof Jotko,Alen Amedovski,Red,Middleweight
+04/20/2019,Movsar Evloev,SeungWoo Choi,Red,Featherweight
+04/20/2019,Sultan Aliev,Keita Nakamura,Red,Welterweight
+04/20/2019,Alexander Yakovlev,Alex Da Silva,Red,Lightweight
+04/20/2019,Marcin Tybura,Shamil Abdurakhimov,Blue,Heavyweight
+04/20/2019,Gadzhimurad Antigulov,Michal Oleksiejczuk,Blue,Light Heavyweight
+04/20/2019,Magomed Mustafaev,Rafael Fiziev,Red,Lightweight
+04/13/2019,Max Holloway,Dustin Poirier,Blue,UFC Interim Lightweight Title
+04/13/2019,Kelvin Gastelum,Israel Adesanya,Blue,UFC Interim Middleweight Title
+04/13/2019,Eryk Anders,Khalil Rountree Jr.,Blue,Light Heavyweight
+04/13/2019,Alan Jouban,Dwight Grant,Blue,Welterweight
+04/13/2019,Ovince Saint Preux,Nikita Krylov,Blue,Light Heavyweight
+04/13/2019,Jalin Turner,Matt Frevola,Blue,Lightweight
+04/13/2019,Wilson Reis,Alexandre Pantoja,Blue,Flyweight
+04/13/2019,Max Griffin,Zelim Imadaev,Red,Welterweight
+04/13/2019,Boston Salmon,Khalid Taha,Blue,Bantamweight
+04/13/2019,Curtis Millender,Belal Muhammad,Blue,Welterweight
+04/13/2019,Montel Jackson,Andre Soukhamthath,Red,Bantamweight
+04/13/2019,Lauren Mueller,Poliana Botelho,Blue,Women's Flyweight
+04/13/2019,Brandon Davis,Randy Costa,Red,Bantamweight
+03/30/2019,Edson Barboza,Justin Gaethje,Blue,Lightweight
+03/30/2019,David Branch,Jack Hermansson,Blue,Middleweight
+03/30/2019,Josh Emmett,Michael Johnson,Red,Featherweight
+03/30/2019,Karolina Kowalkiewicz,Michelle Waterson-Gomez,Blue,Women's Strawweight
+03/30/2019,Kennedy Nzechukwu,Paul Craig,Blue,Light Heavyweight
+03/30/2019,Sodiq Yusuff,Sheymon Moraes,Red,Featherweight
+03/30/2019,Marina Rodriguez,Jessica Aguilar,Red,Women's Strawweight
+03/30/2019,Ross Pearson,Desmond Green,Blue,Lightweight
+03/30/2019,Enrique Barzola,Kevin Aguilar,Blue,Featherweight
+03/30/2019,Kevin Holland,Gerald Meerschaert,Red,Middleweight
+03/30/2019,Ray Borg,Casey Kenney,Blue,Bantamweight
+03/30/2019,Sabina Mazo,Maryna Moroz,Blue,Women's Flyweight
+03/30/2019,Alex Perez,Mark De La Rosa,Red,Bantamweight
+03/23/2019,Stephen Thompson,Anthony Pettis,Blue,Welterweight
+03/23/2019,Curtis Blaydes,Justin Willis,Red,Heavyweight
+03/23/2019,John Makdessi,Jesus Pinedo,Red,Lightweight
+03/23/2019,Jussier Formiga,Deiveson Figueiredo,Red,Flyweight
+03/23/2019,Luis Pena,Steven Peterson,Red,Featherweight
+03/23/2019,Maycee Barber,JJ Aldrich,Red,Women's Flyweight
+03/23/2019,Bryce Mitchell,Bobby Moffett,Red,Featherweight
+03/23/2019,Marlon Vera,Frankie Saenz,Red,Bantamweight
+03/23/2019,Alexis Davis,Jennifer Maia,Blue,Women's Flyweight
+03/23/2019,Randa Markos,Angela Hill,Red,Women's Strawweight
+03/23/2019,Ryan MacDonald,Chris Gutierrez,Blue,Bantamweight
+03/23/2019,Eric Shelton,Jordan Espinosa,Blue,Flyweight
+03/16/2019,Darren Till,Jorge Masvidal,Blue,Welterweight
+03/16/2019,Leon Edwards,Gunnar Nelson,Red,Welterweight
+03/16/2019,Volkan Oezdemir,Dominick Reyes,Blue,Light Heavyweight
+03/16/2019,Nathaniel Wood,Jose Quinonez,Red,Bantamweight
+03/16/2019,Danny Roberts,Claudio Silva,Blue,Welterweight
+03/16/2019,Jack Marshman,John Phillips,Red,Middleweight
+03/16/2019,Arnold Allen,Jordan Rinaldi,Red,Featherweight
+03/16/2019,Marc Diakiese,Joe Duffy,Red,Lightweight
+03/16/2019,Nicolae Negumereanu,Saparbeg Safarov,Blue,Light Heavyweight
+03/16/2019,Danny Henry,Dan Ige,Blue,Featherweight
+03/16/2019,Molly McCann,Priscila Cachoeira,Red,Women's Flyweight
+03/16/2019,Mike Grundy,Nad Narimani,Red,Featherweight
+03/09/2019,Derrick Lewis,Junior Dos Santos,Blue,Heavyweight
+03/09/2019,Elizeu Zaleski dos Santos,Curtis Millender,Red,Welterweight
+03/09/2019,Tim Means,Niko Price,Blue,Welterweight
+03/09/2019,Blagoy Ivanov,Ben Rothwell,Red,Heavyweight
+03/09/2019,Beneil Dariush,Drew Dober,Red,Lightweight
+03/09/2019,Tim Boetsch,Omari Akhmedov,Blue,Middleweight
+03/09/2019,Anthony Rocco Martin,Sergio Moraes,Red,Welterweight
+03/09/2019,Marion Reneau,Yana Santos,Blue,Women's Bantamweight
+03/09/2019,Grant Dawson,Julian Erosa,Red,Featherweight
+03/09/2019,Maurice Greene,Jeff Hughes,Red,Heavyweight
+03/09/2019,Louis Smolka,Matt Schnell,Blue,Bantamweight
+03/09/2019,Alex Morono,Zak Ottow,Red,Welterweight
+03/09/2019,Alex White,Dan Moret,Red,Lightweight
+03/02/2019,Jon Jones,Anthony Smith,Red,UFC Light Heavyweight Title
+03/02/2019,Tyron Woodley,Kamaru Usman,Blue,UFC Welterweight Title
+03/02/2019,Robbie Lawler,Ben Askren,Blue,Welterweight
+03/02/2019,Tecia Torres,Zhang Weili,Blue,Women's Strawweight
+03/02/2019,Cody Garbrandt,Pedro Munhoz,Blue,Bantamweight
+03/02/2019,Jeremy Stephens,Zabit Magomedsharipov,Blue,Featherweight
+03/02/2019,Misha Cirkunov,Johnny Walker,Blue,Light Heavyweight
+03/02/2019,Cody Stamann,Alejandro Perez,Red,Bantamweight
+03/02/2019,Diego Sanchez,Mickey Gall,Red,Welterweight
+03/02/2019,Edmen Shahbazyan,Charles Byrd,Red,Middleweight
+03/02/2019,Gina Mazany,Macy Chiasson,Blue,Women's Bantamweight
+03/02/2019,Polyana Viana,Hannah Cifers,Blue,Women's Strawweight
+02/23/2019,Jan Blachowicz,Thiago Santos,Blue,Light Heavyweight
+02/23/2019,Stefan Struve,Marcos Rogerio de Lima,Red,Heavyweight
+02/23/2019,Gian Villante,Michal Oleksiejczuk,Blue,Light Heavyweight
+02/23/2019,Liz Carmouche,Lucie Pudilova,Red,Women's Flyweight
+02/23/2019,John Dodson,Petr Yan,Blue,Bantamweight
+02/23/2019,Magomed Ankalaev,Klidson Abreu,Red,Light Heavyweight
+02/23/2019,Dwight Grant,Carlo Pedersoli Jr.,Red,Welterweight
+02/23/2019,Daniel Teymur,Chris Fishgold,Blue,Featherweight
+02/23/2019,Veronica Hardy,Gillian Robertson,Blue,Women's Flyweight
+02/23/2019,Damir Hadzovic,Marco Polo Reyes,Red,Lightweight
+02/23/2019,Michel Prazeres,Ismail Naurdiev,Blue,Welterweight
+02/23/2019,Rustam Khabilov,Diego Ferreira,Blue,Lightweight
+02/23/2019,Damir Ismagulov,Joel Alvarez,Red,Lightweight
+02/17/2019,Francis Ngannou,Cain Velasquez,Red,Heavyweight
+02/17/2019,James Vick,Paul Felder,Blue,Lightweight
+02/17/2019,Cortney Casey,Cynthia Calvillo,Blue,Women's Strawweight
+02/17/2019,Alex Caceres,Kron Gracie,Blue,Featherweight
+02/17/2019,Vicente Luque,Bryan Barberena,Red,Welterweight
+02/17/2019,Andre Fili,Myles Jury,Red,Featherweight
+02/17/2019,Jimmie Rivera,Aljamain Sterling,Blue,Bantamweight
+02/17/2019,Benito Lopez,Manny Bermudez,Blue,Bantamweight
+02/17/2019,Ashlee Evans-Smith,Andrea Lee,Blue,Women's Flyweight
+02/17/2019,Scott Holtzman,Nik Lentz,Blue,Lightweight
+02/17/2019,Renan Barao,Luke Sanders,Blue,Bantamweight
+02/17/2019,Aleksandra Albu,Emily Whitmire,Blue,Women's Strawweight
+02/09/2019,Israel Adesanya,Anderson Silva,Red,Middleweight
+02/09/2019,Lando Vannata,Marcos Mariano,Red,Lightweight
+02/09/2019,Rani Yahya,Ricky Simon,Blue,Bantamweight
+02/09/2019,Montana De La Rosa,Nadia Kassem,Red,Women's Flyweight
+02/09/2019,Jimmy Crute,Sam Alvey,Red,Light Heavyweight
+02/09/2019,Devonte Smith,Dong Hyun Ma,Red,Lightweight
+02/09/2019,Shane Young,Austin Arnett,Red,Featherweight
+02/09/2019,Kai Kara-France,Raulian Paiva,Red,Flyweight
+02/09/2019,Teruto Ishihara,Kyung Ho Kang,Blue,Bantamweight
+02/09/2019,Callan Potter,Jalin Turner,Blue,Lightweight
+02/09/2019,Wulijiburen,Jonathan Martinez,Blue,Bantamweight
+02/02/2019,Raphael Assuncao,Marlon Moraes,Blue,Bantamweight
+02/02/2019,Jose Aldo,Renato Moicano,Red,Featherweight
+02/02/2019,Demian Maia,Lyman Good,Red,Welterweight
+02/02/2019,Charles Oliveira,David Teymur,Red,Lightweight
+02/02/2019,Johnny Walker,Justin Ledet,Red,Light Heavyweight
+02/02/2019,Livinha Souza,Sarah Frota,Red,Women's Strawweight
+02/02/2019,Markus Perez,Anthony Hernandez,Red,Middleweight
+02/02/2019,Mara Romero Borella,Taila Santos,Red,Women's Flyweight
+02/02/2019,Thiago Alves,Max Griffin,Red,Welterweight
+02/02/2019,Junior Albini,Jairzinho Rozenstruik,Blue,Heavyweight
+02/02/2019,Geraldo de Freitas,Felipe Colares,Red,Featherweight
+02/02/2019,Ricardo Ramos,Said Nurmagomedov,Blue,Bantamweight
+02/02/2019,Bibulatov Magomed,Rogerio Bontorin,Blue,Flyweight
+01/19/2019,Henry Cejudo,TJ Dillashaw,Red,UFC Flyweight Title
+01/19/2019,Greg Hardy,Allen Crowder,Blue,Heavyweight
+01/19/2019,Gregor Gillespie,Yancy Medeiros,Red,Lightweight
+01/19/2019,Joseph Benavidez,Dustin Ortiz,Red,Flyweight
+01/19/2019,Paige VanZant,Rachael Ostovich,Red,Women's Flyweight
+01/19/2019,Glover Teixeira,Karl Roberson,Red,Light Heavyweight
+01/19/2019,Alexander Hernandez,Donald Cerrone,Blue,Lightweight
+01/19/2019,Joanne Wood,Ariane Lipski,Red,Women's Flyweight
+01/19/2019,Alonzo Menifield,Vinicius Moreira,Red,Light Heavyweight
+01/19/2019,Cory Sandhagen,Mario Bautista,Red,Bantamweight
+01/19/2019,Dennis Bermudez,Te Edwards,Red,Lightweight
+01/19/2019,Belal Muhammad,Geoff Neal,Blue,Welterweight
+01/19/2019,Kyle Stewart,Chance Rencountre,Blue,Welterweight
+12/29/2018,Jon Jones,Alexander Gustafsson,Red,UFC Light Heavyweight Title
+12/29/2018,Cristiane Justino,Amanda Nunes,Blue,UFC Women's Featherweight Title
+12/29/2018,Carlos Condit,Michael Chiesa,Blue,Welterweight
+12/29/2018,Ilir Latifi,Corey Anderson,Blue,Light Heavyweight
+12/29/2018,Chad Mendes,Alexander Volkanovski,Blue,Featherweight
+12/29/2018,Cat Zingano,Megan Anderson,Blue,Women's Featherweight
+12/29/2018,Douglas Silva de Andrade,Petr Yan,Blue,Bantamweight
+12/29/2018,BJ Penn,Ryan Hall,Blue,Lightweight
+12/29/2018,Nathaniel Wood,Andre Ewell,Red,Bantamweight
+12/29/2018,Uriah Hall,Bevon Lewis,Red,Middleweight
+12/29/2018,Curtis Millender,Siyar Bahadurzada,Red,Welterweight
+12/29/2018,Brian Kelleher,Montel Jackson,Blue,Bantamweight
+12/15/2018,Kevin Lee,Al Iaquinta,Blue,Lightweight
+12/15/2018,Edson Barboza,Dan Hooker,Red,Lightweight
+12/15/2018,Rob Font,Sergio Pettis,Red,Bantamweight
+12/15/2018,Jim Miller,Charles Oliveira,Blue,Lightweight
+12/15/2018,Zak Ottow,Dwight Grant,Red,Welterweight
+12/15/2018,Bobby Green,Drakkar Klose,Blue,Lightweight
+12/15/2018,Jared Gordon,Joaquim Silva,Blue,Lightweight
+12/15/2018,Gerald Meerschaert,Jack Hermansson,Blue,Middleweight
+12/15/2018,Trevor Smith,Zak Cummings,Blue,Middleweight
+12/15/2018,Dan Ige,Jordan Griffin,Red,Featherweight
+12/15/2018,Adam Milstead,Mike Rodriguez,Blue,Light Heavyweight
+12/15/2018,Chris de la Rocha,Juan Adams,Blue,Heavyweight
+12/08/2018,Max Holloway,Brian Ortega,Red,UFC Featherweight Title
+12/08/2018,Valentina Shevchenko,Joanna Jedrzejczyk,Red,UFC Women's Flyweight Title
+12/08/2018,Alex Oliveira,Gunnar Nelson,Blue,Welterweight
+12/08/2018,Hakeem Dawodu,Kyle Bochniak,Red,Featherweight
+12/08/2018,Jimi Manuwa,Thiago Santos,Blue,Light Heavyweight
+12/08/2018,Claudia Gadelha,Nina Nunes,Blue,Women's Strawweight
+12/08/2018,Olivier Aubin-Mercier,Gilbert Burns,Blue,Lightweight
+12/08/2018,Katlyn Cerminara,Jessica Eye,Blue,Women's Flyweight
+12/08/2018,Elias Theodorou,Eryk Anders,Red,Middleweight
+12/08/2018,Brad Katona,Matthew Lopez,Red,Bantamweight
+12/08/2018,Chad Laprise,Dhiego Lima,Blue,Welterweight
+12/08/2018,Diego Ferreira,Kyle Nelson,Red,Lightweight
+12/08/2018,Devin Clark,Aleksandar Rakic,Blue,Light Heavyweight
+12/01/2018,Junior Dos Santos,Tai Tuivasa,Red,Heavyweight
+12/01/2018,Mauricio Rua,Tyson Pedro,Red,Light Heavyweight
+12/01/2018,Mark Hunt,Justin Willis,Blue,Heavyweight
+12/01/2018,Jake Matthews,Anthony Rocco Martin,Blue,Welterweight
+12/01/2018,Suman Mokhtarian,Sodiq Yusuff,Blue,Featherweight
+12/01/2018,Jimmy Crute,Paul Craig,Red,Light Heavyweight
+12/01/2018,Yushin Okami,Aleksei Kunchenko,Blue,Welterweight
+12/01/2018,Wilson Reis,Ben Nguyen,Red,Flyweight
+12/01/2018,Keita Nakamura,Salim Touahri,Red,Welterweight
+12/01/2018,Elias Garcia,Kai Kara-France,Blue,Flyweight
+12/01/2018,Mizuto Hirota,Christos Giagos,Blue,Lightweight
+12/01/2018,Alex Gorgees,Damir Ismagulov,Blue,Lightweight
+11/30/2018,Rafael Dos Anjos,Kamaru Usman,Blue,Welterweight
+11/30/2018,Juan Espino,Justin Frazier,Red,Ultimate Fighter 28 Heavyweight Tournament Title
+11/30/2018,Pannie Kianzad,Macy Chiasson,Blue,Ultimate Fighter 28 Women's Featherweight Tournament Title
+11/30/2018,Pedro Munhoz,Bryan Caraway,Red,Bantamweight
+11/30/2018,Darren Stewart,Edmen Shahbazyan,Blue,Middleweight
+11/30/2018,Ji Yeon Kim,Antonina Shevchenko,Blue,Women's Flyweight
+11/30/2018,Ricky Glenn,Kevin Aguilar,Blue,Featherweight
+11/30/2018,Joseph Benavidez,Alex Perez,Red,Flyweight
+11/30/2018,Maurice Greene,Michel Batista,Red,Heavyweight
+11/30/2018,Julija Stoliarenko,Leah Letson,Blue,Women's Featherweight
+11/30/2018,Roosevelt Roberts,Darrell Horcher,Red,Lightweight
+11/30/2018,Tim Means,Ricky Rainey,Red,Welterweight
+11/30/2018,Raoni Barcelos,Chris Gutierrez,Red,Bantamweight
+11/24/2018,Curtis Blaydes,Francis Ngannou,Blue,Heavyweight
+11/24/2018,Alistair Overeem,Sergei Pavlovich,Red,Heavyweight
+11/24/2018,Song Yadong,Vince Morales,Red,Bantamweight
+11/24/2018,Li Jingliang,David Zawada,Red,Welterweight
+11/24/2018,Song Kenan,Alex Morono,Blue,Welterweight
+11/24/2018,Wu Yanan,Lauren Mueller,Red,Women's Flyweight
+11/24/2018,Hu Yaozong,Rashad Coulter,Blue,Light Heavyweight
+11/24/2018,Zhang Weili,Jessica Aguilar,Red,Women's Strawweight
+11/24/2018,Pingyuan Liu,Martin Day,Red,Bantamweight
+11/24/2018,Yan Xiaonan,Syuri Kondo,Red,Women's Strawweight
+11/24/2018,Kevin Holland,John Phillips,Red,Middleweight
+11/24/2018,Sumudaerji,Louis Smolka,Blue,Bantamweight
+11/17/2018,Neil Magny,Santiago Ponzinibbio,Blue,Welterweight
+11/17/2018,Ricardo Lamas,Darren Elkins,Red,Featherweight
+11/17/2018,Khalil Rountree Jr.,Johnny Walker,Blue,Light Heavyweight
+11/17/2018,Cezar Ferreira,Ian Heinisch,Blue,Middleweight
+11/17/2018,Guido Cannetti,Marlon Vera,Blue,Bantamweight
+11/17/2018,Cynthia Calvillo,Poliana Botelho,Red,Women's Strawweight
+11/17/2018,Michel Prazeres,Bartosz Fabinski,Red,Welterweight
+11/17/2018,Alexandre Pantoja,Yuta Sasaki,Red,Flyweight
+11/17/2018,Humberto Bandenay,Austin Arnett,Blue,Featherweight
+11/17/2018,Laureano Staropoli,Hector Aldana,Red,Welterweight
+11/17/2018,Devin Powell,Jesus Pinedo,Blue,Lightweight
+11/17/2018,Nad Narimani,Anderson Dos Santos,Red,Featherweight
+11/10/2018,Chan Sung Jung,Yair Rodriguez,Blue,Featherweight
+11/10/2018,Donald Cerrone,Mike Perry,Red,Welterweight
+11/10/2018,Raquel Pennington,Germaine de Randamie,Blue,Women's Bantamweight
+11/10/2018,Beneil Dariush,Thiago Moises,Red,Lightweight
+11/10/2018,Maycee Barber,Hannah Cifers,Red,Women's Strawweight
+11/10/2018,Michael Trizano,Luis Pena,Red,Lightweight
+11/10/2018,Ashley Yoder,Amanda Cooper,Red,Women's Strawweight
+11/10/2018,Davi Ramos,John Gunther,Red,Lightweight
+11/10/2018,Devonte Smith,Julian Erosa,Red,Lightweight
+11/10/2018,Joseph Morales,Eric Shelton,Blue,Flyweight
+11/10/2018,Mark De La Rosa,Joby Sanchez,Red,Bantamweight
+11/03/2018,Daniel Cormier,Derrick Lewis,Red,UFC Heavyweight Title
+11/03/2018,Chris Weidman,Jacare Souza,Blue,Middleweight
+11/03/2018,David Branch,Jared Cannonier,Blue,Middleweight
+11/03/2018,Karl Roberson,Jack Marshman,Red,Middleweight
+11/03/2018,Derek Brunson,Israel Adesanya,Blue,Middleweight
+11/03/2018,Jason Knight,Jordan Rinaldi,Blue,Featherweight
+11/03/2018,Sijara Eubanks,Roxanne Modafferi,Red,Women's Flyweight
+11/03/2018,Julio Arce,Sheymon Moraes,Blue,Featherweight
+11/03/2018,Lyman Good,Ben Saunders,Red,Welterweight
+11/03/2018,Shane Burgos,Kurt Holobaugh,Red,Featherweight
+11/03/2018,Adam Wieczorek,Marcos Rogerio de Lima,Blue,Heavyweight
+10/27/2018,Volkan Oezdemir,Anthony Smith,Blue,Light Heavyweight
+10/27/2018,Michael Johnson,Artem Lobov,Red,Featherweight
+10/27/2018,Misha Cirkunov,Patrick Cummins,Red,Light Heavyweight
+10/27/2018,Andre Soukhamthath,Jonathan Martinez,Red,Bantamweight
+10/27/2018,Gian Villante,Ed Herman,Red,Light Heavyweight
+10/27/2018,Alex Garcia,Court McGee,Blue,Welterweight
+10/27/2018,Nordine Taleb,Sean Strickland,Blue,Welterweight
+10/27/2018,Thibault Gouti,Nasrat Haqparast,Blue,Lightweight
+10/27/2018,Calvin Kattar,Chris Fishgold,Red,Featherweight
+10/27/2018,Sarah Moras,Talita Bernardo,Blue,Women's Bantamweight
+10/27/2018,Te Edwards,Don Madge,Blue,Lightweight
+10/27/2018,Arjan Bhullar,Marcelo Golm,Red,Heavyweight
+10/27/2018,Stevie Ray,Jessin Ayari,Red,Lightweight
+10/06/2018,Khabib Nurmagomedov,Conor McGregor,Red,UFC Lightweight Title
+10/06/2018,Tony Ferguson,Anthony Pettis,Red,Lightweight
+10/06/2018,Ovince Saint Preux,Dominick Reyes,Blue,Light Heavyweight
+10/06/2018,Derrick Lewis,Alexander Volkov,Red,Heavyweight
+10/06/2018,Michelle Waterson-Gomez,Felice Herrig,Red,Women's Strawweight
+10/06/2018,Sergio Pettis,Jussier Formiga,Blue,Flyweight
+10/06/2018,Vicente Luque,Jalin Turner,Red,Welterweight
+10/06/2018,Aspen Ladd,Tonya Evinger,Red,Women's Bantamweight
+10/06/2018,Scott Holtzman,Alan Patrick,Red,Lightweight
+10/06/2018,Lina Lansberg,Yana Santos,Blue,Women's Bantamweight
+10/06/2018,Gray Maynard,Nik Lentz,Blue,Lightweight
+10/06/2018,Ryan LaFlare,Anthony Rocco Martin,Blue,Welterweight
+09/22/2018,Thiago Santos,Eryk Anders,Red,Light Heavyweight
+09/22/2018,Alex Oliveira,Carlo Pedersoli Jr.,Red,Welterweight
+09/22/2018,Sam Alvey,Rogerio Nogueira,Blue,Light Heavyweight
+09/22/2018,Renan Barao,Andre Ewell,Blue,Bantamweight
+09/22/2018,Charles Oliveira,Christos Giagos,Red,Lightweight
+09/22/2018,Francisco Trinaldo,Evan Dunham,Red,Lightweight
+09/22/2018,Luis Henrique,Ryan Spann,Blue,Light Heavyweight
+09/22/2018,Augusto Sakai,Chase Sherman,Red,Heavyweight
+09/22/2018,Sergio Moraes,Ben Saunders,Red,Welterweight
+09/22/2018,Mayra Bueno Silva,Gillian Robertson,Red,Women's Flyweight
+09/22/2018,Thales Leites,Hector Lombard,Red,Middleweight
+09/22/2018,Elizeu Zaleski dos Santos,Luigi Vendramini,Red,Welterweight
+09/22/2018,Livinha Souza,Alex Chambers,Red,Women's Strawweight
+09/15/2018,Mark Hunt,Aleksei Oleinik,Blue,Heavyweight
+09/15/2018,Jan Blachowicz,Nikita Krylov,Red,Light Heavyweight
+09/15/2018,Andrei Arlovski,Shamil Abdurakhimov,Blue,Heavyweight
+09/15/2018,Aleksei Kunchenko,Thiago Alves,Red,Welterweight
+09/15/2018,Khalid Murtazaliev,CB Dollaway,Red,Middleweight
+09/15/2018,Petr Yan,Jin Soo Son,Red,Bantamweight
+09/15/2018,Rustam Khabilov,Kajan Johnson,Red,Lightweight
+09/15/2018,Mairbek Taisumov,Desmond Green,Red,Lightweight
+09/15/2018,Magomed Ankalaev,Marcin Prachnio,Red,Light Heavyweight
+09/15/2018,Adam Yandiev,Jordan Johnson,Blue,Middleweight
+09/15/2018,Ramazan Emeev,Stefan Sekulic,Red,Welterweight
+09/15/2018,Merab Dvalishvili,Terrion Ware,Red,Bantamweight
+09/08/2018,Tyron Woodley,Darren Till,Red,UFC Welterweight Title
+09/08/2018,Jessica Andrade,Karolina Kowalkiewicz,Red,Women's Strawweight
+09/08/2018,Zabit Magomedsharipov,Brandon Davis,Red,Featherweight
+09/08/2018,Jimmie Rivera,John Dodson,Red,Bantamweight
+09/08/2018,Abdul Razak Alhassan,Niko Price,Red,Welterweight
+09/08/2018,Carla Esparza,Tatiana Suarez,Blue,Women's Strawweight
+09/08/2018,Aljamain Sterling,Cody Stamann,Red,Bantamweight
+09/08/2018,Geoff Neal,Frank Camacho,Red,Welterweight
+09/08/2018,Charles Byrd,Darren Stewart,Blue,Middleweight
+09/08/2018,Diego Sanchez,Craig White,Red,Welterweight
+09/08/2018,Jim Miller,Alex White,Red,Lightweight
+09/08/2018,Irene Aldana,Lucie Pudilova,Red,Women's Bantamweight
+09/08/2018,Robert Sanchez,Jarred Brooks,Blue,Flyweight
+08/25/2018,Justin Gaethje,James Vick,Red,Lightweight
+08/25/2018,Michael Johnson,Andre Fili,Red,Featherweight
+08/25/2018,Cortney Casey,Angela Hill,Red,Women's Strawweight
+08/25/2018,Jake Ellenberger,Bryan Barberena,Blue,Welterweight
+08/25/2018,John Moraga,Deiveson Figueiredo,Blue,Flyweight
+08/25/2018,Eryk Anders,Tim Williams,Red,Middleweight
+08/25/2018,James Krause,Warlley Alves,Red,Welterweight
+08/25/2018,Cory Sandhagen,Iuri Alcantara,Red,Bantamweight
+08/25/2018,Andrew Sanchez,Markus Perez,Red,Middleweight
+08/25/2018,Mickey Gall,George Sullivan,Red,Welterweight
+08/25/2018,Joanne Wood,Kalindra Faria,Red,Women's Flyweight
+08/25/2018,Drew Dober,Jon Tuck,Red,Lightweight
+08/25/2018,Rani Yahya,Luke Sanders,Red,Bantamweight
+08/04/2018,TJ Dillashaw,Cody Garbrandt,Red,UFC Bantamweight Title
+08/04/2018,Demetrious Johnson,Henry Cejudo,Blue,UFC Flyweight Title
+08/04/2018,Cub Swanson,Renato Moicano,Blue,Featherweight
+08/04/2018,Polyana Viana,JJ Aldrich,Blue,Women's Strawweight
+08/04/2018,Thiago Santos,Kevin Holland,Red,Middleweight
+08/04/2018,Pedro Munhoz,Brett Johns,Red,Bantamweight
+08/04/2018,Ricky Simon,Montel Jackson,Red,Bantamweight
+08/04/2018,Ricardo Ramos,Kyung Ho Kang,Red,Bantamweight
+08/04/2018,Matt Sayles,Sheymon Moraes,Blue,Featherweight
+08/04/2018,Alex Perez,Jose Torres,Red,Flyweight
+08/04/2018,Danielle Taylor,Zhang Weili,Blue,Women's Strawweight
+08/04/2018,Marlon Vera,Wulijiburen,Red,Bantamweight
+07/28/2018,Eddie Alvarez,Dustin Poirier,Blue,Lightweight
+07/28/2018,Jose Aldo,Jeremy Stephens,Red,Featherweight
+07/28/2018,Joanna Jedrzejczyk,Tecia Torres,Red,Women's Strawweight
+07/28/2018,Alexander Hernandez,Olivier Aubin-Mercier,Red,Lightweight
+07/28/2018,Jordan Mein,Alex Morono,Red,Welterweight
+07/28/2018,Hakeem Dawodu,Austin Arnett,Red,Featherweight
+07/28/2018,Kajan Johnson,Islam Makhachev,Blue,Lightweight
+07/28/2018,Gadzhimurad Antigulov,Ion Cutelaba,Blue,Light Heavyweight
+07/28/2018,John Makdessi,Ross Pearson,Red,Lightweight
+07/28/2018,Alexis Davis,Katlyn Cerminara,Blue,Women's Flyweight
+07/28/2018,Dustin Ortiz,Matheus Nicolau,Red,Flyweight
+07/28/2018,Randa Markos,Nina Nunes,Blue,Women's Strawweight
+07/28/2018,Devin Powell,Alvaro Herrera Mendoza,Red,Lightweight
+07/22/2018,Mauricio Rua,Anthony Smith,Blue,Light Heavyweight
+07/22/2018,Glover Teixeira,Corey Anderson,Blue,Light Heavyweight
+07/22/2018,Vitor Miranda,Abu Azaitar,Blue,Middleweight
+07/22/2018,Marcin Tybura,Stefan Struve,Red,Heavyweight
+07/22/2018,Danny Roberts,David Zawada,Red,Welterweight
+07/22/2018,Nasrat Haqparast,Marc Diakiese,Red,Lightweight
+07/22/2018,Nick Hein,Damir Hadzovic,Blue,Lightweight
+07/22/2018,Emil Meek,Bartosz Fabinski,Blue,Welterweight
+07/22/2018,Khalid Taha,Nad Narimani,Blue,Featherweight
+07/22/2018,Justin Ledet,Aleksandar Rakic,Blue,Light Heavyweight
+07/22/2018,Davey Grant,Manny Bermudez,Blue,Bantamweight
+07/22/2018,Jeremy Kimball,Darko Stosic,Blue,Light Heavyweight
+07/22/2018,Damian Stasiak,Pingyuan Liu,Blue,Bantamweight
+07/14/2018,Junior Dos Santos,Blagoy Ivanov,Red,Heavyweight
+07/14/2018,Sage Northcutt,Zak Ottow,Red,Welterweight
+07/14/2018,Dennis Bermudez,Ricky Glenn,Blue,Featherweight
+07/14/2018,Randy Brown,Niko Price,Blue,Welterweight
+07/14/2018,Myles Jury,Chad Mendes,Blue,Featherweight
+07/14/2018,Cat Zingano,Marion Reneau,Red,Women's Bantamweight
+07/14/2018,Eddie Wineland,Alejandro Perez,Blue,Bantamweight
+07/14/2018,Darren Elkins,Alexander Volkanovski,Blue,Featherweight
+07/14/2018,Justin Scoggins,Said Nurmagomedov,Blue,Flyweight
+07/14/2018,Kurt Holobaugh,Raoni Barcelos,Blue,Featherweight
+07/14/2018,Liz Carmouche,Jennifer Maia,Red,Women's Flyweight
+07/14/2018,Mark De La Rosa,Elias Garcia,Red,Flyweight
+07/14/2018,Jessica Aguilar,Jodie Esquibel,Red,Women's Strawweight
+07/07/2018,Stipe Miocic,Daniel Cormier,Blue,UFC Heavyweight Title
+07/07/2018,Francis Ngannou,Derrick Lewis,Blue,Heavyweight
+07/07/2018,Paul Felder,Mike Perry,Blue,Welterweight
+07/07/2018,Michael Chiesa,Anthony Pettis,Blue,Lightweight
+07/07/2018,Gokhan Saki,Khalil Rountree Jr.,Blue,Light Heavyweight
+07/07/2018,Uriah Hall,Paulo Costa,Blue,Middleweight
+07/07/2018,Raphael Assuncao,Rob Font,Red,Bantamweight
+07/07/2018,Lando Vannata,Drakkar Klose,Blue,Lightweight
+07/07/2018,Curtis Millender,Max Griffin,Red,Welterweight
+07/07/2018,Dan Hooker,Gilbert Burns,Red,Lightweight
+07/07/2018,Jamie Moyle,Emily Whitmire,Blue,Women's Strawweight
+07/06/2018,Brad Tavares,Israel Adesanya,Blue,Middleweight
+07/06/2018,Michael Trizano,Joe Giannetti,Red,Ultimate Fighter 27 Lightweight Tournament Title
+07/06/2018,Jay Cucciniello,Brad Katona,Blue,Ultimate Fighter 27 Featherweight Tournament Title
+07/06/2018,Alex Caceres,Martin Bravo,Red,Featherweight
+07/06/2018,Roxanne Modafferi,Barb Honchak,Red,Women's Flyweight
+07/06/2018,Alessio Di Chirico,Julian Marquez,Red,Middleweight
+07/06/2018,Montana De La Rosa,Rachael Ostovich,Red,Women's Flyweight
+07/06/2018,Luis Pena,Richie Smullen,Red,Lightweight
+07/06/2018,John Gunther,Allan Zuniga,Red,Lightweight
+07/06/2018,Tyler Diamond,Bryce Mitchell,Blue,Featherweight
+07/06/2018,Matt Bessette,Steven Peterson,Blue,Featherweight
+07/06/2018,Gerald Meerschaert,Oskar Piechota,Red,Middleweight
+06/23/2018,Donald Cerrone,Leon Edwards,Blue,Welterweight
+06/23/2018,Ovince Saint Preux,Tyson Pedro,Red,Light Heavyweight
+06/23/2018,Jessica-Rose Clark,Jessica Eye,Blue,Women's Flyweight
+06/23/2018,Li Jingliang,Daichi Abe,Red,Welterweight
+06/23/2018,Teruto Ishihara,Petr Yan,Blue,Bantamweight
+06/23/2018,Felipe Arantes,Song Yadong,Blue,Bantamweight
+06/23/2018,Rolando Dy,Shane Young,Blue,Featherweight
+06/23/2018,Song Kenan,Hector Aldana,Red,Welterweight
+06/23/2018,Shinsho Anzai,Jake Matthews,Blue,Welterweight
+06/23/2018,Viviane Pereira,Yan Xiaonan,Blue,Women's Strawweight
+06/23/2018,Matt Schnell,Naoki Inoue,Red,Flyweight
+06/23/2018,Jenel Lausa,Yuta Sasaki,Blue,Flyweight
+06/23/2018,Ji Yeon Kim,Melinda Fabian,Red,Women's Flyweight
+06/09/2018,Robert Whittaker,Yoel Romero,Red,Middleweight
+06/09/2018,Rafael Dos Anjos,Colby Covington,Blue,UFC Interim Welterweight Title
+06/09/2018,Holly Holm,Megan Anderson,Red,Women's Featherweight
+06/09/2018,Andrei Arlovski,Tai Tuivasa,Blue,Heavyweight
+06/09/2018,Alistair Overeem,Curtis Blaydes,Blue,Heavyweight
+06/09/2018,Claudia Gadelha,Carla Esparza,Red,Women's Strawweight
+06/09/2018,Ricardo Lamas,Mirsad Bektic,Blue,Featherweight
+06/09/2018,Rashad Coulter,Chris de la Rocha,Blue,Heavyweight
+06/09/2018,Rashad Evans,Anthony Smith,Blue,Light Heavyweight
+06/09/2018,Joseph Benavidez,Sergio Pettis,Blue,Flyweight
+06/09/2018,Clay Guida,Charles Oliveira,Blue,Lightweight
+06/09/2018,Mike Santiago,Dan Ige,Blue,Featherweight
+06/01/2018,Jimmie Rivera,Marlon Moraes,Blue,Bantamweight
+06/01/2018,Gregor Gillespie,Vinc Pichel,Red,Lightweight
+06/01/2018,Walt Harris,Daniel Spitz,Red,Heavyweight
+06/01/2018,Jake Ellenberger,Ben Saunders,Blue,Welterweight
+06/01/2018,Julio Arce,Daniel Teymur,Red,Featherweight
+06/01/2018,Gian Villante,Sam Alvey,Blue,Light Heavyweight
+06/01/2018,Sijara Eubanks,Lauren Murphy,Red,Women's Flyweight
+06/01/2018,Nik Lentz,David Teymur,Blue,Lightweight
+06/01/2018,Belal Muhammad,Chance Rencountre,Red,Welterweight
+06/01/2018,Desmond Green,Gleison Tibau,Red,Lightweight
+06/01/2018,Johnny Eduardo,Nathaniel Wood,Blue,Bantamweight
+06/01/2018,Jarred Brooks,Jose Torres,Blue,Flyweight
+05/27/2018,Stephen Thompson,Darren Till,Blue,Welterweight
+05/27/2018,Neil Magny,Craig White,Red,Welterweight
+05/27/2018,Arnold Allen,Mads Burnell,Red,Featherweight
+05/27/2018,Jason Knight,Makwan Amirkhani,Blue,Featherweight
+05/27/2018,Claudio Silva,Nordine Taleb,Red,Welterweight
+05/27/2018,Eric Spicely,Darren Stewart,Blue,Middleweight
+05/27/2018,Daniel Kelly,Tom Breese,Blue,Middleweight
+05/27/2018,Lina Lansberg,Gina Mazany,Red,Women's Bantamweight
+05/27/2018,Brad Scott,Carlo Pedersoli Jr.,Blue,Welterweight
+05/27/2018,Gillian Robertson,Molly McCann,Red,Women's Flyweight
+05/27/2018,Elias Theodorou,Trevor Smith,Red,Middleweight
+05/19/2018,Demian Maia,Kamaru Usman,Blue,Welterweight
+05/19/2018,Alexa Grasso,Tatiana Suarez,Blue,Women's Strawweight
+05/19/2018,Jared Cannonier,Dominick Reyes,Blue,Light Heavyweight
+05/19/2018,Diego Rivas,Guido Cannetti,Blue,Bantamweight
+05/19/2018,Veronica Hardy,Andrea Lee,Blue,Women's Flyweight
+05/19/2018,Vicente Luque,Chad Laprise,Red,Welterweight
+05/19/2018,Zak Cummings,Michel Prazeres,Blue,Welterweight
+05/19/2018,Brandon Moreno,Alexandre Pantoja,Blue,Flyweight
+05/19/2018,Poliana Botelho,Syuri Kondo,Red,Women's Strawweight
+05/19/2018,Gabriel Benitez,Humberto Bandenay,Red,Featherweight
+05/19/2018,Enrique Barzola,Brandon Davis,Red,Featherweight
+05/19/2018,Henry Briones,Frankie Saenz,Blue,Bantamweight
+05/19/2018,Claudio Puelles,Felipe Silva,Red,Lightweight
+05/12/2018,Amanda Nunes,Raquel Pennington,Red,UFC Women's Bantamweight Title
+05/12/2018,Jacare Souza,Kelvin Gastelum,Blue,Middleweight
+05/12/2018,Mackenzie Dern,Amanda Cooper,Red,Women's Strawweight
+05/12/2018,John Lineker,Brian Kelleher,Red,Bantamweight
+05/12/2018,Vitor Belfort,Lyoto Machida,Blue,Middleweight
+05/12/2018,Cezar Ferreira,Karl Roberson,Red,Middleweight
+05/12/2018,Aleksei Oleinik,Junior Albini,Red,Heavyweight
+05/12/2018,Davi Ramos,Nick Hein,Red,Lightweight
+05/12/2018,Elizeu Zaleski dos Santos,Sean Strickland,Red,Welterweight
+05/12/2018,Warlley Alves,Sultan Aliev,Red,Welterweight
+05/12/2018,Thales Leites,Jack Hermansson,Blue,Middleweight
+05/12/2018,Alberto Mina,Ramazan Emeev,Blue,Welterweight
+05/12/2018,Markus Perez,James Bochnovic,Red,Middleweight
+04/21/2018,Edson Barboza,Kevin Lee,Blue,Lightweight
+04/21/2018,Frankie Edgar,Cub Swanson,Red,Featherweight
+04/21/2018,Justin Willis,Chase Sherman,Red,Heavyweight
+04/21/2018,David Branch,Thiago Santos,Red,Middleweight
+04/21/2018,Aljamain Sterling,Brett Johns,Red,Bantamweight
+04/21/2018,Jim Miller,Dan Hooker,Blue,Lightweight
+04/21/2018,Ryan LaFlare,Alex Garcia,Red,Welterweight
+04/21/2018,Merab Dvalishvili,Ricky Simon,Blue,Bantamweight
+04/21/2018,Siyar Bahadurzada,Luan Chagas,Red,Welterweight
+04/21/2018,Corey Anderson,Patrick Cummins,Red,Light Heavyweight
+04/21/2018,Anthony Rocco Martin,Keita Nakamura,Red,Welterweight
+04/14/2018,Dustin Poirier,Justin Gaethje,Red,Lightweight
+04/14/2018,Carlos Condit,Alex Oliveira,Blue,Welterweight
+04/14/2018,Israel Adesanya,Marvin Vettori,Red,Middleweight
+04/14/2018,Michelle Waterson-Gomez,Cortney Casey,Red,Women's Strawweight
+04/14/2018,Tim Boetsch,Antonio Carlos Junior,Blue,Middleweight
+04/14/2018,Muslim Salikhov,Ricky Rainey,Red,Welterweight
+04/14/2018,Wilson Reis,John Moraga,Blue,Flyweight
+04/14/2018,Krzysztof Jotko,Brad Tavares,Blue,Middleweight
+04/14/2018,Gilbert Burns,Dan Moret,Red,Lightweight
+04/14/2018,Shana Dobson,Lauren Mueller,Blue,Women's Flyweight
+04/14/2018,Dhiego Lima,Yushin Okami,Blue,Welterweight
+04/14/2018,Arjan Bhullar,Adam Wieczorek,Blue,Heavyweight
+04/14/2018,Matthew Lopez,Alejandro Perez,Blue,Bantamweight
+04/14/2018,Luke Sanders,Patrick Williams,Red,Bantamweight
+04/07/2018,Khabib Nurmagomedov,Al Iaquinta,Red,UFC Lightweight Title
+04/07/2018,Rose Namajunas,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+04/07/2018,Renato Moicano,Calvin Kattar,Red,Featherweight
+04/07/2018,Zabit Magomedsharipov,Kyle Bochniak,Red,Featherweight
+04/07/2018,Joe Lauzon,Chris Gruetzemacher,Blue,Lightweight
+04/07/2018,Karolina Kowalkiewicz,Felice Herrig,Red,Women's Strawweight
+04/07/2018,Evan Dunham,Olivier Aubin-Mercier,Blue,Lightweight
+04/07/2018,Bec Rawlings,Ashlee Evans-Smith,Blue,Women's Flyweight
+04/07/2018,Devin Clark,Mike Rodriguez,Red,Light Heavyweight
+03/17/2018,Fabricio Werdum,Alexander Volkov,Blue,Heavyweight
+03/17/2018,Jimi Manuwa,Jan Blachowicz,Blue,Light Heavyweight
+03/17/2018,Tom Duquesnoy,Terrion Ware,Red,Bantamweight
+03/17/2018,Leon Edwards,Peter Sobotta,Red,Welterweight
+03/17/2018,John Phillips,Charles Byrd,Blue,Middleweight
+03/17/2018,Danny Roberts,Oliver Enkamp,Red,Welterweight
+03/17/2018,Danny Henry,Hakeem Dawodu,Red,Featherweight
+03/17/2018,Paul Craig,Magomed Ankalaev,Red,Light Heavyweight
+03/17/2018,Stevie Ray,Kajan Johnson,Blue,Lightweight
+03/17/2018,Mark Godbeer,Dmitry Sosnovskiy,Blue,Heavyweight
+03/03/2018,Cristiane Justino,Yana Santos,Red,UFC Women's Featherweight Title
+03/03/2018,Frankie Edgar,Brian Ortega,Blue,Featherweight
+03/03/2018,Sean O'Malley,Andre Soukhamthath,Red,Bantamweight
+03/03/2018,Stefan Struve,Andrei Arlovski,Blue,Heavyweight
+03/03/2018,Cat Zingano,Ketlen Vieira,Blue,Women's Bantamweight
+03/03/2018,Ashley Yoder,Mackenzie Dern,Blue,Women's Strawweight
+03/03/2018,Beneil Dariush,Alexander Hernandez,Blue,Lightweight
+03/03/2018,John Dodson,Pedro Munhoz,Red,Bantamweight
+03/03/2018,CB Dollaway,Hector Lombard,Red,Middleweight
+03/03/2018,Mike Pyle,Zak Ottow,Blue,Welterweight
+03/03/2018,Bryan Caraway,Cody Stamann,Blue,Bantamweight
+03/03/2018,Jordan Johnson,Adam Milstead,Red,Light Heavyweight
+02/24/2018,Josh Emmett,Jeremy Stephens,Blue,Featherweight
+02/24/2018,Jessica Andrade,Tecia Torres,Red,Women's Strawweight
+02/24/2018,Ovince Saint Preux,Ilir Latifi,Blue,Light Heavyweight
+02/24/2018,Mike Perry,Max Griffin,Blue,Welterweight
+02/24/2018,Renan Barao,Brian Kelleher,Blue,Bantamweight
+02/24/2018,Sara McMann,Marion Reneau,Blue,Women's Bantamweight
+02/24/2018,Maryna Moroz,Angela Hill,Blue,Women's Strawweight
+02/24/2018,Ben Saunders,Alan Jouban,Blue,Welterweight
+02/24/2018,Sam Alvey,Marcin Prachnio,Red,Light Heavyweight
+02/24/2018,Rani Yahya,Russell Doane,Red,Bantamweight
+02/24/2018,Eric Shelton,Alex Perez,Blue,Flyweight
+02/24/2018,Albert Morales,Manny Bermudez,Blue,Bantamweight
+02/18/2018,Donald Cerrone,Yancy Medeiros,Red,Welterweight
+02/18/2018,Derrick Lewis,Marcin Tybura,Red,Heavyweight
+02/18/2018,James Vick,Francisco Trinaldo,Red,Lightweight
+02/18/2018,Thiago Alves,Curtis Millender,Blue,Welterweight
+02/18/2018,Steven Peterson,Brandon Davis,Blue,Featherweight
+02/18/2018,Sage Northcutt,Thibault Gouti,Red,Lightweight
+02/18/2018,Jared Gordon,Diego Ferreira,Blue,Lightweight
+02/18/2018,Geoff Neal,Brian Camozzi,Red,Welterweight
+02/18/2018,Robert Sanchez,Joby Sanchez,Red,Flyweight
+02/18/2018,Sarah Moras,Lucie Pudilova,Blue,Women's Bantamweight
+02/18/2018,Joshua Burkman,Alex Morono,Blue,Welterweight
+02/18/2018,Oskar Piechota,Tim Williams,Red,Middleweight
+02/10/2018,Yoel Romero,Luke Rockhold,Red,Middleweight
+02/10/2018,Mark Hunt,Curtis Blaydes,Blue,Heavyweight
+02/10/2018,Tai Tuivasa,Cyril Asker,Red,Heavyweight
+02/10/2018,Jake Matthews,Li Jingliang,Red,Welterweight
+02/10/2018,Tyson Pedro,Saparbeg Safarov,Red,Light Heavyweight
+02/10/2018,Damien Brown,Dong Hyun Ma,Blue,Lightweight
+02/10/2018,Rob Wilkinson,Israel Adesanya,Blue,Middleweight
+02/10/2018,Alexander Volkanovski,Jeremy Kennedy,Red,Featherweight
+02/10/2018,Jussier Formiga,Ben Nguyen,Red,Flyweight
+02/10/2018,Ross Pearson,Mizuto Hirota,Red,Lightweight
+02/10/2018,Teruto Ishihara,Jose Quinonez,Blue,Bantamweight
+02/10/2018,Luke Jumeau,Daichi Abe,Red,Welterweight
+02/03/2018,Lyoto Machida,Eryk Anders,Red,Middleweight
+02/03/2018,Valentina Shevchenko,Priscila Cachoeira,Red,Women's Flyweight
+02/03/2018,Michel Prazeres,Desmond Green,Red,Lightweight
+02/03/2018,Timothy Johnson,Marcelo Golm,Red,Heavyweight
+02/03/2018,Douglas Silva de Andrade,Marlon Vera,Red,Bantamweight
+02/03/2018,Thiago Santos,Anthony Smith,Red,Middleweight
+02/03/2018,Sergio Moraes,Tim Means,Red,Welterweight
+02/03/2018,Alan Patrick,Damir Hadzovic,Red,Lightweight
+02/03/2018,Maia Stevenson,Polyana Viana,Blue,Women's Strawweight
+02/03/2018,Iuri Alcantara,Joe Soto,Red,Bantamweight
+02/03/2018,Deiveson Figueiredo,Joseph Morales,Red,Flyweight
+01/27/2018,Jacare Souza,Derek Brunson,Red,Middleweight
+01/27/2018,Dennis Bermudez,Andre Fili,Blue,Featherweight
+01/27/2018,Jordan Rinaldi,Gregor Gillespie,Blue,Lightweight
+01/27/2018,Drew Dober,Frank Camacho,Red,Welterweight
+01/27/2018,Erik Koch,Bobby Green,Blue,Lightweight
+01/27/2018,Mirsad Bektic,Godofredo Pepey,Red,Featherweight
+01/27/2018,Katlyn Cerminara,Mara Romero Borella,Red,Women's Flyweight
+01/27/2018,Randa Markos,Juliana Lima,Red,Women's Strawweight
+01/27/2018,Justine Kish,Ji Yeon Kim,Blue,Women's Flyweight
+01/27/2018,Vinc Pichel,Joaquim Silva,Red,Lightweight
+01/27/2018,Niko Price,George Sullivan,Red,Welterweight
+01/27/2018,Austin Arnett,Cory Sandhagen,Blue,Featherweight
+01/20/2018,Stipe Miocic,Francis Ngannou,Red,UFC Heavyweight Title
+01/20/2018,Daniel Cormier,Volkan Oezdemir,Red,UFC Light Heavyweight Title
+01/20/2018,Calvin Kattar,Shane Burgos,Red,Featherweight
+01/20/2018,Gian Villante,Francimar Barroso,Red,Light Heavyweight
+01/20/2018,Thomas Almeida,Rob Font,Blue,Bantamweight
+01/20/2018,Kyle Bochniak,Brandon Davis,Red,Featherweight
+01/20/2018,Sabah Homasi,Abdul Razak Alhassan,Blue,Welterweight
+01/20/2018,Dustin Ortiz,Alexandre Pantoja,Red,Flyweight
+01/20/2018,Dan Ige,Julio Arce,Blue,Featherweight
+01/20/2018,Matt Bessette,Enrique Barzola,Blue,Featherweight
+01/20/2018,Islam Makhachev,Gleison Tibau,Red,Lightweight
+01/14/2018,Jeremy Stephens,Dooho Choi,Red,Featherweight
+01/14/2018,Paige VanZant,Jessica-Rose Clark,Blue,Women's Flyweight
+01/14/2018,Kamaru Usman,Emil Meek,Red,Welterweight
+01/14/2018,Darren Elkins,Michael Johnson,Red,Featherweight
+01/14/2018,James Krause,Alex White,Red,Lightweight
+01/14/2018,Matt Frevola,Marco Polo Reyes,Blue,Lightweight
+01/14/2018,Talita Bernardo,Irene Aldana,Blue,Women's Bantamweight
+01/14/2018,Kyung Ho Kang,Guido Cannetti,Red,Bantamweight
+01/14/2018,Kalindra Faria,Jessica Eye,Blue,Women's Flyweight
+01/14/2018,Danielle Taylor,JJ Aldrich,Blue,Women's Strawweight
+01/14/2018,Mads Burnell,Mike Santiago,Red,Featherweight
+12/30/2017,Cristiane Justino,Holly Holm,Red,UFC Women's Featherweight Title
+12/30/2017,Khabib Nurmagomedov,Edson Barboza,Red,Lightweight
+12/30/2017,Dan Hooker,Marc Diakiese,Red,Lightweight
+12/30/2017,Cynthia Calvillo,Carla Esparza,Blue,Women's Strawweight
+12/30/2017,Carlos Condit,Neil Magny,Blue,Welterweight
+12/30/2017,Myles Jury,Ricky Glenn,Red,Featherweight
+12/30/2017,Louis Smolka,Matheus Nicolau,Blue,Flyweight
+12/30/2017,Tim Elliott,Mark De La Rosa,Red,Bantamweight
+12/16/2017,Robbie Lawler,Rafael Dos Anjos,Blue,Welterweight
+12/16/2017,Ricardo Lamas,Josh Emmett,Blue,Featherweight
+12/16/2017,Santiago Ponzinibbio,Mike Perry,Red,Welterweight
+12/16/2017,Glover Teixeira,Misha Cirkunov,Red,Light Heavyweight
+12/16/2017,Jared Cannonier,Jan Blachowicz,Blue,Light Heavyweight
+12/16/2017,Julian Marquez,Darren Stewart,Red,Middleweight
+12/16/2017,Chad Laprise,Galore Bofando,Red,Welterweight
+12/16/2017,Nordine Taleb,Danny Roberts,Red,Welterweight
+12/16/2017,John Makdessi,Abel Trujillo,Red,Lightweight
+12/16/2017,Alessio Di Chirico,Oluwale Bamgbose,Red,Middleweight
+12/16/2017,Jordan Mein,Erick Silva,Red,Welterweight
+12/09/2017,Cub Swanson,Brian Ortega,Blue,Featherweight
+12/09/2017,Jason Knight,Gabriel Benitez,Blue,Featherweight
+12/09/2017,Marlon Moraes,Aljamain Sterling,Red,Bantamweight
+12/09/2017,Scott Holtzman,Darrell Horcher,Red,Lightweight
+12/09/2017,Eryk Anders,Markus Perez,Red,Middleweight
+12/09/2017,Albert Morales,Benito Lopez,Blue,Bantamweight
+12/09/2017,Alexis Davis,Liz Carmouche,Red,Women's Flyweight
+12/09/2017,Luke Sanders,Andre Soukhamthath,Blue,Bantamweight
+12/09/2017,Carls John De Tomas,Alex Perez,Blue,Bantamweight
+12/09/2017,Frankie Saenz,Merab Dvalishvili,Red,Bantamweight
+12/09/2017,Alejandro Perez,Iuri Alcantara,Red,Bantamweight
+12/09/2017,Chris Gruetzemacher,Davi Ramos,Blue,Lightweight
+12/09/2017,Antonio Braga Neto,Trevin Giles,Blue,Middleweight
+12/02/2017,Max Holloway,Jose Aldo,Red,UFC Featherweight Title
+12/02/2017,Alistair Overeem,Francis Ngannou,Blue,Heavyweight
+12/02/2017,Henry Cejudo,Sergio Pettis,Red,Flyweight
+12/02/2017,Eddie Alvarez,Justin Gaethje,Red,Lightweight
+12/02/2017,Tecia Torres,Michelle Waterson-Gomez,Red,Women's Strawweight
+12/02/2017,Charles Oliveira,Paul Felder,Blue,Lightweight
+12/02/2017,Alex Oliveira,Yancy Medeiros,Blue,Welterweight
+12/02/2017,David Teymur,Drakkar Klose,Red,Lightweight
+12/02/2017,Felice Herrig,Cortney Casey,Red,Women's Strawweight
+12/02/2017,Amanda Cooper,Angela Magana,Red,Women's Strawweight
+12/02/2017,Sabah Homasi,Abdul Razak Alhassan,Blue,Welterweight
+12/02/2017,Jeremy Kimball,Dominick Reyes,Blue,Light Heavyweight
+12/02/2017,Justin Willis,Allen Crowder,Red,Heavyweight
+12/01/2017,Nicco Montano,Roxanne Modafferi,Red,UFC Women's Flyweight Title
+12/01/2017,Sean O'Malley,Terrion Ware,Red,Bantamweight
+12/01/2017,Barb Honchak,Lauren Murphy,Blue,Women's Flyweight
+12/01/2017,Eric Spicely,Gerald Meerschaert,Blue,Middleweight
+12/01/2017,Joe Soto,Brett Johns,Blue,Bantamweight
+12/01/2017,Christina Marks,Montana De La Rosa,Blue,Women's Flyweight
+12/01/2017,Andrew Sanchez,Ryan Janes,Blue,Middleweight
+12/01/2017,Karine Gevorgyan,Rachael Ostovich,Blue,Women's Flyweight
+12/01/2017,Ariel Beck,Shana Dobson,Blue,Women's Flyweight
+12/01/2017,Gillian Robertson,Emily Whitmire,Red,Women's Flyweight
+11/25/2017,Michael Bisping,Kelvin Gastelum,Blue,Middleweight
+11/25/2017,Li Jingliang,Zak Ottow,Red,Welterweight
+11/25/2017,Wang Guan,Alex Caceres,Red,Featherweight
+11/25/2017,Muslim Salikhov,Alex Garcia,Blue,Welterweight
+11/25/2017,Zabit Magomedsharipov,Sheymon Moraes,Red,Featherweight
+11/25/2017,Song Kenan,Bobby Nash,Red,Welterweight
+11/25/2017,Kailin Curran,Yan Xiaonan,Blue,Women's Strawweight
+11/25/2017,Song Yadong,Bharat Kandare,Red,Featherweight
+11/25/2017,Chase Sherman,Shamil Abdurakhimov,Blue,Heavyweight
+11/25/2017,Wu Yanan,Gina Mazany,Blue,Women's Bantamweight
+11/25/2017,Wulijiburen,Rolando Dy,Blue,Featherweight
+11/25/2017,Cyril Asker,Hu Yaozong,Red,Heavyweight
+11/18/2017,Fabricio Werdum,Marcin Tybura,Red,Heavyweight
+11/18/2017,Bec Rawlings,Jessica-Rose Clark,Blue,Women's Flyweight
+11/18/2017,Tim Means,Belal Muhammad,Blue,Welterweight
+11/18/2017,Jake Matthews,Bojan Velickovic,Red,Welterweight
+11/18/2017,Elias Theodorou,Daniel Kelly,Red,Middleweight
+11/18/2017,Alexander Volkanovski,Shane Young,Red,Catch Weight
+11/18/2017,Ryan Benoit,Ashkan Mokhtarian,Red,Flyweight
+11/18/2017,Nik Lentz,Will Brooks,Red,Lightweight
+11/18/2017,Rashad Coulter,Tai Tuivasa,Blue,Heavyweight
+11/18/2017,Damien Brown,Frank Camacho,Blue,Lightweight
+11/18/2017,Alex Chambers,Nadia Kassem,Blue,Women's Strawweight
+11/18/2017,Jenel Lausa,Eric Shelton,Blue,Flyweight
+11/18/2017,Anthony Hamilton,Adam Wieczorek,Blue,Heavyweight
+11/11/2017,Dustin Poirier,Anthony Pettis,Red,Lightweight
+11/11/2017,Matt Brown,Diego Sanchez,Red,Welterweight
+11/11/2017,Junior Albini,Andrei Arlovski,Blue,Heavyweight
+11/11/2017,Nate Marquardt,Cezar Ferreira,Blue,Middleweight
+11/11/2017,Raphael Assuncao,Matthew Lopez,Red,Bantamweight
+11/11/2017,Joe Lauzon,Clay Guida,Blue,Lightweight
+11/11/2017,John Dodson,Marlon Moraes,Blue,Bantamweight
+11/11/2017,Tatiana Suarez,Viviane Pereira,Red,Women's Strawweight
+11/11/2017,Sage Northcutt,Michel Quinones,Red,Lightweight
+11/11/2017,Angela Hill,Nina Nunes,Blue,Women's Strawweight
+11/11/2017,Court McGee,Sean Strickland,Blue,Welterweight
+11/11/2017,Jake Collier,Marcel Fortuna,Red,Light Heavyweight
+11/11/2017,Darren Stewart,Karl Roberson,Blue,Middleweight
+11/04/2017,Michael Bisping,Georges St-Pierre,Blue,UFC Middleweight Title
+11/04/2017,Cody Garbrandt,TJ Dillashaw,Blue,UFC Bantamweight Title
+11/04/2017,Joanna Jedrzejczyk,Rose Namajunas,Blue,UFC Women's Strawweight Title
+11/04/2017,Stephen Thompson,Jorge Masvidal,Red,Welterweight
+11/04/2017,Johny Hendricks,Paulo Costa,Blue,Middleweight
+11/04/2017,James Vick,Joe Duffy,Red,Lightweight
+11/04/2017,Walt Harris,Mark Godbeer,Blue,Heavyweight
+11/04/2017,Ovince Saint Preux,Corey Anderson,Red,Light Heavyweight
+11/04/2017,Randy Brown,Mickey Gall,Red,Welterweight
+11/04/2017,Aleksei Oleinik,Curtis Blaydes,Blue,Heavyweight
+11/04/2017,Aiemann Zahabi,Ricardo Ramos,Blue,Bantamweight
+10/28/2017,Derek Brunson,Lyoto Machida,Red,Middleweight
+10/28/2017,Demian Maia,Colby Covington,Blue,Welterweight
+10/28/2017,Pedro Munhoz,Rob Font,Red,Bantamweight
+10/28/2017,Francisco Trinaldo,Jim Miller,Red,Lightweight
+10/28/2017,Thiago Santos,Jack Hermansson,Red,Middleweight
+10/28/2017,John Lineker,Marlon Vera,Red,Bantamweight
+10/28/2017,Vicente Luque,Niko Price,Red,Welterweight
+10/28/2017,Antonio Carlos Junior,Jack Marshman,Red,Middleweight
+10/28/2017,Hacran Dias,Jared Gordon,Blue,Lightweight
+10/28/2017,Elizeu Zaleski dos Santos,Max Griffin,Red,Welterweight
+10/28/2017,Deiveson Figueiredo,Jarred Brooks,Red,Flyweight
+10/28/2017,Marcelo Golm,Christian Colombo,Red,Heavyweight
+10/21/2017,Donald Cerrone,Darren Till,Blue,Welterweight
+10/21/2017,Karolina Kowalkiewicz,Jodie Esquibel,Red,Women's Strawweight
+10/21/2017,Jan Blachowicz,Devin Clark,Red,Light Heavyweight
+10/21/2017,Oskar Piechota,Jonathan Wilson,Red,Middleweight
+10/21/2017,Marcin Held,Nasrat Haqparast,Red,Lightweight
+10/21/2017,Damian Stasiak,Brian Kelleher,Blue,Bantamweight
+10/21/2017,Sam Alvey,Ramazan Emeev,Blue,Middleweight
+10/21/2017,Artem Lobov,Andre Fili,Blue,Featherweight
+10/21/2017,Salim Touahri,Warlley Alves,Blue,Welterweight
+10/21/2017,Lina Lansberg,Aspen Ladd,Blue,Women's Bantamweight
+10/21/2017,Felipe Arantes,Josh Emmett,Blue,Featherweight
+10/07/2017,Tony Ferguson,Kevin Lee,Red,UFC Interim Lightweight Title
+10/07/2017,Demetrious Johnson,Ray Borg,Red,UFC Flyweight Title
+10/07/2017,Fabricio Werdum,Walt Harris,Red,Heavyweight
+10/07/2017,Mara Romero Borella,Kalindra Faria,Red,Women's Flyweight
+10/07/2017,Tom Duquesnoy,Cody Stamann,Blue,Bantamweight
+10/07/2017,Pearl Gonzalez,Poliana Botelho,Blue,Women's Strawweight
+10/07/2017,Matt Schnell,Marco Beltran,Red,Flyweight
+10/07/2017,John Moraga,Bibulatov Magomed,Red,Flyweight
+10/07/2017,Thales Leites,Brad Tavares,Blue,Middleweight
+09/22/2017,Ovince Saint Preux,Yushin Okami,Red,Light Heavyweight
+09/22/2017,Claudia Gadelha,Jessica Andrade,Blue,Women's Strawweight
+09/22/2017,Takanori Gomi,Dong Hyun Ma,Blue,Lightweight
+09/22/2017,Gokhan Saki,Henrique da Silva,Red,Light Heavyweight
+09/22/2017,Teruto Ishihara,Rolando Dy,Red,Featherweight
+09/22/2017,Jussier Formiga,Yuta Sasaki,Red,Flyweight
+09/22/2017,Keita Nakamura,Alex Morono,Red,Welterweight
+09/22/2017,Syuri Kondo,Chan-Mi Jeon,Red,Women's Strawweight
+09/22/2017,Shinsho Anzai,Luke Jumeau,Red,Welterweight
+09/22/2017,Daichi Abe,Hyun Gyu Lim,Red,Welterweight
+09/16/2017,Luke Rockhold,David Branch,Red,Middleweight
+09/16/2017,Mike Perry,Alex Reyes,Red,Welterweight
+09/16/2017,Hector Lombard,Anthony Smith,Blue,Middleweight
+09/16/2017,Gregor Gillespie,Jason Gonzalez,Red,Lightweight
+09/16/2017,Kamaru Usman,Sergio Moraes,Red,Welterweight
+09/16/2017,Justin Ledet,Azunna Anyanwu,Red,Heavyweight
+09/16/2017,Anthony Rocco Martin,Olivier Aubin-Mercier,Blue,Lightweight
+09/16/2017,Anthony Hamilton,Daniel Spitz,Blue,Heavyweight
+09/16/2017,Krzysztof Jotko,Uriah Hall,Blue,Middleweight
+09/16/2017,Jason Saggo,Gilbert Burns,Blue,Lightweight
+09/09/2017,Amanda Nunes,Valentina Shevchenko,Red,UFC Women's Bantamweight Title
+09/09/2017,Neil Magny,Rafael Dos Anjos,Blue,Welterweight
+09/09/2017,Henry Cejudo,Wilson Reis,Red,Flyweight
+09/09/2017,Ilir Latifi,Tyson Pedro,Red,Light Heavyweight
+09/09/2017,Jeremy Stephens,Gilbert Melendez,Red,Featherweight
+09/09/2017,Sara McMann,Ketlen Vieira,Blue,Women's Bantamweight
+09/09/2017,Sarah Moras,Ashlee Evans-Smith,Red,Women's Bantamweight
+09/09/2017,Gavin Tucker,Ricky Glenn,Blue,Featherweight
+09/09/2017,Mitch Clarke,Alex White,Blue,Lightweight
+09/09/2017,Luis Henrique,Arjan Bhullar,Blue,Heavyweight
+09/09/2017,Kajan Johnson,Adriano Martins,Red,Lightweight
+09/02/2017,Alexander Volkov,Stefan Struve,Red,Heavyweight
+09/02/2017,Siyar Bahadurzada,Rob Wilkinson,Red,Middleweight
+09/02/2017,Marion Reneau,Talita Bernardo,Red,Women's Bantamweight
+09/02/2017,Leon Edwards,Bryan Barberena,Red,Welterweight
+09/02/2017,Darren Till,Bojan Velickovic,Red,Welterweight
+09/02/2017,Mairbek Taisumov,Felipe Silva,Red,Lightweight
+09/02/2017,Michel Prazeres,Mads Burnell,Red,Lightweight
+09/02/2017,Rustam Khabilov,Desmond Green,Red,Lightweight
+09/02/2017,Francimar Barroso,Aleksandar Rakic,Blue,Light Heavyweight
+09/02/2017,Mike Santiago,Zabit Magomedsharipov,Blue,Featherweight
+09/02/2017,Bojan Mihajlovic,Abdul-Kerim Edilov,Blue,Light Heavyweight
+09/02/2017,Thibault Gouti,Andrew Holbrook,Red,Lightweight
+08/05/2017,Sergio Pettis,Brandon Moreno,Red,Flyweight
+08/05/2017,Randa Markos,Alexa Grasso,Blue,Women's Strawweight
+08/05/2017,Alan Jouban,Niko Price,Blue,Welterweight
+08/05/2017,Martin Bravo,Humberto Bandenay,Blue,Featherweight
+08/05/2017,Sam Alvey,Rashad Evans,Red,Middleweight
+08/05/2017,Alejandro Perez,Andre Soukhamthath,Red,Bantamweight
+08/05/2017,Brad Scott,Jack Hermansson,Blue,Middleweight
+08/05/2017,Dustin Ortiz,Hector Sandoval,Red,Flyweight
+08/05/2017,Henry Briones,Rani Yahya,Blue,Bantamweight
+08/05/2017,Jose Quinonez,Diego Rivas,Red,Bantamweight
+08/05/2017,Joseph Morales,Robert Sanchez,Red,Flyweight
+08/05/2017,Alvaro Herrera Mendoza,Jordan Rinaldi,Blue,Lightweight
+07/29/2017,Tyron Woodley,Demian Maia,Red,UFC Welterweight Title
+07/29/2017,Cristiane Justino,Tonya Evinger,Red,UFC Women's Featherweight Title
+07/29/2017,Robbie Lawler,Donald Cerrone,Red,Welterweight
+07/29/2017,Jimi Manuwa,Volkan Oezdemir,Blue,Light Heavyweight
+07/29/2017,Ricardo Lamas,Jason Knight,Red,Featherweight
+07/29/2017,Aljamain Sterling,Renan Barao,Red,Catch Weight
+07/29/2017,Brian Ortega,Renato Moicano,Red,Featherweight
+07/29/2017,Andre Fili,Calvin Kattar,Blue,Featherweight
+07/29/2017,Kailin Curran,Aleksandra Albu,Blue,Women's Strawweight
+07/29/2017,Eric Shelton,Jarred Brooks,Blue,Flyweight
+07/29/2017,Joshua Burkman,Drew Dober,Blue,Lightweight
+07/22/2017,Chris Weidman,Kelvin Gastelum,Red,Middleweight
+07/22/2017,Dennis Bermudez,Darren Elkins,Blue,Featherweight
+07/22/2017,Patrick Cummins,Gian Villante,Red,Light Heavyweight
+07/22/2017,Jimmie Rivera,Thomas Almeida,Red,Bantamweight
+07/22/2017,Lyman Good,Elizeu Zaleski dos Santos,Blue,Welterweight
+07/22/2017,Rafael Natal,Eryk Anders,Blue,Middleweight
+07/22/2017,Ryan LaFlare,Alex Oliveira,Blue,Welterweight
+07/22/2017,Damian Grabowski,Chase Sherman,Blue,Heavyweight
+07/22/2017,Kyle Bochniak,Jeremy Kennedy,Blue,Featherweight
+07/22/2017,Brian Kelleher,Marlon Vera,Blue,Bantamweight
+07/22/2017,Timothy Johnson,Junior Albini,Blue,Heavyweight
+07/22/2017,Shane Burgos,Godofredo Pepey,Red,Featherweight
+07/22/2017,Frankie Perez,Chris Wade,Blue,Lightweight
+07/16/2017,Gunnar Nelson,Santiago Ponzinibbio,Blue,Welterweight
+07/16/2017,Joanne Wood,Cynthia Calvillo,Blue,Women's Strawweight
+07/16/2017,Stevie Ray,Paul Felder,Blue,Lightweight
+07/16/2017,Jack Marshman,Ryan Janes,Red,Middleweight
+07/16/2017,Khalil Rountree Jr.,Paul Craig,Red,Light Heavyweight
+07/16/2017,James Mulheron,Justin Willis,Blue,Heavyweight
+07/16/2017,Danny Roberts,Bobby Nash,Red,Welterweight
+07/16/2017,Alexandre Pantoja,Neil Seery,Red,Flyweight
+07/16/2017,Charlie Ward,Galore Bofando,Blue,Welterweight
+07/16/2017,Danny Henry,Daniel Teymur,Red,Lightweight
+07/16/2017,Brett Johns,Albert Morales,Red,Bantamweight
+07/16/2017,Leslie Smith,Amanda Lemos,Red,Women's Bantamweight
+07/08/2017,Yoel Romero,Robert Whittaker,Blue,UFC Interim Middleweight Title
+07/08/2017,Fabricio Werdum,Alistair Overeem,Blue,Heavyweight
+07/08/2017,Daniel Omielanczuk,Curtis Blaydes,Blue,Heavyweight
+07/08/2017,Anthony Pettis,Jim Miller,Red,Lightweight
+07/08/2017,Rob Font,Douglas Silva de Andrade,Red,Bantamweight
+07/08/2017,Travis Browne,Aleksei Oleinik,Blue,Heavyweight
+07/08/2017,Chad Laprise,Brian Camozzi,Red,Welterweight
+07/08/2017,Thiago Santos,Gerald Meerschaert,Red,Middleweight
+07/08/2017,Jordan Mein,Belal Muhammad,Blue,Welterweight
+07/08/2017,Cody Stamann,Terrion Ware,Red,Featherweight
+07/08/2017,Trevin Giles,James Bochnovic,Red,Light Heavyweight
+07/07/2017,Michael Johnson,Justin Gaethje,Blue,Lightweight
+07/07/2017,Dhiego Lima,Jesse Taylor,Blue,Ultimate Fighter 25 Welterweight Tournament Title
+07/07/2017,Marc Diakiese,Drakkar Klose,Blue,Lightweight
+07/07/2017,Jared Cannonier,Nick Roehrick,Red,Light Heavyweight
+07/07/2017,Brad Tavares,Elias Theodorou,Red,Middleweight
+07/07/2017,Jordan Johnson,Marcel Fortuna,Red,Light Heavyweight
+07/07/2017,Angela Hill,Ashley Yoder,Red,Women's Strawweight
+07/07/2017,James Krause,Tom Gallicchio,Red,Welterweight
+07/07/2017,Ed Herman,CB Dollaway,Blue,Light Heavyweight
+07/07/2017,Tecia Torres,Juliana Lima,Red,Women's Strawweight
+07/07/2017,Gray Maynard,Teruto Ishihara,Red,Featherweight
+06/25/2017,Michael Chiesa,Kevin Lee,Blue,Lightweight
+06/25/2017,Tim Boetsch,Johny Hendricks,Red,Middleweight
+06/25/2017,Felice Herrig,Justine Kish,Red,Women's Strawweight
+06/25/2017,Joachim Christensen,Dominick Reyes,Blue,Light Heavyweight
+06/25/2017,Tim Means,Alex Garcia,Red,Welterweight
+06/25/2017,BJ Penn,Dennis Siver,Blue,Featherweight
+06/25/2017,Clay Guida,Erik Koch,Red,Lightweight
+06/25/2017,Vitor Miranda,Marvin Vettori,Blue,Middleweight
+06/25/2017,Carla Esparza,Maryna Moroz,Red,Women's Strawweight
+06/25/2017,Devin Powell,Darrell Horcher,Blue,Lightweight
+06/25/2017,Jared Gordon,Michel Quinones,Red,Featherweight
+06/25/2017,Anthony Rocco Martin,Johnny Case,Red,Lightweight
+06/25/2017,Josh Stansbury,Jeremy Kimball,Blue,Light Heavyweight
+06/17/2017,Holly Holm,Bethe Correia,Red,Women's Bantamweight
+06/17/2017,Andrei Arlovski,Marcin Tybura,Blue,Heavyweight
+06/17/2017,Dong Hyun Kim,Colby Covington,Blue,Welterweight
+06/17/2017,Tarec Saffiedine,Rafael Dos Anjos,Blue,Welterweight
+06/17/2017,Takanori Gomi,Jon Tuck,Blue,Lightweight
+06/17/2017,Cyril Asker,Walt Harris,Blue,Heavyweight
+06/17/2017,Alex Caceres,Rolando Dy,Red,Featherweight
+06/17/2017,Justin Scoggins,Yuta Sasaki,Blue,Flyweight
+06/17/2017,Li Jingliang,Frank Camacho,Red,Welterweight
+06/17/2017,Kwan Ho Kwak,Russell Doane,Blue,Bantamweight
+06/17/2017,Naoki Inoue,Carls John De Tomas,Red,Flyweight
+06/17/2017,Ji Yeon Kim,Lucie Pudilova,Blue,Women's Bantamweight
+06/10/2017,Derrick Lewis,Mark Hunt,Blue,Heavyweight
+06/10/2017,Derek Brunson,Daniel Kelly,Red,Middleweight
+06/10/2017,Dan Hooker,Ross Pearson,Red,Lightweight
+06/10/2017,Ion Cutelaba,Henrique da Silva,Red,Light Heavyweight
+06/10/2017,Tim Elliott,Ben Nguyen,Blue,Flyweight
+06/10/2017,Alexander Volkanovski,Mizuto Hirota,Red,Featherweight
+06/10/2017,Damien Brown,Vinc Pichel,Blue,Lightweight
+06/10/2017,Luke Jumeau,Dominique Steele,Red,Welterweight
+06/10/2017,John Moraga,Ashkan Mokhtarian,Red,Flyweight
+06/10/2017,Kiichi Kunimoto,Zak Ottow,Blue,Welterweight
+06/10/2017,JJ Aldrich,Chan-Mi Jeon,Red,Women's Strawweight
+06/03/2017,Jose Aldo,Max Holloway,Blue,UFC Featherweight Title
+06/03/2017,Claudia Gadelha,Karolina Kowalkiewicz,Red,Women's Strawweight
+06/03/2017,Vitor Belfort,Nate Marquardt,Red,Middleweight
+06/03/2017,Paulo Costa,Oluwale Bamgbose,Red,Middleweight
+06/03/2017,Erick Silva,Yancy Medeiros,Blue,Welterweight
+06/03/2017,Raphael Assuncao,Marlon Moraes,Red,Bantamweight
+06/03/2017,Antonio Carlos Junior,Eric Spicely,Red,Middleweight
+06/03/2017,Johnny Eduardo,Matthew Lopez,Blue,Bantamweight
+06/03/2017,Iuri Alcantara,Brian Kelleher,Blue,Bantamweight
+06/03/2017,Viviane Pereira,Jamie Moyle,Red,Women's Strawweight
+06/03/2017,Luan Chagas,Jim Wallhead,Red,Welterweight
+06/03/2017,Marco Beltran,Deiveson Figueiredo,Blue,Flyweight
+05/28/2017,Alexander Gustafsson,Glover Teixeira,Red,Light Heavyweight
+05/28/2017,Volkan Oezdemir,Misha Cirkunov,Red,Light Heavyweight
+05/28/2017,Peter Sobotta,Ben Saunders,Red,Welterweight
+05/28/2017,Abdul Razak Alhassan,Omari Akhmedov,Blue,Welterweight
+05/28/2017,Oliver Enkamp,Nordine Taleb,Blue,Welterweight
+05/28/2017,Jack Hermansson,Alex Nicholson,Red,Middleweight
+05/28/2017,Pedro Munhoz,Damian Stasiak,Red,Bantamweight
+05/28/2017,Trevor Smith,Chris Camozzi,Red,Middleweight
+05/28/2017,Reza Madadi,Joaquim Silva,Blue,Lightweight
+05/28/2017,Nicholas Musoke,Bojan Velickovic,Blue,Welterweight
+05/28/2017,Darren Till,Jessin Ayari,Red,Welterweight
+05/28/2017,Marcin Held,Damir Hadzovic,Blue,Lightweight
+05/13/2017,Stipe Miocic,Junior Dos Santos,Red,UFC Heavyweight Title
+05/13/2017,Joanna Jedrzejczyk,Jessica Andrade,Red,UFC Women's Strawweight Title
+05/13/2017,Demian Maia,Jorge Masvidal,Red,Welterweight
+05/13/2017,Frankie Edgar,Yair Rodriguez,Red,Featherweight
+05/13/2017,Krzysztof Jotko,David Branch,Blue,Middleweight
+05/13/2017,Chas Skelly,Jason Knight,Blue,Featherweight
+05/13/2017,Chase Sherman,Rashad Coulter,Red,Heavyweight
+05/13/2017,James Vick,Marco Polo Reyes,Red,Lightweight
+05/13/2017,Jessica Aguilar,Cortney Casey,Blue,Women's Strawweight
+05/13/2017,Gabriel Benitez,Enrique Barzola,Blue,Featherweight
+05/13/2017,Joachim Christensen,Gadzhimurad Antigulov,Blue,Light Heavyweight
+04/22/2017,Cub Swanson,Artem Lobov,Red,Featherweight
+04/22/2017,Al Iaquinta,Diego Sanchez,Red,Lightweight
+04/22/2017,Ovince Saint Preux,Marcos Rogerio de Lima,Red,Light Heavyweight
+04/22/2017,John Dodson,Eddie Wineland,Red,Bantamweight
+04/22/2017,Joe Lauzon,Stevie Ray,Blue,Lightweight
+04/22/2017,Jake Ellenberger,Mike Perry,Blue,Welterweight
+04/22/2017,Thales Leites,Sam Alvey,Red,Middleweight
+04/22/2017,Dustin Ortiz,Brandon Moreno,Blue,Flyweight
+04/22/2017,Scott Holtzman,Michael McBride,Red,Lightweight
+04/22/2017,Jessica Penne,Danielle Taylor,Blue,Women's Strawweight
+04/22/2017,Alexis Davis,Cindy Dandois,Red,Women's Bantamweight
+04/22/2017,Bryan Barberena,Joe Proctor,Red,Welterweight
+04/22/2017,Hector Sandoval,Matt Schnell,Red,Flyweight
+04/15/2017,Demetrious Johnson,Wilson Reis,Red,UFC Flyweight Title
+04/15/2017,Rose Namajunas,Michelle Waterson-Gomez,Red,Women's Strawweight
+04/15/2017,Jacare Souza,Robert Whittaker,Blue,Middleweight
+04/15/2017,Jeremy Stephens,Renato Moicano,Blue,Featherweight
+04/15/2017,Alexander Volkov,Roy Nelson,Red,Heavyweight
+04/15/2017,Patrick Williams,Tom Duquesnoy,Blue,Bantamweight
+04/15/2017,Bobby Green,Rashid Magomedov,Blue,Lightweight
+04/15/2017,Louis Smolka,Tim Elliott,Blue,Flyweight
+04/15/2017,Aljamain Sterling,Augusto Mendes,Red,Bantamweight
+04/15/2017,Devin Clark,Jake Collier,Red,Light Heavyweight
+04/15/2017,Anthony Smith,Andrew Sanchez,Red,Middleweight
+04/15/2017,Zak Cummings,Nathan Coy,Red,Welterweight
+04/15/2017,Ashlee Evans-Smith,Ketlen Vieira,Blue,Women's Bantamweight
+04/08/2017,Daniel Cormier,Anthony Johnson,Red,UFC Light Heavyweight Title
+04/08/2017,Chris Weidman,Gegard Mousasi,Blue,Middleweight
+04/08/2017,Cynthia Calvillo,Pearl Gonzalez,Red,Women's Strawweight
+04/08/2017,Thiago Alves,Patrick Cote,Red,Welterweight
+04/08/2017,Will Brooks,Charles Oliveira,Blue,Lightweight
+04/08/2017,Myles Jury,Mike de la Torre,Red,Featherweight
+04/08/2017,Kamaru Usman,Sean Strickland,Red,Welterweight
+04/08/2017,Shane Burgos,Charles Rosa,Red,Featherweight
+04/08/2017,Patrick Cummins,Jan Blachowicz,Red,Light Heavyweight
+04/08/2017,Gregor Gillespie,Andrew Holbrook,Red,Lightweight
+04/08/2017,Josh Emmett,Desmond Green,Blue,Lightweight
+04/08/2017,Katlyn Cerminara,Irene Aldana,Red,Women's Bantamweight
+04/08/2017,Jenel Lausa,Bibulatov Magomed,Blue,Flyweight
+03/18/2017,Jimi Manuwa,Corey Anderson,Red,Light Heavyweight
+03/18/2017,Gunnar Nelson,Alan Jouban,Red,Welterweight
+03/18/2017,Brad Pickett,Marlon Vera,Blue,Catch Weight
+03/18/2017,Arnold Allen,Makwan Amirkhani,Red,Featherweight
+03/18/2017,Joe Duffy,Reza Madadi,Red,Lightweight
+03/18/2017,Darren Stewart,Francimar Barroso,Blue,Light Heavyweight
+03/18/2017,Daniel Omielanczuk,Timothy Johnson,Blue,Heavyweight
+03/18/2017,Leon Edwards,Vicente Luque,Red,Welterweight
+03/18/2017,Marc Diakiese,Teemu Packalen,Red,Lightweight
+03/18/2017,Brad Scott,Scott Askham,Red,Middleweight
+03/18/2017,Lina Lansberg,Lucie Pudilova,Red,Women's Bantamweight
+03/11/2017,Mauricio Rua,Gian Villante,Red,Light Heavyweight
+03/11/2017,Edson Barboza,Beneil Dariush,Red,Lightweight
+03/11/2017,Jussier Formiga,Ray Borg,Blue,Flyweight
+03/11/2017,Alex Oliveira,Tim Means,Red,Welterweight
+03/11/2017,Francisco Trinaldo,Kevin Lee,Blue,Lightweight
+03/11/2017,Sergio Moraes,Davi Ramos,Red,Welterweight
+03/11/2017,Rani Yahya,Joe Soto,Blue,Bantamweight
+03/11/2017,Michel Prazeres,Joshua Burkman,Red,Lightweight
+03/11/2017,Rony Jason,Jeremy Kennedy,Blue,Featherweight
+03/11/2017,Garreth McLellan,Paulo Costa,Blue,Middleweight
+03/04/2017,Tyron Woodley,Stephen Thompson,Red,UFC Welterweight Title
+03/04/2017,Lando Vannata,David Teymur,Blue,Lightweight
+03/04/2017,Rashad Evans,Daniel Kelly,Blue,Middleweight
+03/04/2017,Amanda Cooper,Cynthia Calvillo,Blue,Women's Strawweight
+03/04/2017,Alistair Overeem,Mark Hunt,Red,Heavyweight
+03/04/2017,Marcin Tybura,Luis Henrique,Red,Heavyweight
+03/04/2017,Mirsad Bektic,Darren Elkins,Blue,Featherweight
+03/04/2017,Iuri Alcantara,Luke Sanders,Red,Bantamweight
+03/04/2017,Mark Godbeer,Daniel Spitz,Red,Heavyweight
+03/04/2017,Tyson Pedro,Paul Craig,Red,Light Heavyweight
+03/04/2017,Albert Morales,Andre Soukhamthath,Red,Bantamweight
+02/19/2017,Derrick Lewis,Travis Browne,Red,Heavyweight
+02/19/2017,Johny Hendricks,Hector Lombard,Red,Middleweight
+02/19/2017,Sam Sicilia,Gavin Tucker,Blue,Featherweight
+02/19/2017,Elias Theodorou,Cezar Ferreira,Red,Middleweight
+02/19/2017,Sara McMann,Gina Mazany,Red,Women's Bantamweight
+02/19/2017,Paul Felder,Alex Ricci,Red,Lightweight
+02/19/2017,Nordine Taleb,Santiago Ponzinibbio,Blue,Welterweight
+02/19/2017,Carla Esparza,Randa Markos,Blue,Women's Strawweight
+02/19/2017,Aiemann Zahabi,Reginaldo Vieira,Red,Bantamweight
+02/19/2017,Jack Marshman,Thiago Santos,Blue,Middleweight
+02/19/2017,Gerald Meerschaert,Ryan Janes,Red,Middleweight
+02/11/2017,Holly Holm,Germaine de Randamie,Blue,UFC Women's Featherweight Title
+02/11/2017,Anderson Silva,Derek Brunson,Red,Middleweight
+02/11/2017,Jacare Souza,Tim Boetsch,Red,Middleweight
+02/11/2017,Glover Teixeira,Jared Cannonier,Red,Light Heavyweight
+02/11/2017,Dustin Poirier,Jim Miller,Red,Lightweight
+02/11/2017,Randy Brown,Belal Muhammad,Blue,Welterweight
+02/11/2017,Wilson Reis,Yuta Sasaki,Red,Flyweight
+02/11/2017,Nik Lentz,Islam Makhachev,Blue,Lightweight
+02/11/2017,Ricky Glenn,Phillipe Nover,Red,Featherweight
+02/11/2017,Ryan LaFlare,Roan Carneiro,Red,Welterweight
+02/04/2017,Dennis Bermudez,Chan Sung Jung,Blue,Featherweight
+02/04/2017,Alexa Grasso,Felice Herrig,Blue,Women's Strawweight
+02/04/2017,Abel Trujillo,James Vick,Blue,Lightweight
+02/04/2017,Ovince Saint Preux,Volkan Oezdemir,Blue,Light Heavyweight
+02/04/2017,Anthony Hamilton,Marcel Fortuna,Blue,Heavyweight
+02/04/2017,Jessica Andrade,Angela Hill,Red,Women's Strawweight
+02/04/2017,Chas Skelly,Chris Gruetzemacher,Red,Featherweight
+02/04/2017,Ricardo Ramos,Michinori Tanaka,Red,Bantamweight
+02/04/2017,Tecia Torres,Bec Rawlings,Red,Women's Strawweight
+02/04/2017,Daniel Jolly,Khalil Rountree Jr.,Blue,Light Heavyweight
+01/28/2017,Valentina Shevchenko,Julianna Pena,Red,Women's Bantamweight
+01/28/2017,Donald Cerrone,Jorge Masvidal,Blue,Welterweight
+01/28/2017,Andrei Arlovski,Francis Ngannou,Blue,Heavyweight
+01/28/2017,Alex Caceres,Jason Knight,Blue,Featherweight
+01/28/2017,Nate Marquardt,Sam Alvey,Blue,Middleweight
+01/28/2017,Raphael Assuncao,Aljamain Sterling,Red,Bantamweight
+01/28/2017,Bobby Nash,Li Jingliang,Blue,Welterweight
+01/28/2017,Henrique da Silva,Jordan Johnson,Blue,Light Heavyweight
+01/28/2017,Eric Spicely,Alessio Di Chirico,Red,Middleweight
+01/28/2017,Marcos Rogerio de Lima,Jeremy Kimball,Red,Light Heavyweight
+01/28/2017,Alexandre Pantoja,Eric Shelton,Red,Flyweight
+01/28/2017,Jason Gonzalez,JC Cottrell,Red,Lightweight
+01/15/2017,Yair Rodriguez,BJ Penn,Red,Featherweight
+01/15/2017,Joe Lauzon,Marcin Held,Red,Lightweight
+01/15/2017,Court McGee,Ben Saunders,Blue,Welterweight
+01/15/2017,John Moraga,Sergio Pettis,Blue,Flyweight
+01/15/2017,Devin Powell,Drakkar Klose,Blue,Lightweight
+01/15/2017,Frankie Saenz,Augusto Mendes,Blue,Bantamweight
+01/15/2017,Aleksei Oleinik,Viktor Pesta,Red,Heavyweight
+01/15/2017,Anthony Rocco Martin,Alex White,Red,Lightweight
+01/15/2017,Jocelyn Jones-Lybarger,Nina Nunes,Blue,Women's Strawweight
+01/15/2017,Walt Harris,Chase Sherman,Red,Heavyweight
+01/15/2017,Bojan Mihajlovic,Joachim Christensen,Blue,Light Heavyweight
+01/15/2017,Dmitrii Smoliakov,Cyril Asker,Blue,Heavyweight
+12/30/2016,Amanda Nunes,Ronda Rousey,Red,UFC Women's Bantamweight Title
+12/30/2016,Dominick Cruz,Cody Garbrandt,Blue,UFC Bantamweight Title
+12/30/2016,TJ Dillashaw,John Lineker,Red,Bantamweight
+12/30/2016,Dong Hyun Kim,Tarec Saffiedine,Red,Welterweight
+12/30/2016,Louis Smolka,Ray Borg,Blue,Flyweight
+12/30/2016,Johny Hendricks,Neil Magny,Blue,Welterweight
+12/30/2016,Antonio Carlos Junior,Marvin Vettori,Red,Middleweight
+12/30/2016,Mike Pyle,Alex Garcia,Blue,Welterweight
+12/30/2016,Brandon Thatch,Niko Price,Blue,Welterweight
+12/17/2016,Paige VanZant,Michelle Waterson-Gomez,Blue,Women's Strawweight
+12/17/2016,Sage Northcutt,Mickey Gall,Blue,Welterweight
+12/17/2016,Urijah Faber,Brad Pickett,Red,Bantamweight
+12/17/2016,Alan Jouban,Mike Perry,Red,Welterweight
+12/17/2016,Henrique da Silva,Paul Craig,Blue,Light Heavyweight
+12/17/2016,Cole Miller,Mizuto Hirota,Blue,Featherweight
+12/17/2016,Bryan Barberena,Colby Covington,Blue,Welterweight
+12/17/2016,James Moontasri,Alex Morono,Blue,Welterweight
+12/17/2016,Josh Emmett,Scott Holtzman,Red,Lightweight
+12/17/2016,Leslie Smith,Irene Aldana,Red,Women's Bantamweight
+12/17/2016,Eddie Wineland,Takeya Mizugaki,Red,Bantamweight
+12/17/2016,Hector Sandoval,Fredy Serrano,Red,Flyweight
+12/17/2016,Bojan Velickovic,Sultan Aliev,Blue,Welterweight
+12/10/2016,Max Holloway,Anthony Pettis,Red,UFC Interim Featherweight Title
+12/10/2016,Donald Cerrone,Matt Brown,Red,Welterweight
+12/10/2016,Cub Swanson,Dooho Choi,Red,Featherweight
+12/10/2016,Tim Kennedy,Kelvin Gastelum,Blue,Middleweight
+12/10/2016,Jordan Mein,Emil Meek,Blue,Welterweight
+12/10/2016,Nikita Krylov,Misha Cirkunov,Blue,Light Heavyweight
+12/10/2016,Olivier Aubin-Mercier,Drew Dober,Red,Lightweight
+12/10/2016,Valerie Letourneau,Viviane Pereira,Blue,Women's Strawweight
+12/10/2016,Mitch Gagnon,Matthew Lopez,Blue,Bantamweight
+12/10/2016,John Makdessi,Lando Vannata,Blue,Lightweight
+12/10/2016,Jason Saggo,Rustam Khabilov,Blue,Lightweight
+12/10/2016,Zach Makovsky,Dustin Ortiz,Blue,Flyweight
+12/09/2016,Derrick Lewis,Shamil Abdurakhimov,Red,Heavyweight
+12/09/2016,Francis Ngannou,Anthony Hamilton,Red,Heavyweight
+12/09/2016,Corey Anderson,Sean O'Connell,Red,Light Heavyweight
+12/09/2016,Gian Villante,Saparbeg Safarov,Red,Light Heavyweight
+12/09/2016,Justine Kish,Ashley Yoder,Red,Women's Strawweight
+12/09/2016,Randy Brown,Brian Camozzi,Red,Welterweight
+12/09/2016,Joseph Gigliotti,Gerald Meerschaert,Blue,Middleweight
+12/09/2016,Andrew Sanchez,Trevor Smith,Red,Middleweight
+12/09/2016,Tiago dos Santos e Silva,Shane Burgos,Blue,Featherweight
+12/09/2016,Frankie Perez,Marc Diakiese,Blue,Lightweight
+12/09/2016,Keith Berish,Ryan Janes,Blue,Middleweight
+12/09/2016,Juliana Lima,JJ Aldrich,Red,Women's Strawweight
+12/03/2016,Demetrious Johnson,Tim Elliott,Red,UFC Flyweight Title
+12/03/2016,Joseph Benavidez,Henry Cejudo,Red,Flyweight
+12/03/2016,Jake Ellenberger,Jorge Masvidal,Blue,Welterweight
+12/03/2016,Ion Cutelaba,Jared Cannonier,Blue,Light Heavyweight
+12/03/2016,Sara McMann,Alexis Davis,Red,Women's Bantamweight
+12/03/2016,Brandon Moreno,Ryan Benoit,Red,Flyweight
+12/03/2016,Gray Maynard,Ryan Hall,Blue,Featherweight
+12/03/2016,Rob Font,Matt Schnell,Red,Bantamweight
+12/03/2016,Dong Hyun Ma,Brendan O'Reilly,Red,Lightweight
+12/03/2016,Kailin Curran,Jamie Moyle,Blue,Women's Strawweight
+12/03/2016,Elvis Mutapcic,Anthony Smith,Blue,Middleweight
+12/03/2016,Josh Stansbury,Devin Clark,Blue,Light Heavyweight
+11/26/2016,Robert Whittaker,Derek Brunson,Red,Middleweight
+11/26/2016,Jake Matthews,Andrew Holbrook,Blue,Lightweight
+11/26/2016,Kyle Noke,Omari Akhmedov,Blue,Welterweight
+11/26/2016,Yusuke Kasuya,Alexander Volkanovski,Blue,Lightweight
+11/26/2016,Khalil Rountree Jr.,Tyson Pedro,Blue,Light Heavyweight
+11/26/2016,Seo Hee Ham,Danielle Taylor,Blue,Women's Strawweight
+11/26/2016,Daniel Kelly,Chris Camozzi,Red,Middleweight
+11/26/2016,Damien Brown,Jon Tuck,Red,Lightweight
+11/26/2016,Richard Walsh,Jonathan Meunier,Blue,Welterweight
+11/26/2016,Ben Nguyen,Geane Herrera,Red,Flyweight
+11/26/2016,Dan Hooker,Jason Knight,Blue,Featherweight
+11/26/2016,Marlon Vera,Guangyou Ning,Red,Featherweight
+11/26/2016,Yao Zhikui,Jenel Lausa,Blue,Flyweight
+11/19/2016,Ryan Bader,Rogerio Nogueira,Red,Light Heavyweight
+11/19/2016,Thomas Almeida,Albert Morales,Red,Bantamweight
+11/19/2016,Claudia Gadelha,Cortney Casey,Red,Women's Strawweight
+11/19/2016,Thales Leites,Krzysztof Jotko,Blue,Middleweight
+11/19/2016,Warlley Alves,Kamaru Usman,Blue,Welterweight
+11/19/2016,Sergio Moraes,Zak Ottow,Red,Welterweight
+11/19/2016,Cezar Ferreira,Jack Hermansson,Red,Middleweight
+11/19/2016,Marcos Rogerio de Lima,Gadzhimurad Antigulov,Blue,Light Heavyweight
+11/19/2016,Johnny Eduardo,Manvel Gamburyan,Red,Bantamweight
+11/19/2016,Luis Henrique,Christian Colombo,Red,Heavyweight
+11/19/2016,Pedro Munhoz,Justin Scoggins,Red,Bantamweight
+11/19/2016,Gegard Mousasi,Uriah Hall,Red,Middleweight
+11/19/2016,Ross Pearson,Stevie Ray,Blue,Lightweight
+11/19/2016,Timothy Johnson,Alexander Volkov,Blue,Heavyweight
+11/19/2016,Artem Lobov,Teruto Ishihara,Red,Featherweight
+11/19/2016,Magnus Cedenblad,Jack Marshman,Blue,Middleweight
+11/19/2016,Kyoji Horiguchi,Ali Bagautinov,Red,Flyweight
+11/19/2016,Kevin Lee,Magomed Mustafaev,Red,Lightweight
+11/19/2016,Anna Elmose,Amanda Cooper,Blue,Women's Strawweight
+11/19/2016,Justin Ledet,Mark Godbeer,Red,Heavyweight
+11/19/2016,Zak Cummings,Alexander Yakovlev,Red,Welterweight
+11/19/2016,Marion Reneau,Milana Dudieva,Red,Women's Bantamweight
+11/19/2016,Brett Johns,Kwan Ho Kwak,Red,Bantamweight
+11/19/2016,Charlie Ward,Abdul Razak Alhassan,Blue,Welterweight
+11/12/2016,Eddie Alvarez,Conor McGregor,Blue,UFC Lightweight Title
+11/12/2016,Joanna Jedrzejczyk,Karolina Kowalkiewicz,Red,UFC Women's Strawweight Title
+11/12/2016,Chris Weidman,Yoel Romero,Blue,Middleweight
+11/12/2016,Miesha Tate,Raquel Pennington,Blue,Women's Bantamweight
+11/12/2016,Frankie Edgar,Jeremy Stephens,Red,Featherweight
+11/12/2016,Khabib Nurmagomedov,Michael Johnson,Red,Lightweight
+11/12/2016,Rafael Natal,Tim Boetsch,Blue,Middleweight
+11/12/2016,Vicente Luque,Belal Muhammad,Red,Welterweight
+11/12/2016,Jim Miller,Thiago Alves,Red,Catch Weight
+11/12/2016,Liz Carmouche,Katlyn Cerminara,Red,Women's Bantamweight
+11/05/2016,Rafael Dos Anjos,Tony Ferguson,Blue,Lightweight
+11/05/2016,Diego Sanchez,Marcin Held,Red,Lightweight
+11/05/2016,Ricardo Lamas,Charles Oliveira,Red,Featherweight
+11/05/2016,Martin Bravo,Claudio Puelles,Red,Ultimate Fighter Latin America 3 Lightweight Tournament Title
+11/05/2016,Beneil Dariush,Rashid Magomedov,Red,Lightweight
+11/05/2016,Alexa Grasso,Heather Clark,Red,Women's Strawweight
+11/05/2016,Erik Perez,Felipe Arantes,Red,Bantamweight
+11/05/2016,Marco Beltran,Joe Soto,Blue,Catch Weight
+11/05/2016,Erick Montano,Max Griffin,Blue,Welterweight
+11/05/2016,Henry Briones,Douglas Silva de Andrade,Blue,Bantamweight
+11/05/2016,Sam Alvey,Alex Nicholson,Red,Middleweight
+11/05/2016,Marco Polo Reyes,Jason Novelli,Red,Lightweight
+11/05/2016,Enrique Barzola,Chris Avila,Red,Featherweight
+10/08/2016,Michael Bisping,Dan Henderson,Red,UFC Middleweight Title
+10/08/2016,Vitor Belfort,Gegard Mousasi,Blue,Middleweight
+10/08/2016,Ovince Saint Preux,Jimi Manuwa,Blue,Light Heavyweight
+10/08/2016,Stefan Struve,Daniel Omielanczuk,Red,Heavyweight
+10/08/2016,Mirsad Bektic,Russell Doane,Red,Featherweight
+10/08/2016,Brad Pickett,Iuri Alcantara,Blue,Bantamweight
+10/08/2016,Davey Grant,Damian Stasiak,Blue,Bantamweight
+10/08/2016,Leon Edwards,Albert Tumenov,Red,Welterweight
+10/08/2016,Lukasz Sajewski,Marc Diakiese,Blue,Lightweight
+10/08/2016,Danny Roberts,Mike Perry,Blue,Welterweight
+10/08/2016,Leonardo Santos,Adriano Martins,Red,Lightweight
+10/01/2016,John Lineker,John Dodson,Red,Bantamweight
+10/01/2016,Will Brooks,Alex Oliveira,Blue,Lightweight
+10/01/2016,Joshua Burkman,Zak Ottow,Blue,Welterweight
+10/01/2016,Louis Smolka,Brandon Moreno,Blue,Flyweight
+10/01/2016,Henrique da Silva,Joachim Christensen,Red,Light Heavyweight
+10/01/2016,Hacran Dias,Andre Fili,Blue,Featherweight
+10/01/2016,Shamil Abdurakhimov,Walt Harris,Red,Heavyweight
+10/01/2016,Keita Nakamura,Elizeu Zaleski dos Santos,Blue,Welterweight
+10/01/2016,Nate Marquardt,Tamdan McCrory,Red,Middleweight
+10/01/2016,Jonathan Wilson,Ion Cutelaba,Blue,Light Heavyweight
+10/01/2016,Cody East,Curtis Blaydes,Blue,Heavyweight
+10/01/2016,Kelly Faszholz,Ketlen Vieira,Blue,Women's Bantamweight
+09/24/2016,Cristiane Justino,Lina Lansberg,Red,Catch Weight
+09/24/2016,Renan Barao,Phillipe Nover,Red,Featherweight
+09/24/2016,Roy Nelson,Antonio Silva,Red,Heavyweight
+09/24/2016,Francisco Trinaldo,Paul Felder,Red,Lightweight
+09/24/2016,Thiago Santos,Eric Spicely,Blue,Middleweight
+09/24/2016,Godofredo Pepey,Mike de la Torre,Red,Featherweight
+09/24/2016,Gilbert Burns,Michel Prazeres,Blue,Lightweight
+09/24/2016,Rani Yahya,Michinori Tanaka,Red,Bantamweight
+09/24/2016,Jussier Formiga,Dustin Ortiz,Red,Flyweight
+09/24/2016,Erick Silva,Luan Chagas,Red,Welterweight
+09/24/2016,Alan Patrick,Stevie Ray,Red,Lightweight
+09/24/2016,Vicente Luque,Hector Urbina,Red,Welterweight
+09/24/2016,Glaico Franca Moreira,Gregor Gillespie,Blue,Lightweight
+09/17/2016,Dustin Poirier,Michael Johnson,Blue,Lightweight
+09/17/2016,Uriah Hall,Derek Brunson,Blue,Middleweight
+09/17/2016,Evan Dunham,Ricky Glenn,Red,Lightweight
+09/17/2016,Roan Carneiro,Kenny Robertson,Red,Welterweight
+09/17/2016,Chris Wade,Islam Makhachev,Blue,Lightweight
+09/17/2016,Chas Skelly,Maximo Blanco,Red,Featherweight
+09/17/2016,Gabriel Benitez,Sam Sicilia,Red,Featherweight
+09/17/2016,Augusto Montano,Belal Muhammad,Blue,Welterweight
+09/17/2016,Antonio Carlos Junior,Leonardo Guimaraes,Red,Middleweight
+09/17/2016,Jose Quinonez,Joey Gomez,Red,Bantamweight
+09/17/2016,Erick Montano,Randy Brown,Blue,Welterweight
+09/10/2016,Stipe Miocic,Alistair Overeem,Red,UFC Heavyweight Title
+09/10/2016,Fabricio Werdum,Travis Browne,Red,Heavyweight
+09/10/2016,CM Punk,Mickey Gall,Blue,Welterweight
+09/10/2016,Urijah Faber,Jimmie Rivera,Blue,Bantamweight
+09/10/2016,Jessica Andrade,Joanne Wood,Red,Women's Strawweight
+09/10/2016,Jessica Eye,Bethe Correia,Blue,Women's Bantamweight
+09/10/2016,Brad Tavares,Caio Magalhaes,Red,Middleweight
+09/10/2016,Nik Lentz,Michael McBride,Red,Lightweight
+09/10/2016,Drew Dober,Jason Gonzalez,Red,Lightweight
+09/10/2016,Yancy Medeiros,Sean Spencer,Red,Welterweight
+09/03/2016,Andrei Arlovski,Josh Barnett,Blue,Heavyweight
+09/03/2016,Alexander Gustafsson,Jan Blachowicz,Red,Light Heavyweight
+09/03/2016,Ryan Bader,Ilir Latifi,Red,Light Heavyweight
+09/03/2016,Nick Hein,Tae Hyun Bang,Red,Lightweight
+09/03/2016,Jessin Ayari,Jim Wallhead,Red,Welterweight
+09/03/2016,Peter Sobotta,Nicolas Dalby,Red,Welterweight
+09/03/2016,Ashlee Evans-Smith,Veronica Hardy,Red,Women's Bantamweight
+09/03/2016,Taylor Lapilus,Leandro Issa,Red,Bantamweight
+09/03/2016,Scott Askham,Jack Hermansson,Blue,Middleweight
+09/03/2016,Rustam Khabilov,Leandro Silva,Red,Lightweight
+08/27/2016,Demian Maia,Carlos Condit,Red,Welterweight
+08/27/2016,Anthony Pettis,Charles Oliveira,Red,Featherweight
+08/27/2016,Paige VanZant,Bec Rawlings,Red,Women's Strawweight
+08/27/2016,Joe Lauzon,Jim Miller,Blue,Lightweight
+08/27/2016,Sam Alvey,Kevin Casey,Red,Middleweight
+08/27/2016,Enrique Barzola,Kyle Bochniak,Blue,Featherweight
+08/27/2016,Garreth McLellan,Alessio Di Chirico,Blue,Middleweight
+08/27/2016,Shane Campbell,Felipe Silva,Blue,Lightweight
+08/27/2016,Chad Laprise,Thibault Gouti,Red,Lightweight
+08/27/2016,Jeremy Kennedy,Alex Ricci,Red,Lightweight
+08/20/2016,Nate Diaz,Conor McGregor,Blue,Welterweight
+08/20/2016,Anthony Johnson,Glover Teixeira,Red,Light Heavyweight
+08/20/2016,Rick Story,Donald Cerrone,Blue,Welterweight
+08/20/2016,Hyun Gyu Lim,Mike Perry,Blue,Welterweight
+08/20/2016,Tim Means,Sabah Homasi,Red,Welterweight
+08/20/2016,Cody Garbrandt,Takeya Mizugaki,Red,Bantamweight
+08/20/2016,Raquel Pennington,Elizabeth Phillips,Red,Women's Bantamweight
+08/20/2016,Artem Lobov,Chris Avila,Red,Featherweight
+08/20/2016,Randa Markos,Cortney Casey,Blue,Women's Strawweight
+08/20/2016,Neil Magny,Lorenz Larkin,Blue,Welterweight
+08/20/2016,Colby Covington,Max Griffin,Red,Welterweight
+08/20/2016,Alberto Uda,Marvin Vettori,Blue,Middleweight
+08/06/2016,Yair Rodriguez,Alex Caceres,Red,Featherweight
+08/06/2016,Dennis Bermudez,Rony Jason,Red,Featherweight
+08/06/2016,Thales Leites,Chris Camozzi,Red,Middleweight
+08/06/2016,Santiago Ponzinibbio,Zak Cummings,Red,Welterweight
+08/06/2016,Trevor Smith,Joseph Gigliotti,Red,Middleweight
+08/06/2016,Maryna Moroz,Danielle Taylor,Red,Women's Strawweight
+08/06/2016,Court McGee,Dominique Steele,Red,Welterweight
+08/06/2016,Viktor Pesta,Marcin Tybura,Blue,Heavyweight
+08/06/2016,David Teymur,Jason Novelli,Red,Lightweight
+08/06/2016,Teruto Ishihara,Horacio Gutierrez,Red,Featherweight
+08/06/2016,Cub Swanson,Tatsuya Kawajiri,Red,Featherweight
+08/06/2016,Chase Sherman,Justin Ledet,Blue,Heavyweight
+07/30/2016,Robbie Lawler,Tyron Woodley,Blue,UFC Welterweight Title
+07/30/2016,Rose Namajunas,Karolina Kowalkiewicz,Blue,Women's Strawweight
+07/30/2016,Matt Brown,Jake Ellenberger,Blue,Welterweight
+07/30/2016,Francisco Rivera,Erik Perez,Blue,Bantamweight
+07/30/2016,Ryan Benoit,Fredy Serrano,Red,Flyweight
+07/30/2016,Nikita Krylov,Ed Herman,Red,Light Heavyweight
+07/30/2016,Ross Pearson,Jorge Masvidal,Blue,Welterweight
+07/30/2016,Anthony Hamilton,Damian Grabowski,Red,Heavyweight
+07/30/2016,Wilson Reis,Hector Sandoval,Red,Flyweight
+07/30/2016,Cesar Arzamendia,Damien Brown,Blue,Lightweight
+07/23/2016,Holly Holm,Valentina Shevchenko,Blue,Women's Bantamweight
+07/23/2016,Edson Barboza,Gilbert Melendez,Red,Lightweight
+07/23/2016,Francis Ngannou,Bojan Mihajlovic,Red,Heavyweight
+07/23/2016,Felice Herrig,Kailin Curran,Red,Women's Strawweight
+07/23/2016,Frankie Saenz,Eddie Wineland,Blue,Bantamweight
+07/23/2016,Darren Elkins,Godofredo Pepey,Red,Featherweight
+07/23/2016,Kamaru Usman,Alexander Yakovlev,Red,Welterweight
+07/23/2016,Michel Prazeres,JC Cottrell,Red,Lightweight
+07/23/2016,Alex Oliveira,James Moontasri,Red,Welterweight
+07/23/2016,Jim Alers,Jason Knight,Blue,Featherweight
+07/23/2016,Luis Henrique,Dmitrii Smoliakov,Red,Heavyweight
+07/13/2016,Michael McDonald,John Lineker,Blue,Bantamweight
+07/13/2016,Tony Ferguson,Lando Vannata,Red,Lightweight
+07/13/2016,Tim Boetsch,Josh Samman,Red,Middleweight
+07/13/2016,Aleksei Oleinik,Daniel Omielanczuk,Blue,Heavyweight
+07/13/2016,Kyle Noke,Keita Nakamura,Blue,Welterweight
+07/13/2016,Louis Smolka,Ben Nguyen,Red,Flyweight
+07/13/2016,Lauren Murphy,Katlyn Cerminara,Blue,Women's Bantamweight
+07/13/2016,Eric Spicely,Sam Alvey,Blue,Middleweight
+07/13/2016,Cortney Casey,Cristina Stanciu,Red,Women's Strawweight
+07/13/2016,Scott Holtzman,Cody Pfister,Red,Lightweight
+07/13/2016,Rani Yahya,Matthew Lopez,Red,Bantamweight
+07/13/2016,Devin Clark,Alex Nicholson,Blue,Middleweight
+07/09/2016,Miesha Tate,Amanda Nunes,Blue,UFC Women's Bantamweight Title
+07/09/2016,Daniel Cormier,Anderson Silva,Red,Light Heavyweight
+07/09/2016,Jose Aldo,Frankie Edgar,Red,UFC Interim Featherweight Title
+07/09/2016,Cain Velasquez,Travis Browne,Red,Heavyweight
+07/09/2016,Cat Zingano,Julianna Pena,Blue,Women's Bantamweight
+07/09/2016,Johny Hendricks,Kelvin Gastelum,Blue,Welterweight
+07/09/2016,TJ Dillashaw,Raphael Assuncao,Red,Bantamweight
+07/09/2016,Sage Northcutt,Enrique Marin,Red,Lightweight
+07/09/2016,Diego Sanchez,Joe Lauzon,Blue,Lightweight
+07/09/2016,Gegard Mousasi,Thiago Santos,Red,Middleweight
+07/09/2016,Jim Miller,Takanori Gomi,Red,Lightweight
+07/08/2016,Joanna Jedrzejczyk,Claudia Gadelha,Red,UFC Women's Strawweight Title
+07/08/2016,Andrew Sanchez,Khalil Rountree Jr.,Red,Ultimate Fighter 23 Light Heavyweight Tournament Title
+07/08/2016,Tatiana Suarez,Amanda Cooper,Red,Ultimate Fighter 23 Women's Strawweight Tournament Title
+07/08/2016,Ross Pearson,Will Brooks,Blue,Lightweight
+07/08/2016,Dooho Choi,Thiago Tavares,Red,Featherweight
+07/08/2016,Joaquim Silva,Andrew Holbrook,Red,Lightweight
+07/08/2016,Gray Maynard,Fernando Bruno,Red,Featherweight
+07/08/2016,John Moraga,Matheus Nicolau,Blue,Flyweight
+07/08/2016,Cory Hendricks,Josh Stansbury,Blue,Light Heavyweight
+07/08/2016,Cezar Ferreira,Anthony Smith,Red,Middleweight
+07/08/2016,Jake Matthews,Kevin Lee,Blue,Lightweight
+07/08/2016,Li Jingliang,Anton Zafir,Red,Welterweight
+07/07/2016,Rafael Dos Anjos,Eddie Alvarez,Blue,UFC Lightweight Title
+07/07/2016,Roy Nelson,Derrick Lewis,Blue,Heavyweight
+07/07/2016,Alan Jouban,Belal Muhammad,Red,Welterweight
+07/07/2016,Joe Duffy,Mitch Clarke,Red,Lightweight
+07/07/2016,Mike Pyle,Alberto Mina,Blue,Welterweight
+07/07/2016,John Makdessi,Mehdi Baghdad,Red,Lightweight
+07/07/2016,Anthony Birchak,Dileno Lopes,Red,Bantamweight
+07/07/2016,Russell Doane,Pedro Munhoz,Blue,Bantamweight
+07/07/2016,Felipe Arantes,Jerrod Sanders,Red,Bantamweight
+07/07/2016,Gilbert Burns,Lukasz Sajewski,Red,Lightweight
+07/07/2016,Marco Beltran,Reginaldo Vieira,Red,Bantamweight
+07/07/2016,Vicente Luque,Alvaro Herrera Mendoza,Red,Welterweight
+06/18/2016,Rory MacDonald,Stephen Thompson,Blue,Welterweight
+06/18/2016,Donald Cerrone,Patrick Cote,Red,Welterweight
+06/18/2016,Steve Bosse,Sean O'Connell,Red,Light Heavyweight
+06/18/2016,Olivier Aubin-Mercier,Thibault Gouti,Red,Lightweight
+06/18/2016,Valerie Letourneau,Joanne Wood,Blue,Women's Flyweight
+06/18/2016,Jason Saggo,Leandro Silva,Red,Lightweight
+06/18/2016,Misha Cirkunov,Ion Cutelaba,Red,Light Heavyweight
+06/18/2016,Tamdan McCrory,Krzysztof Jotko,Blue,Middleweight
+06/18/2016,Chris Beal,Joe Soto,Blue,Bantamweight
+06/18/2016,Elias Theodorou,Sam Alvey,Red,Middleweight
+06/18/2016,Randa Markos,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+06/18/2016,Colby Covington,Jonathan Meunier,Red,Welterweight
+06/18/2016,Ali Bagautinov,Geane Herrera,Red,Flyweight
+06/04/2016,Luke Rockhold,Michael Bisping,Blue,UFC Middleweight Title
+06/04/2016,Dominick Cruz,Urijah Faber,Red,UFC Bantamweight Title
+06/04/2016,Max Holloway,Ricardo Lamas,Red,Featherweight
+06/04/2016,Dan Henderson,Hector Lombard,Red,Middleweight
+06/04/2016,Dustin Poirier,Bobby Green,Red,Lightweight
+06/04/2016,Brian Ortega,Clay Guida,Red,Featherweight
+06/04/2016,Beneil Dariush,James Vick,Red,Lightweight
+06/04/2016,Jessica Penne,Jessica Andrade,Blue,Women's Strawweight
+06/04/2016,Cole Miller,Alex Caceres,Blue,Featherweight
+06/04/2016,Sean Strickland,Tom Breese,Red,Welterweight
+06/04/2016,Jonathan Wilson,Henrique da Silva,Blue,Light Heavyweight
+06/04/2016,Marco Polo Reyes,Dong Hyun Ma,Red,Lightweight
+05/29/2016,Thomas Almeida,Cody Garbrandt,Blue,Bantamweight
+05/29/2016,Renan Barao,Jeremy Stephens,Blue,Featherweight
+05/29/2016,Tarec Saffiedine,Rick Story,Blue,Welterweight
+05/29/2016,Chris Camozzi,Vitor Miranda,Red,Middleweight
+05/29/2016,Jorge Masvidal,Lorenz Larkin,Blue,Welterweight
+05/29/2016,Joshua Burkman,Paul Felder,Blue,Lightweight
+05/29/2016,Sara McMann,Jessica Eye,Red,Women's Bantamweight
+05/29/2016,Abel Trujillo,Jordan Rinaldi,Red,Lightweight
+05/29/2016,Jake Collier,Alberto Uda,Red,Middleweight
+05/29/2016,Erik Koch,Shane Campbell,Red,Lightweight
+05/29/2016,Aljamain Sterling,Bryan Caraway,Blue,Bantamweight
+05/29/2016,Chris de la Rocha,Adam Milstead,Blue,Heavyweight
+05/14/2016,Fabricio Werdum,Stipe Miocic,Blue,UFC Heavyweight Title
+05/14/2016,Jacare Souza,Vitor Belfort,Red,Middleweight
+05/14/2016,Cristiane Justino,Leslie Smith,Red,Catch Weight
+05/14/2016,Mauricio Rua,Corey Anderson,Red,Light Heavyweight
+05/14/2016,Warlley Alves,Bryan Barberena,Blue,Welterweight
+05/14/2016,Demian Maia,Matt Brown,Red,Welterweight
+05/14/2016,Thiago Santos,Nate Marquardt,Red,Middleweight
+05/14/2016,Francisco Trinaldo,Yancy Medeiros,Red,Lightweight
+05/14/2016,John Lineker,Rob Font,Red,Bantamweight
+05/14/2016,Rogerio Nogueira,Patrick Cummins,Red,Light Heavyweight
+05/14/2016,Renato Moicano,Zubaira Tukhugov,Red,Featherweight
+05/08/2016,Alistair Overeem,Andrei Arlovski,Red,Heavyweight
+05/08/2016,Antonio Silva,Stefan Struve,Blue,Heavyweight
+05/08/2016,Albert Tumenov,Gunnar Nelson,Blue,Welterweight
+05/08/2016,Germaine de Randamie,Anna Elmose,Red,Women's Bantamweight
+05/08/2016,Nikita Krylov,Francimar Barroso,Red,Light Heavyweight
+05/08/2016,Karolina Kowalkiewicz,Heather Clark,Red,Women's Strawweight
+05/08/2016,Rustam Khabilov,Chris Wade,Red,Lightweight
+05/08/2016,Magnus Cedenblad,Garreth McLellan,Red,Middleweight
+05/08/2016,Jon Tuck,Josh Emmett,Blue,Lightweight
+05/08/2016,Yan Cabral,Reza Madadi,Blue,Lightweight
+05/08/2016,Kyoji Horiguchi,Neil Seery,Red,Flyweight
+05/08/2016,Leon Edwards,Dominic Waters,Red,Welterweight
+05/08/2016,Yuta Sasaki,Willie Gates,Red,Flyweight
+04/23/2016,Jon Jones,Ovince Saint Preux,Red,UFC Interim Light Heavyweight Title
+04/23/2016,Demetrious Johnson,Henry Cejudo,Red,UFC Flyweight Title
+04/23/2016,Anthony Pettis,Edson Barboza,Blue,Lightweight
+04/23/2016,Robert Whittaker,Rafael Natal,Red,Middleweight
+04/23/2016,Yair Rodriguez,Andre Fili,Red,Featherweight
+04/23/2016,Sergio Pettis,Chris Kelades,Red,Flyweight
+04/23/2016,Danny Roberts,Dominique Steele,Red,Welterweight
+04/23/2016,Carla Esparza,Juliana Lima,Red,Women's Strawweight
+04/23/2016,Glaico Franca Moreira,James Vick,Blue,Lightweight
+04/23/2016,Walt Harris,Cody East,Red,Heavyweight
+04/23/2016,Marcos Rogerio de Lima,Clint Hester,Red,Light Heavyweight
+04/23/2016,Efrain Escudero,Kevin Lee,Blue,Lightweight
+04/16/2016,Glover Teixeira,Rashad Evans,Red,Light Heavyweight
+04/16/2016,Rose Namajunas,Tecia Torres,Red,Women's Strawweight
+04/16/2016,Khabib Nurmagomedov,Darrell Horcher,Red,Catch Weight
+04/16/2016,Cub Swanson,Hacran Dias,Red,Featherweight
+04/16/2016,Beneil Dariush,Michael Chiesa,Blue,Lightweight
+04/16/2016,Bethe Correia,Raquel Pennington,Blue,Women's Bantamweight
+04/16/2016,Court McGee,Santiago Ponzinibbio,Blue,Welterweight
+04/16/2016,Randy Brown,Michael Graves,Blue,Welterweight
+04/16/2016,John Dodson,Manvel Gamburyan,Red,Bantamweight
+04/16/2016,Oluwale Bamgbose,Cezar Ferreira,Blue,Middleweight
+04/16/2016,Elizeu Zaleski dos Santos,Omari Akhmedov,Red,Welterweight
+04/10/2016,Ben Rothwell,Junior Dos Santos,Blue,Heavyweight
+04/10/2016,Derrick Lewis,Gabriel Gonzaga,Red,Heavyweight
+04/10/2016,Francis Ngannou,Curtis Blaydes,Red,Heavyweight
+04/10/2016,Timothy Johnson,Marcin Tybura,Red,Heavyweight
+04/10/2016,Igor Pokrajac,Jan Blachowicz,Blue,Light Heavyweight
+04/10/2016,Maryna Moroz,Cristina Stanciu,Red,Women's Strawweight
+04/10/2016,Nicolas Dalby,Zak Cummings,Blue,Welterweight
+04/10/2016,Ian Entwistle,Alejandro Perez,Blue,Bantamweight
+04/10/2016,Mairbek Taisumov,Damir Hadzovic,Red,Lightweight
+04/10/2016,Filip Pejic,Damian Stasiak,Blue,Bantamweight
+04/10/2016,Robert Whiteford,Lucas Martins,Blue,Featherweight
+04/10/2016,Jared Cannonier,Cyril Asker,Red,Heavyweight
+04/10/2016,Alessio Di Chirico,Bojan Velickovic,Blue,Middleweight
+03/19/2016,Mark Hunt,Frank Mir,Red,Heavyweight
+03/19/2016,Hector Lombard,Neil Magny,Blue,Welterweight
+03/19/2016,Jake Matthews,Johnny Case,Red,Lightweight
+03/19/2016,Daniel Kelly,Antonio Carlos Junior,Red,Middleweight
+03/19/2016,James Te Huna,Steve Bosse,Blue,Light Heavyweight
+03/19/2016,Bec Rawlings,Seo Hee Ham,Red,Women's Strawweight
+03/19/2016,Brendan O'Reilly,Alan Jouban,Blue,Welterweight
+03/19/2016,Dan Hooker,Mark Eddiva,Red,Featherweight
+03/19/2016,Leslie Smith,Rin Nakai,Red,Women's Bantamweight
+03/19/2016,Richard Walsh,Viscardi Andrade,Blue,Welterweight
+03/19/2016,Ross Pearson,Chad Laprise,Red,Lightweight
+03/19/2016,Alan Patrick,Damien Brown,Red,Lightweight
+03/05/2016,Conor McGregor,Nate Diaz,Blue,Welterweight
+03/05/2016,Holly Holm,Miesha Tate,Blue,UFC Women's Bantamweight Title
+03/05/2016,Gian Villante,Ilir Latifi,Blue,Light Heavyweight
+03/05/2016,Corey Anderson,Tom Lawlor,Red,Light Heavyweight
+03/05/2016,Amanda Nunes,Valentina Shevchenko,Red,Women's Bantamweight
+03/05/2016,Brandon Thatch,Siyar Bahadurzada,Blue,Welterweight
+03/05/2016,Erick Silva,Nordine Taleb,Blue,Welterweight
+03/05/2016,Vitor Miranda,Marcelo Guimaraes,Red,Middleweight
+03/05/2016,Darren Elkins,Chas Skelly,Red,Featherweight
+03/05/2016,Diego Sanchez,Jim Miller,Red,Lightweight
+03/05/2016,Jason Saggo,Justin Salas,Red,Lightweight
+03/05/2016,Julian Erosa,Teruto Ishihara,Blue,Featherweight
+02/27/2016,Anderson Silva,Michael Bisping,Blue,Middleweight
+02/27/2016,Gegard Mousasi,Thales Leites,Red,Middleweight
+02/27/2016,Tom Breese,Keita Nakamura,Red,Welterweight
+02/27/2016,Francisco Rivera,Brad Pickett,Blue,Bantamweight
+02/27/2016,Mike Wilkinson,Makwan Amirkhani,Blue,Featherweight
+02/27/2016,Davey Grant,Marlon Vera,Red,Bantamweight
+02/27/2016,Scott Askham,Chris Dempsey,Red,Middleweight
+02/27/2016,Arnold Allen,Yaotzin Meza,Red,Featherweight
+02/27/2016,Brad Scott,Krzysztof Jotko,Blue,Middleweight
+02/27/2016,Norman Parke,Rustam Khabilov,Blue,Lightweight
+02/27/2016,Daniel Omielanczuk,Jarjis Danho,Red,Heavyweight
+02/27/2016,Teemu Packalen,Thibault Gouti,Red,Lightweight
+02/27/2016,David Teymur,Martin Svensson,Red,Lightweight
+02/21/2016,Donald Cerrone,Alex Oliveira,Red,Welterweight
+02/21/2016,Derek Brunson,Roan Carneiro,Red,Middleweight
+02/21/2016,Cody Garbrandt,Augusto Mendes,Red,Catch Weight
+02/21/2016,Dennis Bermudez,Tatsuya Kawajiri,Red,Featherweight
+02/21/2016,Chris Camozzi,Joe Riggs,Red,Middleweight
+02/21/2016,James Krause,Shane Campbell,Red,Lightweight
+02/21/2016,Alex Garcia,Sean Strickland,Blue,Welterweight
+02/21/2016,Daniel Sarafian,Oluwale Bamgbose,Blue,Middleweight
+02/21/2016,Anthony Smith,Leonardo Guimaraes,Red,Middleweight
+02/21/2016,Jonavin Webb,Nathan Coy,Blue,Welterweight
+02/21/2016,Marion Reneau,Ashlee Evans-Smith,Blue,Women's Bantamweight
+02/21/2016,Lauren Murphy,Kelly Faszholz,Red,Women's Bantamweight
+02/21/2016,Anthony Hamilton,Shamil Abdurakhimov,Blue,Heavyweight
+02/06/2016,Johny Hendricks,Stephen Thompson,Blue,Welterweight
+02/06/2016,Roy Nelson,Jared Rosholt,Red,Heavyweight
+02/06/2016,Ovince Saint Preux,Rafael Cavalcante,Red,Light Heavyweight
+02/06/2016,Joseph Benavidez,Zach Makovsky,Red,Flyweight
+02/06/2016,Misha Cirkunov,Alex Nicholson,Red,Light Heavyweight
+02/06/2016,Mike Pyle,Sean Spencer,Red,Welterweight
+02/06/2016,Joshua Burkman,KJ Noons,Red,Lightweight
+02/06/2016,Derrick Lewis,Damian Grabowski,Red,Heavyweight
+02/06/2016,Ray Borg,Justin Scoggins,Blue,Flyweight
+02/06/2016,Noad Lahat,Diego Rivas,Blue,Featherweight
+02/06/2016,Mickey Gall,Mike Jackson,Red,Welterweight
+02/06/2016,Artem Lobov,Alex White,Blue,Featherweight
+01/30/2016,Anthony Johnson,Ryan Bader,Red,Light Heavyweight
+01/30/2016,Josh Barnett,Ben Rothwell,Blue,Heavyweight
+01/30/2016,Iuri Alcantara,Jimmie Rivera,Blue,Bantamweight
+01/30/2016,Sage Northcutt,Bryan Barberena,Blue,Welterweight
+01/30/2016,Tarec Saffiedine,Jake Ellenberger,Red,Welterweight
+01/30/2016,Olivier Aubin-Mercier,Diego Ferreira,Blue,Lightweight
+01/30/2016,Rafael Natal,Kevin Casey,Red,Middleweight
+01/30/2016,Dustin Ortiz,Wilson Reis,Blue,Flyweight
+01/30/2016,George Sullivan,Alexander Yakovlev,Blue,Welterweight
+01/30/2016,Alex Caceres,Masio Fullen,Red,Featherweight
+01/30/2016,Matt Dwyer,Randy Brown,Blue,Welterweight
+01/30/2016,Anthony Rocco Martin,Felipe Olivieri,Red,Lightweight
+01/17/2016,TJ Dillashaw,Dominick Cruz,Blue,UFC Bantamweight Title
+01/17/2016,Anthony Pettis,Eddie Alvarez,Blue,Lightweight
+01/17/2016,Travis Browne,Matt Mitrione,Red,Heavyweight
+01/17/2016,Ross Pearson,Francisco Trinaldo,Blue,Lightweight
+01/17/2016,Patrick Cote,Ben Saunders,Red,Welterweight
+01/17/2016,Tim Boetsch,Ed Herman,Blue,Light Heavyweight
+01/17/2016,Chris Wade,Mehdi Baghdad,Red,Lightweight
+01/17/2016,Maximo Blanco,Luke Sanders,Blue,Featherweight
+01/17/2016,Paul Felder,Daron Cruickshank,Red,Lightweight
+01/17/2016,Ilir Latifi,Sean O'Connell,Red,Light Heavyweight
+01/17/2016,Charles Rosa,Kyle Bochniak,Red,Featherweight
+01/17/2016,Rob Font,Joey Gomez,Red,Bantamweight
+01/17/2016,Francimar Barroso,Elvis Mutapcic,Red,Light Heavyweight
+01/02/2016,Robbie Lawler,Carlos Condit,Red,UFC Welterweight Title
+01/02/2016,Stipe Miocic,Andrei Arlovski,Red,Heavyweight
+01/02/2016,Lorenz Larkin,Albert Tumenov,Blue,Welterweight
+01/02/2016,Diego Brandao,Brian Ortega,Blue,Featherweight
+01/02/2016,Abel Trujillo,Tony Sims,Red,Lightweight
+01/02/2016,Michael McDonald,Masanori Kanehara,Red,Bantamweight
+01/02/2016,Kyle Noke,Alex Morono,Blue,Welterweight
+01/02/2016,Justine Kish,Nina Nunes,Red,Women's Strawweight
+01/02/2016,Scott Holtzman,Drew Dober,Blue,Lightweight
+01/02/2016,Dustin Poirier,Joe Duffy,Red,Lightweight
+01/02/2016,Joe Soto,Michinori Tanaka,Blue,Bantamweight
+01/02/2016,Sheldon Westcott,Edgar Garcia,Red,Welterweight
+12/19/2015,Rafael Dos Anjos,Donald Cerrone,Red,UFC Lightweight Title
+12/19/2015,Junior Dos Santos,Alistair Overeem,Blue,Heavyweight
+12/19/2015,Michael Johnson,Nate Diaz,Blue,Lightweight
+12/19/2015,Randa Markos,Karolina Kowalkiewicz,Blue,Women's Strawweight
+12/19/2015,Charles Oliveira,Myles Jury,Red,Featherweight
+12/19/2015,CB Dollaway,Nate Marquardt,Blue,Middleweight
+12/19/2015,Sarah Kaufman,Valentina Shevchenko,Blue,Women's Bantamweight
+12/19/2015,Josh Samman,Tamdan McCrory,Blue,Middleweight
+12/19/2015,Nik Lentz,Danny Castillo,Red,Lightweight
+12/19/2015,Kamaru Usman,Leon Edwards,Red,Welterweight
+12/19/2015,Hayder Hassan,Vicente Luque,Blue,Welterweight
+12/19/2015,Francis Ngannou,Luis Henrique,Red,Heavyweight
+12/12/2015,Jose Aldo,Conor McGregor,Blue,UFC Featherweight Title
+12/12/2015,Chris Weidman,Luke Rockhold,Blue,UFC Middleweight Title
+12/12/2015,Jacare Souza,Yoel Romero,Blue,Middleweight
+12/12/2015,Demian Maia,Gunnar Nelson,Red,Welterweight
+12/12/2015,Max Holloway,Jeremy Stephens,Red,Featherweight
+12/12/2015,Urijah Faber,Frankie Saenz,Red,Bantamweight
+12/12/2015,Tecia Torres,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+12/12/2015,Warlley Alves,Colby Covington,Red,Welterweight
+12/12/2015,Leonardo Santos,Kevin Lee,Red,Lightweight
+12/12/2015,Joe Proctor,Magomed Mustafaev,Blue,Lightweight
+12/12/2015,John Makdessi,Yancy Medeiros,Blue,Lightweight
+12/12/2015,Court McGee,Marcio Alexandre Junior,Red,Welterweight
+12/11/2015,Frankie Edgar,Chad Mendes,Red,Featherweight
+12/11/2015,Artem Lobov,Ryan Hall,Blue,Ultimate Fighter 22 Lightweight Tournament Title
+12/11/2015,Edson Barboza,Tony Ferguson,Blue,Lightweight
+12/11/2015,Joe Lauzon,Evan Dunham,Blue,Lightweight
+12/11/2015,Tatsuya Kawajiri,Jason Knight,Red,Featherweight
+12/11/2015,Julian Erosa,Marcin Wrzosek,Red,Lightweight
+12/11/2015,Gabriel Gonzaga,Konstantin Erokhin,Red,Heavyweight
+12/11/2015,Ryan LaFlare,Mike Pierce,Red,Welterweight
+12/11/2015,Joby Sanchez,Geane Herrera,Blue,Flyweight
+12/11/2015,Chris Gruetzemacher,Abner Lloveras,Red,Lightweight
+12/10/2015,Rose Namajunas,Paige VanZant,Red,Women's Strawweight
+12/10/2015,Jim Miller,Michael Chiesa,Blue,Lightweight
+12/10/2015,Sage Northcutt,Cody Pfister,Red,Lightweight
+12/10/2015,Elias Theodorou,Thiago Santos,Blue,Middleweight
+12/10/2015,Tim Means,John Howard,Red,Welterweight
+12/10/2015,Omari Akhmedov,Sergio Moraes,Blue,Welterweight
+12/10/2015,Aljamain Sterling,Johnny Eduardo,Red,Bantamweight
+12/10/2015,Santiago Ponzinibbio,Andreas Stahl,Red,Welterweight
+12/10/2015,Danny Roberts,Nathan Coy,Red,Welterweight
+12/10/2015,Zubaira Tukhugov,Phillipe Nover,Red,Featherweight
+12/10/2015,Kailin Curran,Emily Kagan,Red,Women's Strawweight
+11/28/2015,Benson Henderson,Jorge Masvidal,Red,Welterweight
+11/28/2015,Dong Hyun Kim,Dominic Waters,Red,Welterweight
+11/28/2015,Yoshihiro Akiyama,Alberto Mina,Blue,Welterweight
+11/28/2015,Dooho Choi,Sam Sicilia,Red,Featherweight
+11/28/2015,Dongi Yang,Jake Collier,Red,Middleweight
+11/28/2015,Yui Chul Nam,Mike de la Torre,Blue,Featherweight
+11/28/2015,Tae Hyun Bang,Leo Kuntz,Red,Lightweight
+11/28/2015,Seo Hee Ham,Cortney Casey,Red,Women's Strawweight
+11/28/2015,Yao Zhikui,Fredy Serrano,Blue,Flyweight
+11/28/2015,Guangyou Ning,Marco Beltran,Blue,Bantamweight
+11/28/2015,Dominique Steele,Dong Hyun Ma,Red,Welterweight
+11/21/2015,Neil Magny,Kelvin Gastelum,Red,Welterweight
+11/21/2015,Ricardo Lamas,Diego Sanchez,Red,Featherweight
+11/21/2015,Jussier Formiga,Henry Cejudo,Blue,Flyweight
+11/21/2015,Erick Montano,Enrique Marin,Red,Ultimate Fighter Latin America 2 Welterweight Tournament Title
+11/21/2015,Horacio Gutierrez,Enrique Barzola,Blue,Ultimate Fighter Latin America 2 Lightweight Tournament Title
+11/21/2015,Efrain Escudero,Leandro Silva,Blue,Lightweight
+11/21/2015,Erik Perez,Taylor Lapilus,Red,Bantamweight
+11/21/2015,Hector Urbina,Bartosz Fabinski,Blue,Welterweight
+11/21/2015,Alejandro Perez,Scott Jorgensen,Red,Bantamweight
+11/21/2015,Gabriel Benitez,Andre Fili,Blue,Featherweight
+11/21/2015,Vernon Ramos Ho,Alvaro Herrera Mendoza,Blue,Welterweight
+11/21/2015,Cesar Arzamendia,Marco Polo Reyes,Blue,Lightweight
+11/21/2015,Valmir Lazaro,Michel Prazeres,Blue,Lightweight
+11/14/2015,Ronda Rousey,Holly Holm,Blue,UFC Women's Bantamweight Title
+11/14/2015,Joanna Jedrzejczyk,Valerie Letourneau,Red,UFC Women's Strawweight Title
+11/14/2015,Mark Hunt,Antonio Silva,Red,Heavyweight
+11/14/2015,Uriah Hall,Robert Whittaker,Blue,Middleweight
+11/14/2015,Stefan Struve,Jared Rosholt,Blue,Heavyweight
+11/14/2015,Jake Matthews,Akbarh Arreola,Red,Lightweight
+11/14/2015,Kyle Noke,Peter Sobotta,Red,Welterweight
+11/14/2015,Anthony Perosh,Gian Villante,Blue,Light Heavyweight
+11/14/2015,Richie Vaculik,Danny Martinez,Blue,Flyweight
+11/14/2015,Daniel Kelly,Steve Montgomery,Red,Middleweight
+11/14/2015,Richard Walsh,Steve Kennedy,Red,Welterweight
+11/14/2015,James Moontasri,Anton Zafir,Red,Welterweight
+11/14/2015,Ben Nguyen,Ryan Benoit,Red,Flyweight
+11/07/2015,Vitor Belfort,Dan Henderson,Red,Middleweight
+11/07/2015,Glover Teixeira,Patrick Cummins,Red,Light Heavyweight
+11/07/2015,Thomas Almeida,Anthony Birchak,Red,Bantamweight
+11/07/2015,Alex Oliveira,Piotr Hallmann,Red,Lightweight
+11/07/2015,Gilbert Burns,Rashid Magomedov,Blue,Lightweight
+11/07/2015,Fabio Maldonado,Corey Anderson,Blue,Light Heavyweight
+11/07/2015,Gleison Tibau,Abel Trujillo,Blue,Lightweight
+11/07/2015,Yan Cabral,Johnny Case,Blue,Lightweight
+11/07/2015,Clay Guida,Thiago Tavares,Blue,Featherweight
+11/07/2015,Edimilson Souza,Chas Skelly,Blue,Featherweight
+11/07/2015,Viscardi Andrade,Gasan Umalatov,Red,Welterweight
+11/07/2015,Pedro Munhoz,Jimmie Rivera,Blue,Bantamweight
+11/07/2015,Bruno Korea,Matheus Nicolau,Blue,Bantamweight
+10/24/2015,Paddy Holohan,Louis Smolka,Blue,Flyweight
+10/24/2015,Norman Parke,Reza Madadi,Red,Lightweight
+10/24/2015,Neil Seery,Jon Delos Reyes,Red,Flyweight
+10/24/2015,Stevie Ray,Mickael Lebout,Red,Lightweight
+10/24/2015,Aisling Daly,Ericka Almeida,Red,Women's Strawweight
+10/24/2015,Scott Askham,Krzysztof Jotko,Blue,Middleweight
+10/24/2015,Cathal Pendred,Tom Breese,Blue,Welterweight
+10/24/2015,Darren Elkins,Robert Whiteford,Red,Featherweight
+10/24/2015,Bubba Bush,Garreth McLellan,Blue,Middleweight
+10/03/2015,Daniel Cormier,Alexander Gustafsson,Red,UFC Light Heavyweight Title
+10/03/2015,Ryan Bader,Rashad Evans,Red,Light Heavyweight
+10/03/2015,Shawn Jordan,Ruslan Magomedov,Blue,Heavyweight
+10/03/2015,Joseph Benavidez,Ali Bagautinov,Red,Flyweight
+10/03/2015,Jessica Eye,Julianna Pena,Blue,Women's Bantamweight
+10/03/2015,Yair Rodriguez,Dan Hooker,Red,Featherweight
+10/03/2015,Alan Jouban,Albert Tumenov,Blue,Welterweight
+10/03/2015,Adriano Martins,Islam Makhachev,Red,Lightweight
+10/03/2015,Rose Namajunas,Angela Hill,Red,Women's Strawweight
+10/03/2015,Francisco Trevino,Sage Northcutt,Blue,Lightweight
+10/03/2015,Chris Cariaso,Sergio Pettis,Blue,Flyweight
+10/03/2015,Derrick Lewis,Viktor Pesta,Red,Heavyweight
+09/26/2015,Josh Barnett,Roy Nelson,Red,Heavyweight
+09/26/2015,Gegard Mousasi,Uriah Hall,Blue,Middleweight
+09/26/2015,Kyoji Horiguchi,Chico Camus,Red,Flyweight
+09/26/2015,Takeya Mizugaki,George Roop,Red,Bantamweight
+09/26/2015,Katsunori Kikuno,Diego Brandao,Blue,Featherweight
+09/26/2015,Keita Nakamura,Li Jingliang,Red,Welterweight
+09/26/2015,Nick Hein,Yusuke Kasuya,Red,Lightweight
+09/26/2015,Naoyuki Kotani,Kajan Johnson,Blue,Lightweight
+09/26/2015,Shinsho Anzai,Roger Zapata,Red,Welterweight
+09/05/2015,Demetrious Johnson,John Dodson,Red,UFC Flyweight Title
+09/05/2015,Andrei Arlovski,Frank Mir,Red,Heavyweight
+09/05/2015,Anthony Johnson,Jimi Manuwa,Red,Light Heavyweight
+09/05/2015,Jan Blachowicz,Corey Anderson,Blue,Light Heavyweight
+09/05/2015,Paige VanZant,Alex Chambers,Red,Women's Strawweight
+09/05/2015,Ross Pearson,Paul Felder,Red,Lightweight
+09/05/2015,Francisco Rivera,John Lineker,Blue,Bantamweight
+09/05/2015,Jessica Andrade,Raquel Pennington,Blue,Women's Bantamweight
+09/05/2015,Clay Collard,Tiago dos Santos e Silva,Blue,Featherweight
+09/05/2015,Joe Riggs,Ron Stallings,Red,Middleweight
+09/05/2015,Joaquim Silva,Nazareno Malegarie,Red,Lightweight
+08/23/2015,Max Holloway,Charles Oliveira,Red,Featherweight
+08/23/2015,Neil Magny,Erick Silva,Red,Welterweight
+08/23/2015,Patrick Cote,Joshua Burkman,Red,Welterweight
+08/23/2015,Chad Laprise,Francisco Trinaldo,Blue,Lightweight
+08/23/2015,Olivier Aubin-Mercier,Tony Sims,Red,Lightweight
+08/23/2015,Maryna Moroz,Valerie Letourneau,Blue,Women's Strawweight
+08/23/2015,Sam Stout,Frankie Perez,Blue,Lightweight
+08/23/2015,Yves Jabouin,Felipe Arantes,Blue,Bantamweight
+08/23/2015,Marcos Rogerio de Lima,Nikita Krylov,Blue,Light Heavyweight
+08/23/2015,Chris Kelades,Chris Beal,Red,Flyweight
+08/23/2015,Shane Campbell,Elias Silverio,Red,Lightweight
+08/23/2015,Misha Cirkunov,Daniel Jolly,Red,Light Heavyweight
+08/08/2015,Glover Teixeira,Ovince Saint Preux,Red,Light Heavyweight
+08/08/2015,Michael Johnson,Beneil Dariush,Blue,Lightweight
+08/08/2015,Derek Brunson,Sam Alvey,Red,Middleweight
+08/08/2015,Jared Rosholt,Timothy Johnson,Red,Heavyweight
+08/08/2015,Sara McMann,Amanda Nunes,Blue,Women's Bantamweight
+08/08/2015,Ray Borg,Geane Herrera,Red,Flyweight
+08/08/2015,Uriah Hall,Oluwale Bamgbose,Red,Middleweight
+08/08/2015,Chris Camozzi,Tom Watson,Red,Middleweight
+08/08/2015,Dustin Ortiz,Willie Gates,Red,Flyweight
+08/08/2015,Frankie Saenz,Sirwan Kakai,Red,Bantamweight
+08/08/2015,Chris Dempsey,Jonathan Wilson,Blue,Light Heavyweight
+08/08/2015,Marlon Vera,Roman Salazar,Red,Bantamweight
+08/08/2015,Anthony Christodoulou,Scott Holtzman,Blue,Lightweight
+08/01/2015,Ronda Rousey,Bethe Correia,Red,UFC Women's Bantamweight Title
+08/01/2015,Mauricio Rua,Rogerio Nogueira,Red,Light Heavyweight
+08/01/2015,Glaico Franca Moreira,Fernando Bruno,Red,Ultimate Fighter Brazil 4 Lightweight Tournament Title
+08/01/2015,Reginaldo Vieira,Dileno Lopes,Red,Ultimate Fighter Brazil 4 Bantamweight Tournament Title
+08/01/2015,Stefan Struve,Antonio Rodrigo Nogueira,Red,Heavyweight
+08/01/2015,Antonio Silva,Soa Palelei,Red,Heavyweight
+08/01/2015,Claudia Gadelha,Jessica Aguilar,Red,Women's Strawweight
+08/01/2015,Demian Maia,Neil Magny,Red,Welterweight
+08/01/2015,Rafael Cavalcante,Patrick Cummins,Blue,Light Heavyweight
+08/01/2015,Warlley Alves,Nordine Taleb,Red,Welterweight
+08/01/2015,Iuri Alcantara,Leandro Issa,Red,Bantamweight
+08/01/2015,Vitor Miranda,Clint Hester,Red,Middleweight
+08/01/2015,Hugo Viana,Guido Cannetti,Blue,Bantamweight
+07/25/2015,TJ Dillashaw,Renan Barao,Red,UFC Bantamweight Title
+07/25/2015,Miesha Tate,Jessica Eye,Red,Women's Bantamweight
+07/25/2015,Edson Barboza,Paul Felder,Red,Lightweight
+07/25/2015,Joe Lauzon,Takanori Gomi,Red,Lightweight
+07/25/2015,Gian Villante,Tom Lawlor,Blue,Light Heavyweight
+07/25/2015,Jim Miller,Danny Castillo,Red,Lightweight
+07/25/2015,Kenny Robertson,Ben Saunders,Blue,Welterweight
+07/25/2015,Eddie Wineland,Bryan Caraway,Blue,Bantamweight
+07/25/2015,Daron Cruickshank,James Krause,Blue,Lightweight
+07/25/2015,Ramsey Nijem,Andrew Holbrook,Blue,Lightweight
+07/25/2015,Jessamyn Duke,Elizabeth Phillips,Blue,Women's Bantamweight
+07/25/2015,Zak Cummings,Dominique Steele,Red,Middleweight
+07/18/2015,Michael Bisping,Thales Leites,Red,Middleweight
+07/18/2015,Ross Pearson,Evan Dunham,Blue,Lightweight
+07/18/2015,Joe Duffy,Ivan Jorge,Red,Lightweight
+07/18/2015,Joanne Wood,Cortney Casey,Red,Women's Strawweight
+07/18/2015,Leon Edwards,Pawel Pawlak,Red,Welterweight
+07/18/2015,Stevie Ray,Leonardo Mafra,Red,Lightweight
+07/18/2015,Paddy Holohan,Vaughan Lee,Red,Flyweight
+07/18/2015,Ilir Latifi,Hans Stringer,Red,Light Heavyweight
+07/18/2015,Mickael Lebout,Teemu Packalen,Red,Lightweight
+07/18/2015,Robert Whiteford,Paul Redmond,Red,Featherweight
+07/18/2015,Marcus Brimage,Jimmie Rivera,Blue,Bantamweight
+07/18/2015,Daniel Omielanczuk,Chris de la Rocha,Red,Heavyweight
+07/15/2015,Frank Mir,Todd Duffee,Red,Heavyweight
+07/15/2015,Josh Thomson,Tony Ferguson,Blue,Lightweight
+07/15/2015,Holly Holm,Marion Reneau,Red,Women's Bantamweight
+07/15/2015,Scott Jorgensen,Manvel Gamburyan,Blue,Bantamweight
+07/15/2015,Kevin Lee,James Moontasri,Red,Lightweight
+07/15/2015,Alan Jouban,Matt Dwyer,Red,Welterweight
+07/15/2015,Sam Sicilia,Yaotzin Meza,Red,Featherweight
+07/15/2015,Jessica Andrade,Sarah Moras,Red,Women's Bantamweight
+07/15/2015,Rani Yahya,Masanori Kanehara,Red,Bantamweight
+07/15/2015,Igor Araujo,Sean Strickland,Blue,Welterweight
+07/15/2015,Kevin Casey,Ildemar Alcantara,Red,Middleweight
+07/15/2015,Andrew Craig,Lyman Good,Blue,Welterweight
+07/12/2015,Jake Ellenberger,Stephen Thompson,Blue,Welterweight
+07/12/2015,Kamaru Usman,Hayder Hassan,Red,Ultimate Fighter 21 Welterweight Tournament Title
+07/12/2015,Michael Graves,Vicente Luque,Red,Welterweight
+07/12/2015,Jorge Masvidal,Cezar Ferreira,Red,Welterweight
+07/12/2015,Angela Magana,Michelle Waterson-Gomez,Blue,Women's Strawweight
+07/12/2015,Maximo Blanco,Mike de la Torre,Red,Featherweight
+07/12/2015,Josh Samman,Caio Magalhaes,Red,Middleweight
+07/12/2015,Russell Doane,Jerrod Sanders,Blue,Bantamweight
+07/12/2015,Dan Miller,Trevor Smith,Blue,Middleweight
+07/12/2015,George Sullivan,Dominic Waters,Red,Welterweight
+07/12/2015,Darrell Montague,Willie Gates,Blue,Flyweight
+07/11/2015,Chad Mendes,Conor McGregor,Blue,UFC Interim Featherweight Title
+07/11/2015,Robbie Lawler,Rory MacDonald,Red,UFC Welterweight Title
+07/11/2015,Dennis Bermudez,Jeremy Stephens,Blue,Featherweight
+07/11/2015,Gunnar Nelson,Brandon Thatch,Red,Welterweight
+07/11/2015,Brad Pickett,Thomas Almeida,Blue,Bantamweight
+07/11/2015,Matt Brown,Tim Means,Red,Welterweight
+07/11/2015,Mike Swick,Alex Garcia,Blue,Welterweight
+07/11/2015,Cathal Pendred,John Howard,Blue,Welterweight
+07/11/2015,Cody Garbrandt,Henry Briones,Red,Bantamweight
+07/11/2015,Neil Seery,Louis Smolka,Blue,Flyweight
+07/11/2015,Yosdenis Cedeno,Cody Pfister,Blue,Lightweight
+06/27/2015,Lyoto Machida,Yoel Romero,Blue,Middleweight
+06/27/2015,Santiago Ponzinibbio,Lorenz Larkin,Blue,Welterweight
+06/27/2015,Antonio Carlos Junior,Eddie Gordon,Red,Middleweight
+06/27/2015,Thiago Santos,Steve Bosse,Red,Middleweight
+06/27/2015,Hacran Dias,Levan Makashvili,Red,Featherweight
+06/27/2015,Alex Oliveira,Joe Merritt,Red,Welterweight
+06/27/2015,Leandro Silva,Lewis Gonzalez,Red,Welterweight
+06/27/2015,Steve Montgomery,Tony Sims,Blue,Welterweight
+06/27/2015,Danny Martinez,Sirwan Kakai,Blue,Bantamweight
+06/20/2015,Joanna Jedrzejczyk,Jessica Penne,Red,UFC Women's Strawweight Title
+06/20/2015,Dennis Siver,Tatsuya Kawajiri,Blue,Featherweight
+06/20/2015,Peter Sobotta,Steve Kennedy,Red,Welterweight
+06/20/2015,Nick Hein,Lukasz Sajewski,Red,Lightweight
+06/20/2015,Makwan Amirkhani,Masio Fullen,Red,Featherweight
+06/20/2015,Mairbek Taisumov,Alan Patrick,Red,Lightweight
+06/20/2015,Alan Omer,Arnold Allen,Blue,Featherweight
+06/20/2015,Niklas Backstrom,Noad Lahat,Blue,Featherweight
+06/20/2015,Scott Askham,Antonio Dos Santos,Red,Middleweight
+06/20/2015,Piotr Hallmann,Magomed Mustafaev,Blue,Lightweight
+06/20/2015,Taylor Lapilus,Yuta Sasaki,Red,Bantamweight
+06/13/2015,Cain Velasquez,Fabricio Werdum,Blue,UFC Heavyweight Title
+06/13/2015,Gilbert Melendez,Eddie Alvarez,Blue,Lightweight
+06/13/2015,Kelvin Gastelum,Nate Marquardt,Red,Middleweight
+06/13/2015,Yair Rodriguez,Charles Rosa,Red,Featherweight
+06/13/2015,Tecia Torres,Angela Hill,Red,Women's Strawweight
+06/13/2015,Henry Cejudo,Chico Camus,Red,Flyweight
+06/13/2015,Efrain Escudero,Drew Dober,Red,Lightweight
+06/13/2015,Alejandro Perez,Patrick Williams,Blue,Bantamweight
+06/13/2015,Francisco Trevino,Johnny Case,Blue,Lightweight
+06/13/2015,Augusto Montano,Cathal Pendred,Blue,Welterweight
+06/13/2015,Gabriel Benitez,Clay Collard,Red,Featherweight
+06/06/2015,Tim Boetsch,Dan Henderson,Blue,Middleweight
+06/06/2015,Ben Rothwell,Matt Mitrione,Red,Heavyweight
+06/06/2015,Dustin Poirier,Yancy Medeiros,Red,Lightweight
+06/06/2015,Thiago Tavares,Brian Ortega,Blue,Featherweight
+06/06/2015,Joe Soto,Anthony Birchak,Blue,Bantamweight
+06/06/2015,Francisco Rivera,Alex Caceres,Red,Bantamweight
+06/06/2015,Shawn Jordan,Derrick Lewis,Red,Heavyweight
+06/06/2015,Brian Ebersole,Omari Akhmedov,Blue,Welterweight
+06/06/2015,Chris Wade,Christos Giagos,Red,Lightweight
+06/06/2015,Joe Proctor,Justin Edwards,Red,Lightweight
+06/06/2015,Ricardo Abreu,Jake Collier,Blue,Middleweight
+06/06/2015,Jose Quinonez,Leonardo Morales,Red,Bantamweight
+05/30/2015,Carlos Condit,Thiago Alves,Red,Welterweight
+05/30/2015,Nik Lentz,Charles Oliveira,Blue,Featherweight
+05/30/2015,KJ Noons,Alex Oliveira,Blue,Welterweight
+05/30/2015,Francimar Barroso,Ryan Jimmo,Red,Light Heavyweight
+05/30/2015,Francisco Trinaldo,Norman Parke,Red,Lightweight
+05/30/2015,Wendell Oliveira Marques,Darren Till,Blue,Welterweight
+05/30/2015,Jussier Formiga,Wilson Reis,Red,Flyweight
+05/30/2015,Elizeu Zaleski dos Santos,Nicolas Dalby,Blue,Welterweight
+05/30/2015,Lucas Martins,Mirsad Bektic,Blue,Featherweight
+05/30/2015,Juliana Lima,Ericka Almeida,Red,Women's Strawweight
+05/30/2015,Luiz Dutra,Tom Breese,Blue,Welterweight
+05/23/2015,Anthony Johnson,Daniel Cormier,Blue,UFC Light Heavyweight Title
+05/23/2015,Chris Weidman,Vitor Belfort,Red,UFC Middleweight Title
+05/23/2015,Donald Cerrone,John Makdessi,Red,Lightweight
+05/23/2015,Travis Browne,Andrei Arlovski,Blue,Heavyweight
+05/23/2015,Joseph Benavidez,John Moraga,Red,Flyweight
+05/23/2015,John Dodson,Zach Makovsky,Red,Flyweight
+05/23/2015,Dong Hyun Kim,Joshua Burkman,Red,Welterweight
+05/23/2015,Uriah Hall,Rafael Natal,Blue,Middleweight
+05/23/2015,Mike Pyle,Colby Covington,Blue,Welterweight
+05/23/2015,Islam Makhachev,Leo Kuntz,Red,Lightweight
+05/23/2015,Justin Scoggins,Josh Sampo,Red,Flyweight
+05/16/2015,Frankie Edgar,Urijah Faber,Red,Featherweight
+05/16/2015,Gegard Mousasi,Constantinos Philippou,Red,Middleweight
+05/16/2015,Mark Munoz,Luke Barnatt,Red,Middleweight
+05/16/2015,Hyun Gyu Lim,Neil Magny,Blue,Welterweight
+05/16/2015,Phillipe Nover,Yui Chul Nam,Red,Featherweight
+05/16/2015,Mark Eddiva,Levan Makashvili,Blue,Featherweight
+05/16/2015,Tae Hyun Bang,Jon Tuck,Blue,Lightweight
+05/16/2015,Zhang Lipeng,Kajan Johnson,Blue,Lightweight
+05/16/2015,Li Jingliang,Dhiego Lima,Red,Welterweight
+05/16/2015,Guangyou Ning,Royston Wee,Red,Bantamweight
+05/16/2015,Roldan Sangcha'an,Jon Delos Reyes,Blue,Flyweight
+05/16/2015,Nolan Ticman,Yao Zhikui,Blue,Flyweight
+05/09/2015,Stipe Miocic,Mark Hunt,Red,Heavyweight
+05/09/2015,Brad Tavares,Robert Whittaker,Blue,Middleweight
+05/09/2015,Anthony Perosh,Sean O'Connell,Blue,Light Heavyweight
+05/09/2015,Jake Matthews,James Vick,Blue,Lightweight
+05/09/2015,Hatsu Hioki,Dan Hooker,Blue,Featherweight
+05/09/2015,Kyle Noke,Jonavin Webb,Red,Welterweight
+05/09/2015,Daniel Kelly,Sam Alvey,Blue,Middleweight
+05/09/2015,Bec Rawlings,Lisa Ellis,Red,Women's Strawweight
+05/09/2015,Dylan Andrews,Brad Scott,Blue,Middleweight
+05/09/2015,Alex Chambers,Kailin Curran,Red,Women's Strawweight
+05/09/2015,Vik Grujic,Brendan O'Reilly,Blue,Welterweight
+05/09/2015,Alptekin Ozkilic,Ben Nguyen,Blue,Flyweight
+04/25/2015,Demetrious Johnson,Kyoji Horiguchi,Red,UFC Flyweight Title
+04/25/2015,Quinton Jackson,Fabio Maldonado,Red,Catch Weight
+04/25/2015,Michael Bisping,CB Dollaway,Red,Middleweight
+04/25/2015,John Makdessi,Shane Campbell,Red,Catch Weight
+04/25/2015,Yves Jabouin,Thomas Almeida,Blue,Bantamweight
+04/25/2015,Patrick Cote,Joe Riggs,Red,Welterweight
+04/25/2015,Alexis Davis,Sarah Kaufman,Red,Women's Bantamweight
+04/25/2015,Chad Laprise,Bryan Barberena,Red,Lightweight
+04/25/2015,Olivier Aubin-Mercier,David Michaud,Red,Lightweight
+04/25/2015,Nordine Taleb,Chris Clements,Red,Welterweight
+04/25/2015,Jessica Rakoczy,Valerie Letourneau,Blue,Women's Strawweight
+04/25/2015,Randa Markos,Aisling Daly,Red,Women's Strawweight
+04/18/2015,Lyoto Machida,Luke Rockhold,Blue,Middleweight
+04/18/2015,Jacare Souza,Chris Camozzi,Red,Middleweight
+04/18/2015,Cub Swanson,Max Holloway,Blue,Featherweight
+04/18/2015,Felice Herrig,Paige VanZant,Blue,Women's Strawweight
+04/18/2015,Jim Miller,Beneil Dariush,Blue,Lightweight
+04/18/2015,Ovince Saint Preux,Patrick Cummins,Red,Light Heavyweight
+04/18/2015,Corey Anderson,Gian Villante,Blue,Light Heavyweight
+04/18/2015,Takeya Mizugaki,Aljamain Sterling,Blue,Bantamweight
+04/18/2015,George Sullivan,Tim Means,Blue,Welterweight
+04/18/2015,Diego Brandao,Jimy Hettes,Red,Featherweight
+04/18/2015,Eddie Gordon,Chris Dempsey,Blue,Middleweight
+04/11/2015,Gabriel Gonzaga,Mirko Filipovic,Blue,Heavyweight
+04/11/2015,Jimi Manuwa,Jan Blachowicz,Red,Light Heavyweight
+04/11/2015,Pawel Pawlak,Sheldon Westcott,Red,Welterweight
+04/11/2015,Joanne Wood,Maryna Moroz,Blue,Women's Strawweight
+04/11/2015,Seth Baczynski,Leon Edwards,Blue,Welterweight
+04/11/2015,Bartosz Fabinski,Garreth McLellan,Red,Middleweight
+04/11/2015,Sergio Moraes,Mickael Lebout,Red,Welterweight
+04/11/2015,Damian Stasiak,Yaotzin Meza,Blue,Featherweight
+04/11/2015,Daniel Omielanczuk,Anthony Hamilton,Blue,Heavyweight
+04/11/2015,Izabela Badurek,Aleksandra Albu,Blue,Women's Strawweight
+04/11/2015,Marcin Bandel,Stevie Ray,Blue,Lightweight
+04/11/2015,Taylor Lapilus,Rocky Lee,Red,Featherweight
+04/04/2015,Chad Mendes,Ricardo Lamas,Red,Featherweight
+04/04/2015,Jorge Masvidal,Al Iaquinta,Blue,Lightweight
+04/04/2015,Michael Chiesa,Mitch Clarke,Red,Lightweight
+04/04/2015,Julianna Pena,Milana Dudieva,Red,Women's Bantamweight
+04/04/2015,Clay Guida,Robert Peralta,Red,Featherweight
+04/04/2015,Dustin Poirier,Diego Ferreira,Red,Lightweight
+04/04/2015,Liz Carmouche,Lauren Murphy,Red,Women's Bantamweight
+04/04/2015,Gray Maynard,Alexander Yakovlev,Blue,Lightweight
+04/04/2015,Shamil Abdurakhimov,Timothy Johnson,Blue,Heavyweight
+04/04/2015,Ron Stallings,Justin Jones,Red,Middleweight
+03/21/2015,Demian Maia,Ryan LaFlare,Red,Welterweight
+03/21/2015,Erick Silva,Josh Koscheck,Red,Welterweight
+03/21/2015,Leonardo Santos,Anthony Rocco Martin,Red,Lightweight
+03/21/2015,Amanda Nunes,Shayna Baszler,Red,Women's Bantamweight
+03/21/2015,Gilbert Burns,Alex Oliveira,Red,Lightweight
+03/21/2015,Godofredo Pepey,Andre Fili,Red,Featherweight
+03/21/2015,Francisco Trinaldo,Akbarh Arreola,Red,Lightweight
+03/21/2015,Edimilson Souza,Katsunori Kikuno,Red,Featherweight
+03/21/2015,Leonardo Mafra,Cain Carrizosa,Red,Lightweight
+03/21/2015,Jorge de Oliveira,Christos Giagos,Blue,Lightweight
+03/21/2015,Bentley Syler,Fredy Serrano,Blue,Flyweight
+03/14/2015,Anthony Pettis,Rafael Dos Anjos,Blue,UFC Lightweight Title
+03/14/2015,Carla Esparza,Joanna Jedrzejczyk,Blue,UFC Women's Strawweight Title
+03/14/2015,Johny Hendricks,Matt Brown,Red,Welterweight
+03/14/2015,Roy Nelson,Alistair Overeem,Blue,Heavyweight
+03/14/2015,Chris Cariaso,Henry Cejudo,Blue,Flyweight
+03/14/2015,Ross Pearson,Sam Stout,Red,Lightweight
+03/14/2015,Elias Theodorou,Roger Narvaez,Red,Middleweight
+03/14/2015,Daron Cruickshank,Beneil Dariush,Blue,Lightweight
+03/14/2015,Jared Rosholt,Josh Copeland,Red,Heavyweight
+03/14/2015,Sergio Pettis,Ryan Benoit,Blue,Flyweight
+03/14/2015,Jake Lindsey,Joe Duffy,Blue,Lightweight
+03/14/2015,Larissa Pacheco,Germaine de Randamie,Blue,Women's Bantamweight
+02/28/2015,Ronda Rousey,Cat Zingano,Red,UFC Women's Bantamweight Title
+02/28/2015,Raquel Pennington,Holly Holm,Blue,Women's Bantamweight
+02/28/2015,Jake Ellenberger,Josh Koscheck,Red,Welterweight
+02/28/2015,Alan Jouban,Richard Walsh,Red,Welterweight
+02/28/2015,Tony Ferguson,Gleison Tibau,Red,Lightweight
+02/28/2015,Mark Munoz,Roan Carneiro,Blue,Middleweight
+02/28/2015,Dhiego Lima,Tim Means,Blue,Welterweight
+02/28/2015,Derrick Lewis,Ruan Potts,Red,Heavyweight
+02/28/2015,James Krause,Valmir Lazaro,Blue,Lightweight
+02/28/2015,Masio Fullen,Alex Torres,Red,Featherweight
+02/22/2015,Antonio Silva,Frank Mir,Blue,Heavyweight
+02/22/2015,Edson Barboza,Michael Johnson,Blue,Lightweight
+02/22/2015,Cezar Ferreira,Sam Alvey,Blue,Middleweight
+02/22/2015,Rustam Khabilov,Adriano Martins,Blue,Lightweight
+02/22/2015,Iuri Alcantara,Frankie Saenz,Blue,Bantamweight
+02/22/2015,Santiago Ponzinibbio,Sean Strickland,Red,Welterweight
+02/22/2015,Jessica Andrade,Marion Reneau,Blue,Women's Bantamweight
+02/22/2015,William Macario,Matt Dwyer,Blue,Welterweight
+02/22/2015,Tiago dos Santos e Silva,Mike de la Torre,Blue,Featherweight
+02/22/2015,Douglas Silva de Andrade,Cody Gibson,Red,Bantamweight
+02/22/2015,Ivan Jorge,Josh Shockley,Red,Lightweight
+02/14/2015,Benson Henderson,Brandon Thatch,Red,Welterweight
+02/14/2015,Max Holloway,Cole Miller,Red,Featherweight
+02/14/2015,Neil Magny,Kiichi Kunimoto,Red,Welterweight
+02/14/2015,Daniel Kelly,Patrick Walsh,Red,Middleweight
+02/14/2015,Michel Prazeres,Kevin Lee,Blue,Lightweight
+02/14/2015,Ray Borg,Chris Kelades,Red,Flyweight
+02/14/2015,Efrain Escudero,Rodrigo de Lima,Red,Lightweight
+02/14/2015,Chas Skelly,Jim Alers,Red,Featherweight
+02/14/2015,Zach Makovsky,Tim Elliott,Red,Flyweight
+02/14/2015,James Moontasri,Cody Pfister,Red,Lightweight
+01/31/2015,Tyron Woodley,Kelvin Gastelum,Red,Welterweight
+01/31/2015,Joe Lauzon,Al Iaquinta,Blue,Lightweight
+01/31/2015,Thales Leites,Tim Boetsch,Red,Middleweight
+01/31/2015,Jordan Mein,Thiago Alves,Blue,Welterweight
+01/31/2015,Miesha Tate,Sara McMann,Red,Women's Bantamweight
+01/31/2015,Ed Herman,Derek Brunson,Blue,Middleweight
+01/31/2015,Ian McCall,John Lineker,Blue,Flyweight
+01/31/2015,Rafael Natal,Tom Watson,Red,Middleweight
+01/31/2015,Richardson Moreira,Ildemar Alcantara,Blue,Middleweight
+01/31/2015,Thiago Santos,Andy Enz,Red,Middleweight
+01/24/2015,Alexander Gustafsson,Anthony Johnson,Blue,Light Heavyweight
+01/24/2015,Dan Henderson,Gegard Mousasi,Blue,Middleweight
+01/24/2015,Phil Davis,Ryan Bader,Blue,Light Heavyweight
+01/24/2015,Akira Corassani,Sam Sicilia,Blue,Featherweight
+01/24/2015,Nicholas Musoke,Albert Tumenov,Blue,Welterweight
+01/24/2015,Kenny Robertson,Sultan Aliev,Red,Welterweight
+01/24/2015,Andy Ogle,Makwan Amirkhani,Blue,Featherweight
+01/24/2015,Nikita Krylov,Stanislav Nedkov,Red,Light Heavyweight
+01/24/2015,Mairbek Taisumov,Anthony Christodoulou,Red,Lightweight
+01/24/2015,Mirsad Bektic,Paul Redmond,Red,Featherweight
+01/24/2015,Viktor Pesta,Konstantin Erokhin,Red,Heavyweight
+01/24/2015,Neil Seery,Chris Beal,Red,Flyweight
+01/18/2015,Conor McGregor,Dennis Siver,Red,Featherweight
+01/18/2015,Donald Cerrone,Benson Henderson,Red,Lightweight
+01/18/2015,Uriah Hall,Ron Stallings,Red,Middleweight
+01/18/2015,Norman Parke,Gleison Tibau,Blue,Lightweight
+01/18/2015,Cathal Pendred,Sean Spencer,Red,Welterweight
+01/18/2015,John Howard,Lorenz Larkin,Blue,Welterweight
+01/18/2015,Zhang Lipeng,Chris Wade,Blue,Lightweight
+01/18/2015,Paddy Holohan,Shane Howell,Red,Flyweight
+01/18/2015,Johnny Case,Frankie Perez,Red,Lightweight
+01/18/2015,Charles Rosa,Sean Soriano,Red,Featherweight
+01/18/2015,Matt Van Buren,Sean O'Connell,Blue,Light Heavyweight
+01/18/2015,Tateki Matsuda,Joby Sanchez,Blue,Flyweight
+01/03/2015,Jon Jones,Daniel Cormier,Red,UFC Light Heavyweight Title
+01/03/2015,Donald Cerrone,Myles Jury,Red,Lightweight
+01/03/2015,Brad Tavares,Nate Marquardt,Red,Middleweight
+01/03/2015,Kyoji Horiguchi,Louis Gaudinot,Red,Flyweight
+01/03/2015,Danny Castillo,Paul Felder,Blue,Lightweight
+01/03/2015,Marcus Brimage,Cody Garbrandt,Blue,Bantamweight
+01/03/2015,Shawn Jordan,Jared Cannonier,Red,Heavyweight
+01/03/2015,Evan Dunham,Rodrigo Damm,Red,Lightweight
+01/03/2015,Omari Akhmedov,Mats Nilsson,Red,Welterweight
+01/03/2015,Alexis Dufresne,Marion Reneau,Blue,Women's Bantamweight
+12/20/2014,Lyoto Machida,CB Dollaway,Red,Middleweight
+12/20/2014,Renan Barao,Mitch Gagnon,Red,Bantamweight
+12/20/2014,Antonio Carlos Junior,Patrick Cummins,Blue,Light Heavyweight
+12/20/2014,Elias Silverio,Rashid Magomedov,Blue,Lightweight
+12/20/2014,Erick Silva,Mike Rhodes,Red,Welterweight
+12/20/2014,Daniel Sarafian,Antonio Dos Santos,Red,Middleweight
+12/20/2014,Marcos Rogerio de Lima,Igor Pokrajac,Red,Light Heavyweight
+12/20/2014,Tom Niinimaki,Renato Moicano,Blue,Featherweight
+12/20/2014,Darren Elkins,Hacran Dias,Blue,Featherweight
+12/20/2014,Leandro Issa,Yuta Sasaki,Red,Bantamweight
+12/20/2014,Marcio Alexandre Junior,Tim Means,Blue,Welterweight
+12/20/2014,Vitor Miranda,Jake Collier,Red,Middleweight
+12/13/2014,Junior Dos Santos,Stipe Miocic,Red,Heavyweight
+12/13/2014,Rafael Dos Anjos,Nate Diaz,Red,Lightweight
+12/13/2014,Alistair Overeem,Stefan Struve,Red,Heavyweight
+12/13/2014,Gabriel Gonzaga,Matt Mitrione,Blue,Heavyweight
+12/13/2014,Claudia Gadelha,Joanna Jedrzejczyk,Blue,Women's Strawweight
+12/13/2014,John Moraga,Willie Gates,Red,Flyweight
+12/13/2014,Joe Riggs,Ben Saunders,Blue,Welterweight
+12/13/2014,Jamie Varner,Drew Dober,Blue,Lightweight
+12/13/2014,Joe Ellenberger,Bryan Barberena,Blue,Lightweight
+12/13/2014,David Michaud,Garett Whiteley,Red,Lightweight
+12/13/2014,Henry Cejudo,Dustin Kimura,Red,Bantamweight
+12/13/2014,Anthony Birchak,Ian Entwistle,Blue,Bantamweight
+12/12/2014,Carla Esparza,Rose Namajunas,Red,UFC Women's Strawweight Title
+12/12/2014,Jeremy Stephens,Charles Oliveira,Blue,Featherweight
+12/12/2014,Joe Proctor,Yancy Medeiros,Blue,Lightweight
+12/12/2014,Jessica Penne,Randa Markos,Red,Women's Strawweight
+12/12/2014,Felice Herrig,Lisa Ellis,Red,Women's Strawweight
+12/12/2014,Bec Rawlings,Heather Clark,Blue,Women's Strawweight
+12/12/2014,Joanne Wood,Seo Hee Ham,Red,Women's Strawweight
+12/12/2014,Tecia Torres,Angela Magana,Red,Women's Strawweight
+12/12/2014,Aisling Daly,Alex Chambers,Red,Women's Strawweight
+12/12/2014,Emily Kagan,Angela Hill,Blue,Women's Strawweight
+12/06/2014,Johny Hendricks,Robbie Lawler,Blue,UFC Welterweight Title
+12/06/2014,Anthony Pettis,Gilbert Melendez,Red,UFC Lightweight Title
+12/06/2014,Travis Browne,Brendan Schaub,Red,Heavyweight
+12/06/2014,Todd Duffee,Anthony Hamilton,Red,Heavyweight
+12/06/2014,Tony Ferguson,Abel Trujillo,Red,Lightweight
+12/06/2014,Urijah Faber,Francisco Rivera,Red,Bantamweight
+12/06/2014,Eddie Gordon,Josh Samman,Blue,Middleweight
+12/06/2014,Corey Anderson,Justin Jones,Red,Light Heavyweight
+12/06/2014,Raquel Pennington,Ashlee Evans-Smith,Red,Women's Bantamweight
+12/06/2014,Sergio Pettis,Matt Hobar,Red,Bantamweight
+12/06/2014,Alex White,Clay Collard,Blue,Featherweight
+11/22/2014,Frankie Edgar,Cub Swanson,Red,Featherweight
+11/22/2014,Bobby Green,Edson Barboza,Blue,Lightweight
+11/22/2014,Brad Pickett,Chico Camus,Blue,Flyweight
+11/22/2014,Jared Rosholt,Aleksei Oleinik,Blue,Heavyweight
+11/22/2014,Joseph Benavidez,Dustin Ortiz,Red,Flyweight
+11/22/2014,Matt Wiman,Isaac Vallie-Flagg,Red,Lightweight
+11/22/2014,Ruslan Magomedov,Josh Copeland,Red,Heavyweight
+11/22/2014,Luke Barnatt,Roger Narvaez,Blue,Middleweight
+11/22/2014,James Vick,Nick Hein,Red,Lightweight
+11/22/2014,Yves Edwards,Akbarh Arreola,Blue,Lightweight
+11/22/2014,Paige VanZant,Kailin Curran,Red,Women's Strawweight
+11/22/2014,Juan Manuel Puig,Dooho Choi,Blue,Featherweight
+11/15/2014,Fabricio Werdum,Mark Hunt,Red,UFC Interim Heavyweight Title
+11/15/2014,Jake Ellenberger,Kelvin Gastelum,Blue,Welterweight
+11/15/2014,Ricardo Lamas,Dennis Bermudez,Red,Featherweight
+11/15/2014,Augusto Montano,Chris Heatherly,Red,Welterweight
+11/15/2014,Edgar Garcia,Hector Urbina,Blue,Welterweight
+11/15/2014,Yair Rodriguez,Leonardo Morales,Red,Ultimate Fighter Latin America Featherweight Tournament Title
+11/15/2014,Alejandro Perez,Jose Quinonez,Red,Ultimate Fighter Latin America Bantamweight Tournament Title
+11/15/2014,Jessica Eye,Leslie Smith,Red,Women's Bantamweight
+11/15/2014,Gabriel Benitez,Humberto Brown Morrison,Red,Featherweight
+11/15/2014,Henry Briones,Guido Cannetti,Red,Bantamweight
+11/15/2014,Marco Beltran,Marlon Vera,Red,Bantamweight
+11/08/2014,Mauricio Rua,Ovince Saint Preux,Blue,Light Heavyweight
+11/08/2014,Warlley Alves,Alan Jouban,Red,Welterweight
+11/08/2014,Claudio Silva,Leon Edwards,Red,Welterweight
+11/08/2014,Dhiego Lima,Jorge de Oliveira,Red,Welterweight
+11/08/2014,Juliana Lima,Nina Nunes,Red,Women's Strawweight
+11/08/2014,Diego Rivas,Rodolfo Rubio Perez,Red,Featherweight
+11/08/2014,Caio Magalhaes,Trevor Smith,Red,Middleweight
+11/08/2014,Leandro Silva,Charlie Brenneman,Red,Lightweight
+11/08/2014,Thomas Almeida,Tim Gorman,Red,Bantamweight
+11/08/2014,Wagner Silva,Colby Covington,Blue,Welterweight
+11/07/2014,Luke Rockhold,Michael Bisping,Red,Middleweight
+11/07/2014,Ross Pearson,Al Iaquinta,Blue,Lightweight
+11/07/2014,Robert Whittaker,Clint Hester,Red,Middleweight
+11/07/2014,Soa Palelei,Walt Harris,Red,Heavyweight
+11/07/2014,Jake Matthews,Vagner Rocha,Red,Lightweight
+11/07/2014,Anthony Perosh,Guto Inocente,Red,Light Heavyweight
+11/07/2014,Dylan Andrews,Sam Alvey,Blue,Middleweight
+11/07/2014,Richie Vaculik,Louis Smolka,Blue,Flyweight
+11/07/2014,Vik Grujic,Chris Clements,Blue,Welterweight
+11/07/2014,Luke Zachrich,Daniel Kelly,Blue,Middleweight
+11/07/2014,Jumabieke Tuerxun,Marcus Brimage,Blue,Bantamweight
+10/25/2014,Jose Aldo,Chad Mendes,Red,UFC Featherweight Title
+10/25/2014,Glover Teixeira,Phil Davis,Blue,Light Heavyweight
+10/25/2014,Fabio Maldonado,Hans Stringer,Red,Light Heavyweight
+10/25/2014,Darren Elkins,Lucas Martins,Red,Featherweight
+10/25/2014,Diego Ferreira,Beneil Dariush,Blue,Lightweight
+10/25/2014,William Macario,Neil Magny,Blue,Welterweight
+10/25/2014,Yan Cabral,Naoyuki Kotani,Red,Lightweight
+10/25/2014,Scott Jorgensen,Wilson Reis,Blue,Flyweight
+10/25/2014,Felipe Arantes,Andre Fili,Blue,Featherweight
+10/25/2014,Gilbert Burns,Christos Giagos,Red,Lightweight
+10/25/2014,Fabricio Camoes,Anthony Rocco Martin,Blue,Lightweight
+10/04/2014,Rory MacDonald,Tarec Saffiedine,Red,Welterweight
+10/04/2014,Raphael Assuncao,Bryan Caraway,Red,Bantamweight
+10/04/2014,Chad Laprise,Yosdenis Cedeno,Red,Lightweight
+10/04/2014,Elias Theodorou,Bruno Santos,Red,Middleweight
+10/04/2014,Nordine Taleb,Li Jingliang,Red,Welterweight
+10/04/2014,Mitch Gagnon,Roman Salazar,Red,Bantamweight
+10/04/2014,Daron Cruickshank,Anthony Njokuani,Red,Lightweight
+10/04/2014,Olivier Aubin-Mercier,Jake Lindsey,Red,Lightweight
+10/04/2014,Jason Saggo,Paul Felder,Blue,Lightweight
+10/04/2014,Paddy Holohan,Chris Kelades,Blue,Flyweight
+10/04/2014,Albert Tumenov,Matt Dwyer,Red,Welterweight
+10/04/2014,Gunnar Nelson,Rick Story,Blue,Welterweight
+10/04/2014,Akira Corassani,Max Holloway,Blue,Featherweight
+10/04/2014,Ilir Latifi,Jan Blachowicz,Blue,Light Heavyweight
+10/04/2014,Niklas Backstrom,Mike Wilkinson,Blue,Featherweight
+10/04/2014,Magnus Cedenblad,Scott Askham,Red,Middleweight
+10/04/2014,Nicholas Musoke,Alexander Yakovlev,Red,Welterweight
+10/04/2014,Dennis Siver,Charles Rosa,Red,Featherweight
+10/04/2014,Cathal Pendred,Gasan Umalatov,Red,Welterweight
+10/04/2014,Tor Troeng,Krzysztof Jotko,Blue,Middleweight
+10/04/2014,Mairbek Taisumov,Marcin Bandel,Red,Lightweight
+10/04/2014,Zubaira Tukhugov,Ernest Chavez,Red,Featherweight
+09/27/2014,Demetrious Johnson,Chris Cariaso,Red,UFC Flyweight Title
+09/27/2014,Donald Cerrone,Eddie Alvarez,Red,Lightweight
+09/27/2014,Dustin Poirier,Conor McGregor,Blue,Featherweight
+09/27/2014,Tim Kennedy,Yoel Romero,Blue,Middleweight
+09/27/2014,Cat Zingano,Amanda Nunes,Red,Women's Bantamweight
+09/27/2014,Dominick Cruz,Takeya Mizugaki,Red,Bantamweight
+09/27/2014,Jorge Masvidal,James Krause,Red,Lightweight
+09/27/2014,Patrick Cote,Stephen Thompson,Blue,Welterweight
+09/27/2014,John Howard,Brian Ebersole,Blue,Welterweight
+09/27/2014,Jon Tuck,Kevin Lee,Blue,Lightweight
+09/27/2014,Manvel Gamburyan,Cody Gibson,Red,Bantamweight
+09/20/2014,Mark Hunt,Roy Nelson,Red,Heavyweight
+09/20/2014,Myles Jury,Takanori Gomi,Red,Lightweight
+09/20/2014,Yoshihiro Akiyama,Amir Sadollah,Red,Welterweight
+09/20/2014,Miesha Tate,Rin Nakai,Red,Women's Bantamweight
+09/20/2014,Kiichi Kunimoto,Richard Walsh,Red,Welterweight
+09/20/2014,Kyoji Horiguchi,Jon Delos Reyes,Red,Flyweight
+09/20/2014,Alex Caceres,Masanori Kanehara,Blue,Bantamweight
+09/20/2014,Katsunori Kikuno,Sam Sicilia,Red,Featherweight
+09/20/2014,Hyun Gyu Lim,Takenori Sato,Red,Welterweight
+09/20/2014,Michinori Tanaka,Kyung Ho Kang,Blue,Bantamweight
+09/20/2014,Kazuki Tokudome,Johnny Case,Blue,Lightweight
+09/20/2014,Maximo Blanco,Dan Hooker,Red,Featherweight
+09/13/2014,Antonio Silva,Andrei Arlovski,Blue,Heavyweight
+09/13/2014,Gleison Tibau,Piotr Hallmann,Red,Lightweight
+09/13/2014,Leonardo Santos,Efrain Escudero,Red,Lightweight
+09/13/2014,Santiago Ponzinibbio,Wendell Oliveira Marques,Red,Welterweight
+09/13/2014,Iuri Alcantara,Russell Doane,Red,Bantamweight
+09/13/2014,Jessica Andrade,Larissa Pacheco,Red,Women's Bantamweight
+09/13/2014,Godofredo Pepey,Dashon Johnson,Red,Featherweight
+09/13/2014,Igor Araujo,George Sullivan,Blue,Welterweight
+09/13/2014,Francisco Trinaldo,Leandro Silva,Red,Lightweight
+09/13/2014,Paulo Thiago,Sean Spencer,Blue,Welterweight
+09/13/2014,Rani Yahya,Johnny Bedford,Red,Bantamweight
+09/05/2014,Jacare Souza,Gegard Mousasi,Red,Middleweight
+09/05/2014,Alistair Overeem,Ben Rothwell,Blue,Heavyweight
+09/05/2014,Matt Mitrione,Derrick Lewis,Red,Heavyweight
+09/05/2014,Joe Lauzon,Michael Chiesa,Red,Lightweight
+09/05/2014,John Moraga,Justin Scoggins,Red,Flyweight
+09/05/2014,Al Iaquinta,Rodrigo Damm,Red,Lightweight
+09/05/2014,Rafael Natal,Chris Camozzi,Red,Middleweight
+09/05/2014,Chris Beal,Tateki Matsuda,Red,Bantamweight
+09/05/2014,Sean Soriano,Chas Skelly,Blue,Featherweight
+08/30/2014,TJ Dillashaw,Joe Soto,Red,UFC Bantamweight Title
+08/30/2014,Tony Ferguson,Danny Castillo,Red,Lightweight
+08/30/2014,Bethe Correia,Shayna Baszler,Red,Women's Bantamweight
+08/30/2014,Ramsey Nijem,Diego Ferreira,Blue,Lightweight
+08/30/2014,Yancy Medeiros,Damon Jackson,Red,Lightweight
+08/30/2014,Lorenz Larkin,Derek Brunson,Blue,Middleweight
+08/30/2014,Ruan Potts,Anthony Hamilton,Blue,Heavyweight
+08/30/2014,Chris Wade,Cain Carrizosa,Red,Lightweight
+08/23/2014,Benson Henderson,Rafael Dos Anjos,Blue,Lightweight
+08/23/2014,Mike Pyle,Jordan Mein,Blue,Welterweight
+08/23/2014,Francis Carmont,Thales Leites,Blue,Middleweight
+08/23/2014,Max Holloway,Clay Collard,Red,Catch Weight
+08/23/2014,James Vick,Valmir Lazaro,Red,Lightweight
+08/23/2014,Chas Skelly,Tom Niinimaki,Red,Featherweight
+08/23/2014,Neil Magny,Alex Garcia,Red,Welterweight
+08/23/2014,Beneil Dariush,Anthony Rocco Martin,Red,Lightweight
+08/23/2014,Aaron Phillips,Matt Hobar,Blue,Bantamweight
+08/23/2014,Ben Saunders,Chris Heatherly,Red,Welterweight
+08/23/2014,Wilson Reis,Joby Sanchez,Red,Flyweight
+08/23/2014,Michael Bisping,Cung Le,Red,Middleweight
+08/23/2014,Tyron Woodley,Dong Hyun Kim,Red,Welterweight
+08/23/2014,Zhang Lipeng,Brendan O'Reilly,Red,Lightweight
+08/23/2014,Guangyou Ning,Jianping Yang,Red,Ultimate Fighter China Featherweight Tournament Title
+08/23/2014,Sai Wang,Danny Mitchell,Red,Welterweight
+08/23/2014,Alberto Mina,Shinsho Anzai,Red,Welterweight
+08/23/2014,Roland Delorme,Yuta Sasaki,Blue,Bantamweight
+08/23/2014,Anying Wang,Colby Covington,Blue,Welterweight
+08/23/2014,Yao Zhikui,Royston Wee,Blue,Bantamweight
+08/23/2014,Elizabeth Phillips,Milana Dudieva,Blue,Women's Bantamweight
+08/16/2014,Ryan Bader,Ovince Saint Preux,Red,Light Heavyweight
+08/16/2014,Gray Maynard,Ross Pearson,Blue,Lightweight
+08/16/2014,Tim Boetsch,Brad Tavares,Red,Middleweight
+08/16/2014,Seth Baczynski,Alan Jouban,Blue,Welterweight
+08/16/2014,Shawn Jordan,Jack May,Red,Heavyweight
+08/16/2014,Thiago Tavares,Robert Peralta,Red,Featherweight
+08/16/2014,Jussier Formiga,Zach Makovsky,Red,Flyweight
+08/16/2014,Sara McMann,Lauren Murphy,Red,Women's Bantamweight
+08/16/2014,Tom Watson,Sam Alvey,Red,Middleweight
+08/16/2014,Nolan Ticman,Frankie Saenz,Blue,Bantamweight
+07/26/2014,Robbie Lawler,Matt Brown,Red,Welterweight
+07/26/2014,Anthony Johnson,Rogerio Nogueira,Red,Light Heavyweight
+07/26/2014,Clay Guida,Dennis Bermudez,Blue,Featherweight
+07/26/2014,Josh Thomson,Bobby Green,Blue,Lightweight
+07/26/2014,Daron Cruickshank,Jorge Masvidal,Blue,Lightweight
+07/26/2014,Kyle Kingsbury,Patrick Cummins,Blue,Light Heavyweight
+07/26/2014,Hernani Perpetuo,Tim Means,Blue,Welterweight
+07/26/2014,Akbarh Arreola,Tiago dos Santos e Silva,Blue,Lightweight
+07/26/2014,Andreas Stahl,Gilbert Burns,Blue,Welterweight
+07/26/2014,Juliana Lima,Joanna Jedrzejczyk,Blue,Women's Strawweight
+07/26/2014,Steven Siler,Noad Lahat,Blue,Featherweight
+07/19/2014,Conor McGregor,Diego Brandao,Red,Featherweight
+07/19/2014,Gunnar Nelson,Zak Cummings,Red,Welterweight
+07/19/2014,Brad Pickett,Ian McCall,Blue,Flyweight
+07/19/2014,Norman Parke,Naoyuki Kotani,Red,Lightweight
+07/19/2014,Ilir Latifi,Chris Dempsey,Red,Light Heavyweight
+07/19/2014,Neil Seery,Phil Harris,Red,Flyweight
+07/19/2014,Cathal Pendred,Mike King,Red,Middleweight
+07/19/2014,Tor Troeng,Trevor Smith,Blue,Middleweight
+07/19/2014,Cody Donovan,Nikita Krylov,Blue,Light Heavyweight
+07/19/2014,Paddy Holohan,Josh Sampo,Red,Flyweight
+07/16/2014,Donald Cerrone,Jim Miller,Red,Lightweight
+07/16/2014,Edson Barboza,Evan Dunham,Red,Lightweight
+07/16/2014,Rick Story,Leonardo Mafra,Red,Welterweight
+07/16/2014,Justin Salas,Joe Proctor,Blue,Lightweight
+07/16/2014,John Lineker,Alptekin Ozkilic,Red,Flyweight
+07/16/2014,Lucas Martins,Alex White,Red,Featherweight
+07/16/2014,Gleison Tibau,Pat Healy,Red,Lightweight
+07/16/2014,Jessamyn Duke,Leslie Smith,Blue,Women's Bantamweight
+07/16/2014,Hugo Viana,Aljamain Sterling,Blue,Bantamweight
+07/16/2014,Yosdenis Cedeno,Jerrod Sanders,Red,Lightweight
+07/16/2014,Claudia Gadelha,Tina Lahdemaki,Red,Women's Strawweight
+07/06/2014,Frankie Edgar,BJ Penn,Red,Featherweight
+07/06/2014,Corey Anderson,Matt Van Buren,Red,Ultimate Fighter 19 Light Heavyweight Tournament Title
+07/06/2014,Dhiego Lima,Eddie Gordon,Blue,Ultimate Fighter 19 Middleweight Tournament Title
+07/06/2014,Derrick Lewis,Guto Inocente,Red,Heavyweight
+07/06/2014,Justin Scoggins,Dustin Ortiz,Blue,Flyweight
+07/06/2014,Jesse Ronson,Kevin Lee,Blue,Lightweight
+07/06/2014,Jumabieke Tuerxun,Leandro Issa,Blue,Bantamweight
+07/06/2014,Adriano Martins,Juan Manuel Puig,Red,Lightweight
+07/06/2014,Patrick Walsh,Daniel Spohn,Red,Light Heavyweight
+07/06/2014,Sarah Moras,Alexis Dufresne,Red,Catch Weight
+07/05/2014,Chris Weidman,Lyoto Machida,Red,UFC Middleweight Title
+07/05/2014,Ronda Rousey,Alexis Davis,Red,UFC Women's Bantamweight Title
+07/05/2014,Uriah Hall,Thiago Santos,Red,Middleweight
+07/05/2014,Marcus Brimage,Russell Doane,Blue,Bantamweight
+07/05/2014,Urijah Faber,Alex Caceres,Red,Bantamweight
+07/05/2014,Kenny Robertson,Ildemar Alcantara,Red,Welterweight
+07/05/2014,Chris Camozzi,Bruno Santos,Blue,Middleweight
+07/05/2014,George Roop,Rob Font,Blue,Bantamweight
+07/05/2014,Luke Zachrich,Guilherme Vasconcelos,Red,Middleweight
+06/28/2014,Cub Swanson,Jeremy Stephens,Red,Featherweight
+06/28/2014,Kelvin Gastelum,Nicholas Musoke,Red,Welterweight
+06/28/2014,Cezar Ferreira,Andrew Craig,Red,Middleweight
+06/28/2014,Ricardo Lamas,Hacran Dias,Red,Featherweight
+06/28/2014,Clint Hester,Antonio Braga Neto,Red,Middleweight
+06/28/2014,Joe Ellenberger,James Moontasri,Red,Lightweight
+06/28/2014,Colton Smith,Diego Ferreira,Blue,Lightweight
+06/28/2014,Johnny Bedford,Cody Gibson,Blue,Bantamweight
+06/28/2014,Marcelo Guimaraes,Andy Enz,Red,Middleweight
+06/28/2014,Ray Borg,Shane Howell,Red,Flyweight
+06/28/2014,Aleksei Oleinik,Anthony Hamilton,Red,Heavyweight
+06/28/2014,James Te Huna,Nate Marquardt,Blue,Middleweight
+06/28/2014,Soa Palelei,Jared Rosholt,Blue,Heavyweight
+06/28/2014,Hatsu Hioki,Charles Oliveira,Blue,Featherweight
+06/28/2014,Robert Whittaker,Mike Rhodes,Red,Welterweight
+06/28/2014,Jake Matthews,Dashon Johnson,Red,Lightweight
+06/28/2014,Richie Vaculik,Roldan Sangcha'an,Red,Flyweight
+06/28/2014,Chris Indich,Vik Grujic,Blue,Welterweight
+06/28/2014,Neil Magny,Rodrigo de Lima,Red,Welterweight
+06/28/2014,Dan Hooker,Ian Entwistle,Red,Featherweight
+06/28/2014,Gian Villante,Sean O'Connell,Red,Light Heavyweight
+06/14/2014,Demetrious Johnson,Ali Bagautinov,Red,UFC Flyweight Title
+06/14/2014,Rory MacDonald,Tyron Woodley,Red,Welterweight
+06/14/2014,Ryan Bader,Rafael Cavalcante,Red,Light Heavyweight
+06/14/2014,Andrei Arlovski,Brendan Schaub,Red,Heavyweight
+06/14/2014,Ovince Saint Preux,Ryan Jimmo,Red,Light Heavyweight
+06/14/2014,Daniel Sarafian,Kiichi Kunimoto,Blue,Welterweight
+06/14/2014,Valerie Letourneau,Elizabeth Phillips,Red,Women's Bantamweight
+06/14/2014,Yves Jabouin,Mike Easton,Red,Bantamweight
+06/14/2014,Kajan Johnson,Tae Hyun Bang,Blue,Lightweight
+06/14/2014,Roland Delorme,Michinori Tanaka,Blue,Bantamweight
+06/14/2014,Jason Saggo,Josh Shockley,Red,Lightweight
+06/07/2014,Benson Henderson,Rustam Khabilov,Red,Lightweight
+06/07/2014,Diego Sanchez,Ross Pearson,Red,Lightweight
+06/07/2014,John Dodson,John Moraga,Red,Flyweight
+06/07/2014,Rafael Dos Anjos,Jason High,Red,Lightweight
+06/07/2014,Yves Edwards,Piotr Hallmann,Blue,Lightweight
+06/07/2014,Erik Perez,Bryan Caraway,Blue,Bantamweight
+06/07/2014,Yaotzin Meza,Sergio Pettis,Blue,Bantamweight
+06/07/2014,Bobby Voelker,Lance Benoist,Blue,Welterweight
+06/07/2014,Scott Jorgensen,Danny Martinez,Red,Flyweight
+06/07/2014,Jon Tuck,Jake Lindsey,Red,Lightweight
+06/07/2014,Patrick Cummins,Roger Narvaez,Red,Light Heavyweight
+05/31/2014,Stipe Miocic,Fabio Maldonado,Red,Heavyweight
+05/31/2014,Vitor Miranda,Antonio Carlos Junior,Blue,Ultimate Fighter Brazil 3 Heavyweight Tournament Title
+05/31/2014,Marcio Alexandre Junior,Warlley Alves,Blue,Ultimate Fighter Brazil 3 Middleweight Tournament Title
+05/31/2014,Demian Maia,Alexander Yakovlev,Red,Welterweight
+05/31/2014,Rony Jason,Robert Peralta,Blue,Featherweight
+05/31/2014,Rodrigo Damm,Rashid Magomedov,Blue,Lightweight
+05/31/2014,Elias Silverio,Ernest Chavez,Red,Lightweight
+05/31/2014,Paulo Thiago,Gasan Umalatov,Blue,Welterweight
+05/31/2014,Edimilson Souza,Mark Eddiva,Red,Featherweight
+05/31/2014,Ricardo Abreu,Wagner Silva,Red,Middleweight
+05/31/2014,Marcos Rogerio de Lima,Richardson Moreira,Red,Heavyweight
+05/31/2014,Pedro Munhoz,Matt Hobar,Red,Bantamweight
+05/31/2014,Mark Munoz,Gegard Mousasi,Blue,Middleweight
+05/31/2014,Francis Carmont,CB Dollaway,Blue,Middleweight
+05/31/2014,Luke Barnatt,Sean Strickland,Blue,Middleweight
+05/31/2014,Tom Niinimaki,Niklas Backstrom,Blue,Featherweight
+05/31/2014,Nick Hein,Drew Dober,Red,Lightweight
+05/31/2014,Magnus Cedenblad,Krzysztof Jotko,Red,Middleweight
+05/31/2014,Vaughan Lee,Iuri Alcantara,Blue,Bantamweight
+05/31/2014,Peter Sobotta,Pawel Pawlak,Red,Welterweight
+05/31/2014,Andy Ogle,Maximo Blanco,Blue,Featherweight
+05/31/2014,Viktor Pesta,Ruslan Magomedov,Blue,Heavyweight
+05/24/2014,Renan Barao,TJ Dillashaw,Blue,UFC Bantamweight Title
+05/24/2014,Daniel Cormier,Dan Henderson,Red,Light Heavyweight
+05/24/2014,Robbie Lawler,Jake Ellenberger,Red,Welterweight
+05/24/2014,Takeya Mizugaki,Francisco Rivera,Red,Bantamweight
+05/24/2014,Jamie Varner,James Krause,Blue,Lightweight
+05/24/2014,Michael Chiesa,Francisco Trinaldo,Red,Lightweight
+05/24/2014,Tony Ferguson,Katsunori Kikuno,Red,Lightweight
+05/24/2014,Chris Holdsworth,Chico Camus,Red,Bantamweight
+05/24/2014,Al Iaquinta,Mitch Clarke,Blue,Lightweight
+05/24/2014,Anthony Njokuani,Vinc Pichel,Blue,Lightweight
+05/24/2014,Sam Sicilia,Aaron Phillips,Red,Featherweight
+05/24/2014,David Michaud,Li Jingliang,Blue,Welterweight
+05/10/2014,Matt Brown,Erick Silva,Red,Welterweight
+05/10/2014,Constantinos Philippou,Lorenz Larkin,Red,Middleweight
+05/10/2014,Erik Koch,Daron Cruickshank,Blue,Lightweight
+05/10/2014,Neil Magny,Tim Means,Red,Welterweight
+05/10/2014,Soa Palelei,Ruan Potts,Red,Heavyweight
+05/10/2014,Chris Cariaso,Louis Smolka,Red,Flyweight
+05/10/2014,Ed Herman,Rafael Natal,Red,Middleweight
+05/10/2014,Kyoji Horiguchi,Darrell Montague,Red,Flyweight
+05/10/2014,Yan Cabral,Zak Cummings,Blue,Welterweight
+05/10/2014,Eddie Wineland,Johnny Eduardo,Blue,Bantamweight
+05/10/2014,Manvel Gamburyan,Nik Lentz,Blue,Featherweight
+05/10/2014,Justin Salas,Ben Wall,Red,Lightweight
+05/10/2014,Anthony Lapsley,Albert Tumenov,Blue,Welterweight
+04/26/2014,Jon Jones,Glover Teixeira,Red,UFC Light Heavyweight Title
+04/26/2014,Phil Davis,Anthony Johnson,Blue,Light Heavyweight
+04/26/2014,Luke Rockhold,Tim Boetsch,Red,Middleweight
+04/26/2014,Jim Miller,Yancy Medeiros,Red,Lightweight
+04/26/2014,Max Holloway,Andre Fili,Red,Featherweight
+04/26/2014,Joseph Benavidez,Tim Elliott,Red,Flyweight
+04/26/2014,Takanori Gomi,Isaac Vallie-Flagg,Red,Lightweight
+04/26/2014,Jessamyn Duke,Bethe Correia,Blue,Women's Bantamweight
+04/26/2014,Danny Castillo,Charlie Brenneman,Red,Lightweight
+04/26/2014,Chris Beal,Patrick Williams,Red,Bantamweight
+04/19/2014,Fabricio Werdum,Travis Browne,Red,Heavyweight
+04/19/2014,Miesha Tate,Liz Carmouche,Red,Women's Bantamweight
+04/19/2014,Donald Cerrone,Edson Barboza,Red,Lightweight
+04/19/2014,Brad Tavares,Yoel Romero,Blue,Middleweight
+04/19/2014,Rafael Dos Anjos,Khabib Nurmagomedov,Blue,Lightweight
+04/19/2014,Thiago Alves,Seth Baczynski,Red,Welterweight
+04/19/2014,Jorge Masvidal,Pat Healy,Red,Lightweight
+04/19/2014,Estevan Payan,Alex White,Blue,Featherweight
+04/19/2014,Caio Magalhaes,Luke Zachrich,Red,Middleweight
+04/19/2014,Jordan Mein,Hernani Perpetuo,Red,Welterweight
+04/19/2014,Dustin Ortiz,Ray Borg,Red,Flyweight
+04/19/2014,Mirsad Bektic,Chas Skelly,Red,Featherweight
+04/19/2014,Derrick Lewis,Jack May,Red,Heavyweight
+04/16/2014,Michael Bisping,Tim Kennedy,Blue,Middleweight
+04/16/2014,Patrick Cote,Kyle Noke,Red,Welterweight
+04/16/2014,Sheldon Westcott,Elias Theodorou,Blue,TUF Nations Canada vs. Australia Middleweight Tournament Title
+04/16/2014,Chad Laprise,Olivier Aubin-Mercier,Red,TUF Nations Canada vs. Australia Welterweight Tournament Title
+04/16/2014,Dustin Poirier,Akira Corassani,Red,Featherweight
+04/16/2014,Sam Stout,KJ Noons,Blue,Welterweight
+04/16/2014,Sarah Kaufman,Leslie Smith,Red,Women's Bantamweight
+04/16/2014,Ryan Jimmo,Sean O'Connell,Red,Light Heavyweight
+04/16/2014,George Roop,Dustin Kimura,Red,Bantamweight
+04/16/2014,Mark Bocek,Mike de la Torre,Red,Lightweight
+04/16/2014,Nordine Taleb,Vik Grujic,Red,Middleweight
+04/16/2014,Richard Walsh,Chris Indich,Red,Welterweight
+04/16/2014,Mitch Gagnon,Tim Gorman,Red,Bantamweight
+04/11/2014,Antonio Rodrigo Nogueira,Roy Nelson,Blue,Heavyweight
+04/11/2014,Clay Guida,Tatsuya Kawajiri,Red,Featherweight
+04/11/2014,John Howard,Ryan LaFlare,Blue,Welterweight
+04/11/2014,Ramsey Nijem,Beneil Dariush,Red,Lightweight
+04/11/2014,Jared Rosholt,Daniel Omielanczuk,Red,Heavyweight
+04/11/2014,Thales Leites,Trevor Smith,Red,Middleweight
+04/11/2014,Alan Omer,Jim Alers,Blue,Featherweight
+03/23/2014,Mauricio Rua,Dan Henderson,Blue,Light Heavyweight
+03/23/2014,Cezar Ferreira,CB Dollaway,Blue,Middleweight
+03/23/2014,Fabio Maldonado,Gian Villante,Red,Light Heavyweight
+03/23/2014,Michel Prazeres,Mairbek Taisumov,Red,Lightweight
+03/23/2014,Rony Jason,Steven Siler,Red,Featherweight
+03/23/2014,Ronny Markes,Thiago Santos,Blue,Middleweight
+03/23/2014,Jussier Formiga,Scott Jorgensen,Red,Flyweight
+03/23/2014,Thiago Perpetuo,Kenny Robertson,Blue,Welterweight
+03/23/2014,Francimar Barroso,Hans Stringer,Blue,Light Heavyweight
+03/23/2014,Godofredo Pepey,Noad Lahat,Red,Featherweight
+03/15/2014,Johny Hendricks,Robbie Lawler,Red,UFC Welterweight Title
+03/15/2014,Carlos Condit,Tyron Woodley,Blue,Welterweight
+03/15/2014,Diego Sanchez,Myles Jury,Blue,Lightweight
+03/15/2014,Jake Shields,Hector Lombard,Blue,Welterweight
+03/15/2014,Ovince Saint Preux,Nikita Krylov,Red,Light Heavyweight
+03/15/2014,Kelvin Gastelum,Rick Story,Red,Welterweight
+03/15/2014,Raquel Pennington,Jessica Andrade,Blue,Women's Bantamweight
+03/15/2014,Dennis Bermudez,Jimy Hettes,Red,Featherweight
+03/15/2014,Sean Spencer,Alex Garcia,Blue,Welterweight
+03/15/2014,Renee Forte,Francisco Trevino,Blue,Lightweight
+03/15/2014,Will Campuzano,Justin Scoggins,Blue,Flyweight
+03/15/2014,Robert McDaniel,Sean Strickland,Blue,Middleweight
+03/15/2014,Daniel Pineda,Robert Whiteford,Blue,Featherweight
+03/08/2014,Alexander Gustafsson,Jimi Manuwa,Red,Light Heavyweight
+03/08/2014,Michael Johnson,Melvin Guillard,Red,Lightweight
+03/08/2014,Brad Pickett,Neil Seery,Red,Flyweight
+03/08/2014,Gunnar Nelson,Omari Akhmedov,Red,Welterweight
+03/08/2014,Cyrille Diabate,Ilir Latifi,Blue,Light Heavyweight
+03/08/2014,Luke Barnatt,Mats Nilsson,Red,Middleweight
+03/08/2014,Brad Scott,Claudio Silva,Blue,Middleweight
+03/08/2014,Igor Araujo,Danny Mitchell,Red,Welterweight
+03/01/2014,Dong Hyun Kim,John Hathaway,Red,Welterweight
+03/01/2014,Sai Wang,Zhang Lipeng,Blue,Ultimate Fighter China Welterweight Tournament Title
+03/01/2014,Matt Mitrione,Shawn Jordan,Red,Heavyweight
+03/01/2014,Hatsu Hioki,Ivan Menjivar,Red,Featherweight
+03/01/2014,Kazuki Tokudome,Yui Chul Nam,Blue,Lightweight
+03/01/2014,Nam Phan,Vaughan Lee,Blue,Bantamweight
+03/01/2014,Albert Cheng,Anying Wang,Blue,Welterweight
+03/01/2014,Jumabieke Tuerxun,Mark Eddiva,Blue,Featherweight
+02/22/2014,Ronda Rousey,Sara McMann,Red,UFC Women's Bantamweight Title
+02/22/2014,Daniel Cormier,Patrick Cummins,Red,Light Heavyweight
+02/22/2014,Rory MacDonald,Demian Maia,Red,Welterweight
+02/22/2014,Mike Pyle,TJ Waldburger,Red,Welterweight
+02/22/2014,Robert Whittaker,Stephen Thompson,Blue,Welterweight
+02/22/2014,Alexis Davis,Jessica Eye,Red,Women's Bantamweight
+02/22/2014,Raphael Assuncao,Pedro Munhoz,Red,Bantamweight
+02/22/2014,Cody Gibson,Aljamain Sterling,Blue,Bantamweight
+02/22/2014,Zach Makovsky,Josh Sampo,Red,Flyweight
+02/22/2014,Rafaello Oliveira,Erik Koch,Blue,Lightweight
+02/22/2014,Ernest Chavez,Yosdenis Cedeno,Red,Lightweight
+02/15/2014,Lyoto Machida,Gegard Mousasi,Red,Middleweight
+02/15/2014,Jacare Souza,Francis Carmont,Red,Middleweight
+02/15/2014,Erick Silva,Takenori Sato,Red,Welterweight
+02/15/2014,Viscardi Andrade,Nicholas Musoke,Blue,Welterweight
+02/15/2014,Charles Oliveira,Andy Ogle,Red,Featherweight
+02/15/2014,Cristiano Marcello,Joe Proctor,Blue,Lightweight
+02/15/2014,Rodrigo Damm,Ivan Jorge,Red,Lightweight
+02/15/2014,Francisco Trinaldo,Jesse Ronson,Red,Lightweight
+02/15/2014,Iuri Alcantara,Wilson Reis,Red,Bantamweight
+02/15/2014,Felipe Arantes,Maximo Blanco,Red,Featherweight
+02/15/2014,Ildemar Alcantara,Albert Tumenov,Red,Welterweight
+02/15/2014,Douglas Silva de Andrade,Zubaira Tukhugov,Blue,Featherweight
+02/01/2014,Renan Barao,Urijah Faber,Red,UFC Bantamweight Title
+02/01/2014,Jose Aldo,Ricardo Lamas,Red,UFC Featherweight Title
+02/01/2014,Frank Mir,Alistair Overeem,Blue,Heavyweight
+02/01/2014,John Lineker,Ali Bagautinov,Blue,Flyweight
+02/01/2014,Jamie Varner,Abel Trujillo,Blue,Lightweight
+02/01/2014,John Makdessi,Alan Patrick,Blue,Lightweight
+02/01/2014,Chris Cariaso,Danny Martinez,Red,Flyweight
+02/01/2014,Nick Catone,Tom Watson,Red,Middleweight
+02/01/2014,Al Iaquinta,Kevin Lee,Red,Lightweight
+02/01/2014,Clint Hester,Andy Enz,Red,Middleweight
+02/01/2014,Anthony Rocco Martin,Rashid Magomedov,Blue,Lightweight
+02/01/2014,Neil Magny,Gasan Umalatov,Red,Welterweight
+01/25/2014,Benson Henderson,Josh Thomson,Red,Lightweight
+01/25/2014,Stipe Miocic,Gabriel Gonzaga,Red,Heavyweight
+01/25/2014,Donald Cerrone,Adriano Martins,Red,Lightweight
+01/25/2014,Darren Elkins,Jeremy Stephens,Blue,Featherweight
+01/25/2014,Alex Caceres,Sergio Pettis,Red,Bantamweight
+01/25/2014,Eddie Wineland,Yves Jabouin,Red,Bantamweight
+01/25/2014,Ramiro Hernandez,Hugo Viana,Blue,Bantamweight
+01/25/2014,Daron Cruickshank,Mike Rio,Red,Lightweight
+01/25/2014,George Sullivan,Mike Rhodes,Red,Welterweight
+01/25/2014,Walt Harris,Nikita Krylov,Blue,Heavyweight
+01/15/2014,Luke Rockhold,Constantinos Philippou,Red,Middleweight
+01/15/2014,Lorenz Larkin,Brad Tavares,Blue,Middleweight
+01/15/2014,TJ Dillashaw,Mike Easton,Red,Bantamweight
+01/15/2014,Yoel Romero,Derek Brunson,Red,Middleweight
+01/15/2014,John Moraga,Dustin Ortiz,Red,Flyweight
+01/15/2014,Cole Miller,Sam Sicilia,Red,Featherweight
+01/15/2014,Ramsey Nijem,Justin Edwards,Red,Lightweight
+01/15/2014,Isaac Vallie-Flagg,Elias Silverio,Blue,Lightweight
+01/15/2014,Trevor Smith,Brian Houston,Red,Middleweight
+01/15/2014,Alptekin Ozkilic,Louis Smolka,Blue,Flyweight
+01/15/2014,Vinc Pichel,Garett Whiteley,Red,Lightweight
+01/15/2014,Charlie Brenneman,Beneil Dariush,Blue,Lightweight
+01/04/2014,Tarec Saffiedine,Hyun Gyu Lim,Red,Welterweight
+01/04/2014,Tatsuya Kawajiri,Sean Soriano,Red,Featherweight
+01/04/2014,Kiichi Kunimoto,Luiz Dutra,Red,Welterweight
+01/04/2014,Kyung Ho Kang,Shunichi Shimizu,Red,Bantamweight
+01/04/2014,Max Holloway,Will Chope,Red,Featherweight
+01/04/2014,Katsunori Kikuno,Quinn Mulhern,Red,Lightweight
+01/04/2014,Royston Wee,Dave Galera,Red,Bantamweight
+01/04/2014,Mairbek Taisumov,Tae Hyun Bang,Red,Lightweight
+01/04/2014,Dustin Kimura,Jon Delos Reyes,Red,Bantamweight
+01/04/2014,Leandro Issa,Russell Doane,Blue,Bantamweight
+12/28/2013,Chris Weidman,Anderson Silva,Red,UFC Middleweight Title
+12/28/2013,Ronda Rousey,Miesha Tate,Red,UFC Women's Bantamweight Title
+12/28/2013,Josh Barnett,Travis Browne,Blue,Heavyweight
+12/28/2013,Jim Miller,Fabricio Camoes,Red,Lightweight
+12/28/2013,Dustin Poirier,Diego Brandao,Red,Featherweight
+12/28/2013,Chris Leben,Uriah Hall,Blue,Middleweight
+12/28/2013,Gleison Tibau,Michael Johnson,Blue,Lightweight
+12/28/2013,John Howard,Siyar Bahadurzada,Red,Welterweight
+12/28/2013,William Macario,Bobby Voelker,Red,Welterweight
+12/28/2013,Robert Peralta,Estevan Payan,Red,Featherweight
+12/14/2013,Demetrious Johnson,Joseph Benavidez,Red,UFC Flyweight Title
+12/14/2013,Urijah Faber,Michael McDonald,Red,Bantamweight
+12/14/2013,Chad Mendes,Nik Lentz,Red,Featherweight
+12/14/2013,Joe Lauzon,Mac Danzig,Red,Lightweight
+12/14/2013,Court McGee,Ryan LaFlare,Blue,Welterweight
+12/14/2013,Danny Castillo,Edson Barboza,Blue,Lightweight
+12/14/2013,Bobby Green,Pat Healy,Red,Lightweight
+12/14/2013,Scott Jorgensen,Zach Makovsky,Blue,Flyweight
+12/14/2013,Sam Stout,Cody McKenzie,Red,Lightweight
+12/14/2013,Abel Trujillo,Roger Bowling,Red,Lightweight
+12/14/2013,Darren Uyenoyama,Alptekin Ozkilic,Blue,Flyweight
+12/06/2013,Mauricio Rua,James Te Huna,Red,Light Heavyweight
+12/06/2013,Ryan Bader,Anthony Perosh,Red,Light Heavyweight
+12/06/2013,Pat Barry,Soa Palelei,Blue,Heavyweight
+12/06/2013,Dylan Andrews,Clint Hester,Blue,Middleweight
+12/06/2013,Julie Kedzie,Bethe Correia,Blue,Women's Bantamweight
+12/06/2013,Takeya Mizugaki,Nam Phan,Red,Bantamweight
+12/06/2013,Nick Ring,Caio Magalhaes,Blue,Middleweight
+12/06/2013,Richie Vaculik,Justin Scoggins,Blue,Flyweight
+12/06/2013,Bruno Santos,Krzysztof Jotko,Blue,Middleweight
+12/06/2013,Ben Wall,Alex Garcia,Blue,Welterweight
+11/30/2013,Gray Maynard,Nate Diaz,Blue,Lightweight
+11/30/2013,Julianna Pena,Jessica Rakoczy,Red,Ultimate Fighter 18 Women's Bantamweight Tournament Title
+11/30/2013,Chris Holdsworth,Davey Grant,Red,Ultimate Fighter 18 Bantamweight Tournament Title
+11/30/2013,Jessamyn Duke,Peggy Morgan,Red,Women's Bantamweight
+11/30/2013,Roxanne Modafferi,Raquel Pennington,Blue,Women's Bantamweight
+11/30/2013,Akira Corassani,Maximo Blanco,Red,Featherweight
+11/30/2013,Rani Yahya,Tom Niinimaki,Blue,Featherweight
+11/30/2013,Jared Rosholt,Walt Harris,Red,Heavyweight
+11/30/2013,Sean Spencer,Drew Dober,Red,Welterweight
+11/30/2013,Josh Sampo,Ryan Benoit,Red,Flyweight
+11/16/2013,Georges St-Pierre,Johny Hendricks,Red,UFC Welterweight Title
+11/16/2013,Rashad Evans,Chael Sonnen,Red,Light Heavyweight
+11/16/2013,Rory MacDonald,Robbie Lawler,Blue,Welterweight
+11/16/2013,Josh Koscheck,Tyron Woodley,Blue,Welterweight
+11/16/2013,Tim Elliott,Ali Bagautinov,Blue,Flyweight
+11/16/2013,Donald Cerrone,Evan Dunham,Red,Lightweight
+11/16/2013,Ed Herman,Thales Leites,Blue,Middleweight
+11/16/2013,Brian Ebersole,Rick Story,Blue,Welterweight
+11/16/2013,Erik Perez,Edwin Figueroa,Red,Bantamweight
+11/16/2013,Jason High,Anthony Lapsley,Red,Welterweight
+11/16/2013,Will Campuzano,Sergio Pettis,Blue,Bantamweight
+11/16/2013,Cody Donovan,Gian Villante,Blue,Light Heavyweight
+11/09/2013,Vitor Belfort,Dan Henderson,Red,Light Heavyweight
+11/09/2013,Cezar Ferreira,Daniel Sarafian,Red,Middleweight
+11/09/2013,Rafael Cavalcante,Igor Pokrajac,Red,Light Heavyweight
+11/09/2013,Paulo Thiago,Brandon Thatch,Blue,Welterweight
+11/09/2013,Santiago Ponzinibbio,Ryan LaFlare,Blue,Welterweight
+11/09/2013,Rony Jason,Jeremy Stephens,Blue,Featherweight
+11/09/2013,Godofredo Pepey,Sam Sicilia,Blue,Featherweight
+11/09/2013,Thiago Perpetuo,Omari Akhmedov,Blue,Middleweight
+11/09/2013,Thiago Tavares,Justin Salas,Red,Lightweight
+11/09/2013,Adriano Martins,Daron Cruickshank,Red,Lightweight
+11/09/2013,Jose Maria,Dustin Ortiz,Blue,Flyweight
+11/06/2013,Tim Kennedy,Rafael Natal,Red,Middleweight
+11/06/2013,Liz Carmouche,Alexis Davis,Blue,Women's Bantamweight
+11/06/2013,Ronny Markes,Yoel Romero,Blue,Middleweight
+11/06/2013,Jorge Masvidal,Rustam Khabilov,Blue,Lightweight
+11/06/2013,Colton Smith,Michael Chiesa,Blue,Lightweight
+11/06/2013,Bobby Green,James Krause,Red,Lightweight
+11/06/2013,George Roop,Francisco Rivera,Blue,Bantamweight
+11/06/2013,Dennis Bermudez,Steven Siler,Red,Featherweight
+11/06/2013,Amanda Nunes,Germaine de Randamie,Red,Women's Bantamweight
+11/06/2013,Chris Camozzi,Lorenz Larkin,Blue,Middleweight
+11/06/2013,Neil Magny,Seth Baczynski,Blue,Welterweight
+11/06/2013,Derek Brunson,Brian Houston,Red,Middleweight
+10/26/2013,Lyoto Machida,Mark Munoz,Red,Middleweight
+10/26/2013,Jimi Manuwa,Ryan Jimmo,Red,Light Heavyweight
+10/26/2013,Norman Parke,Jon Tuck,Red,Lightweight
+10/26/2013,Alessio Sakara,Nicholas Musoke,Blue,Middleweight
+10/26/2013,Phil Harris,John Lineker,Blue,Flyweight
+10/26/2013,Al Iaquinta,Piotr Hallmann,Red,Lightweight
+10/26/2013,Luke Barnatt,Andrew Craig,Red,Middleweight
+10/26/2013,Rosi Sexton,Jessica Andrade,Blue,Women's Bantamweight
+10/26/2013,Andy Ogle,Cole Miller,Blue,Featherweight
+10/26/2013,Jimy Hettes,Robert Whiteford,Red,Featherweight
+10/26/2013,Brad Scott,Michael Kuiper,Red,Middleweight
+10/19/2013,Cain Velasquez,Junior Dos Santos,Red,UFC Heavyweight Title
+10/19/2013,Daniel Cormier,Roy Nelson,Red,Heavyweight
+10/19/2013,Gilbert Melendez,Diego Sanchez,Red,Lightweight
+10/19/2013,Gabriel Gonzaga,Shawn Jordan,Red,Heavyweight
+10/19/2013,John Dodson,Darrell Montague,Red,Flyweight
+10/19/2013,Tim Boetsch,CB Dollaway,Red,Middleweight
+10/19/2013,Nate Marquardt,Hector Lombard,Blue,Welterweight
+10/19/2013,George Sotiropoulos,KJ Noons,Blue,Lightweight
+10/19/2013,TJ Waldburger,Adlan Amagov,Blue,Welterweight
+10/19/2013,Tony Ferguson,Mike Rio,Red,Lightweight
+10/19/2013,Jeremy Larsen,Andre Fili,Blue,Featherweight
+10/19/2013,Dustin Pague,Kyoji Horiguchi,Blue,Bantamweight
+10/09/2013,Demian Maia,Jake Shields,Blue,Welterweight
+10/09/2013,Erick Silva,Dong Hyun Kim,Blue,Welterweight
+10/09/2013,Thiago Silva,Matt Hamill,Red,Light Heavyweight
+10/09/2013,Fabio Maldonado,Joey Beltran,Red,Light Heavyweight
+10/09/2013,Rousimar Palhares,Mike Pierce,Red,Welterweight
+10/09/2013,Raphael Assuncao,TJ Dillashaw,Red,Bantamweight
+10/09/2013,Ildemar Alcantara,Igor Araujo,Blue,Welterweight
+10/09/2013,Yan Cabral,David Mitchell,Red,Welterweight
+10/09/2013,Iliarde Santos,Chris Cariaso,Blue,Flyweight
+10/09/2013,Alan Patrick,Garett Whiteley,Red,Lightweight
+09/21/2013,Jon Jones,Alexander Gustafsson,Red,UFC Light Heavyweight Title
+09/21/2013,Renan Barao,Eddie Wineland,Red,UFC Interim Bantamweight Title
+09/21/2013,Brendan Schaub,Matt Mitrione,Red,Heavyweight
+09/21/2013,Constantinos Philippou,Francis Carmont,Blue,Middleweight
+09/21/2013,Pat Healy,Khabib Nurmagomedov,Blue,Lightweight
+09/21/2013,Mike Ricci,Myles Jury,Blue,Lightweight
+09/21/2013,Ivan Menjivar,Wilson Reis,Blue,Bantamweight
+09/21/2013,Chris Clements,Stephen Thompson,Blue,Welterweight
+09/21/2013,Mitch Gagnon,Dustin Kimura,Red,Bantamweight
+09/21/2013,John Makdessi,Renee Forte,Red,Lightweight
+09/21/2013,Michel Prazeres,Jesse Ronson,Red,Lightweight
+09/21/2013,Roland Delorme,Alex Caceres,Blue,Bantamweight
+09/21/2013,Nandor Guelmino,Daniel Omielanczuk,Blue,Heavyweight
+09/04/2013,Glover Teixeira,Ryan Bader,Red,Light Heavyweight
+09/04/2013,Yushin Okami,Jacare Souza,Blue,Middleweight
+09/04/2013,Joseph Benavidez,Jussier Formiga,Red,Flyweight
+09/04/2013,Francisco Trinaldo,Piotr Hallmann,Blue,Lightweight
+09/04/2013,Rafael Natal,Tor Troeng,Red,Middleweight
+09/04/2013,Marcos Vinicius,Ali Bagautinov,Blue,Flyweight
+09/04/2013,Felipe Arantes,Edimilson Souza,Blue,Featherweight
+09/04/2013,Lucas Martins,Ramiro Hernandez,Red,Bantamweight
+09/04/2013,Joao Zeferino,Elias Silverio,Blue,Welterweight
+09/04/2013,Keith Wisniewski,Ivan Jorge,Blue,Welterweight
+09/04/2013,Yuri Villefort,Sean Spencer,Blue,Welterweight
+08/31/2013,Benson Henderson,Anthony Pettis,Blue,UFC Lightweight Title
+08/31/2013,Frank Mir,Josh Barnett,Blue,Heavyweight
+08/31/2013,Chad Mendes,Clay Guida,Red,Featherweight
+08/31/2013,Ben Rothwell,Brandon Vera,Red,Heavyweight
+08/31/2013,Erik Koch,Dustin Poirier,Blue,Featherweight
+08/31/2013,Jamie Varner,Gleison Tibau,Blue,Lightweight
+08/31/2013,Louis Gaudinot,Tim Elliott,Blue,Flyweight
+08/31/2013,Pascal Krauss,Hyun Gyu Lim,Blue,Welterweight
+08/31/2013,Chico Camus,Kyung Ho Kang,Red,Bantamweight
+08/31/2013,Soa Palelei,Nikita Krylov,Red,Heavyweight
+08/31/2013,Ryan Couture,Al Iaquinta,Blue,Lightweight
+08/31/2013,Jared Hamman,Magnus Cedenblad,Blue,Middleweight
+08/28/2013,Carlos Condit,Martin Kampmann,Red,Welterweight
+08/28/2013,Donald Cerrone,Rafael Dos Anjos,Blue,Lightweight
+08/28/2013,Kelvin Gastelum,Brian Melancon,Red,Welterweight
+08/28/2013,Court McGee,Robert Whittaker,Red,Welterweight
+08/28/2013,Takeya Mizugaki,Erik Perez,Red,Bantamweight
+08/28/2013,Brad Tavares,Robert McDaniel,Red,Middleweight
+08/28/2013,Dylan Andrews,Papy Abedi,Red,Middleweight
+08/28/2013,Justin Edwards,Brandon Thatch,Blue,Welterweight
+08/28/2013,Darren Elkins,Hatsu Hioki,Red,Featherweight
+08/28/2013,James Head,Jason High,Blue,Welterweight
+08/28/2013,Zak Cummings,Ben Alloway,Red,Welterweight
+08/17/2013,Mauricio Rua,Chael Sonnen,Blue,Light Heavyweight
+08/17/2013,Alistair Overeem,Travis Browne,Blue,Heavyweight
+08/17/2013,Urijah Faber,Iuri Alcantara,Red,Bantamweight
+08/17/2013,Matt Brown,Mike Pyle,Red,Welterweight
+08/17/2013,Uriah Hall,John Howard,Blue,Middleweight
+08/17/2013,Joe Lauzon,Michael Johnson,Blue,Lightweight
+08/17/2013,Brad Pickett,Michael McDonald,Blue,Bantamweight
+08/17/2013,Conor McGregor,Max Holloway,Red,Featherweight
+08/17/2013,Mike Brown,Steven Siler,Blue,Featherweight
+08/17/2013,Diego Brandao,Daniel Pineda,Red,Featherweight
+08/17/2013,Manvel Gamburyan,Cole Miller,Red,Featherweight
+08/17/2013,Cody Donovan,Ovince Saint Preux,Blue,Light Heavyweight
+08/17/2013,Ramsey Nijem,James Vick,Blue,Lightweight
+08/03/2013,Jose Aldo,Chan Sung Jung,Red,UFC Featherweight Title
+08/03/2013,Lyoto Machida,Phil Davis,Blue,Light Heavyweight
+08/03/2013,Cezar Ferreira,Thiago Santos,Red,Middleweight
+08/03/2013,Thales Leites,Tom Watson,Red,Middleweight
+08/03/2013,John Lineker,Jose Maria,Red,Flyweight
+08/03/2013,Vinny Magalhaes,Anthony Perosh,Blue,Light Heavyweight
+08/03/2013,Amanda Nunes,Sheila Gaff,Red,Women's Bantamweight
+08/03/2013,Sergio Moraes,Neil Magny,Red,Welterweight
+08/03/2013,Ian McCall,Iliarde Santos,Red,Flyweight
+08/03/2013,Rani Yahya,Josh Clopton,Red,Featherweight
+08/03/2013,Ednaldo Oliveira,Francimar Barroso,Blue,Light Heavyweight
+08/03/2013,Viscardi Andrade,Bristol Marunde,Red,Welterweight
+07/27/2013,Demetrious Johnson,John Moraga,Red,UFC Flyweight Title
+07/27/2013,Rory MacDonald,Jake Ellenberger,Red,Welterweight
+07/27/2013,Robbie Lawler,Bobby Voelker,Red,Welterweight
+07/27/2013,Liz Carmouche,Jessica Andrade,Red,Women's Bantamweight
+07/27/2013,Michael Chiesa,Jorge Masvidal,Blue,Lightweight
+07/27/2013,Danny Castillo,Tim Means,Red,Lightweight
+07/27/2013,Mac Danzig,Melvin Guillard,Blue,Lightweight
+07/27/2013,Yves Edwards,Daron Cruickshank,Blue,Lightweight
+07/27/2013,Ed Herman,Trevor Smith,Red,Middleweight
+07/27/2013,Julie Kedzie,Germaine de Randamie,Blue,Women's Bantamweight
+07/27/2013,Aaron Riley,Justin Salas,Blue,Lightweight
+07/27/2013,John Albert,Yaotzin Meza,Blue,Bantamweight
+07/06/2013,Anderson Silva,Chris Weidman,Blue,UFC Middleweight Title
+07/06/2013,Frankie Edgar,Charles Oliveira,Red,Featherweight
+07/06/2013,Tim Kennedy,Roger Gracie,Red,Middleweight
+07/06/2013,Mark Munoz,Tim Boetsch,Red,Middleweight
+07/06/2013,Cub Swanson,Dennis Siver,Red,Featherweight
+07/06/2013,Chris Leben,Andrew Craig,Blue,Middleweight
+07/06/2013,Norman Parke,Kazuki Tokudome,Red,Lightweight
+07/06/2013,Gabriel Gonzaga,Dave Herman,Red,Heavyweight
+07/06/2013,Edson Barboza,Rafaello Oliveira,Red,Lightweight
+07/06/2013,Seth Baczynski,Brian Melancon,Blue,Welterweight
+07/06/2013,Mike Pierce,David Mitchell,Red,Welterweight
+06/15/2013,Rashad Evans,Dan Henderson,Red,Light Heavyweight
+06/15/2013,Roy Nelson,Stipe Miocic,Blue,Heavyweight
+06/15/2013,Ryan Jimmo,Igor Pokrajac,Red,Light Heavyweight
+06/15/2013,Alexis Davis,Rosi Sexton,Red,Women's Bantamweight
+06/15/2013,Pat Barry,Shawn Jordan,Blue,Heavyweight
+06/15/2013,Jake Shields,Tyron Woodley,Red,Welterweight
+06/15/2013,Sam Stout,James Krause,Blue,Lightweight
+06/15/2013,Sean Pierson,Kenny Robertson,Red,Welterweight
+06/15/2013,Roland Delorme,Edwin Figueroa,Red,Bantamweight
+06/15/2013,Mitch Clarke,John Maguire,Red,Lightweight
+06/15/2013,Yves Jabouin,Dustin Pague,Red,Bantamweight
+06/08/2013,Antonio Rodrigo Nogueira,Fabricio Werdum,Blue,Heavyweight
+06/08/2013,William Macario,Leonardo Santos,Blue,Ultimate Fighter Brazil 2 Welterweight Tournament Title
+06/08/2013,Thiago Silva,Rafael Cavalcante,Red,Light Heavyweight
+06/08/2013,Erick Silva,Jason High,Red,Welterweight
+06/08/2013,Daniel Sarafian,Eddie Mendez,Red,Middleweight
+06/08/2013,Rony Jason,Mike Wilkinson,Red,Featherweight
+06/08/2013,Raphael Assuncao,Vaughan Lee,Red,Bantamweight
+06/08/2013,Godofredo Pepey,Felipe Arantes,Blue,Featherweight
+06/08/2013,Ildemar Alcantara,Leandro Silva,Red,Welterweight
+06/08/2013,Rodrigo Damm,Mizuto Hirota,Red,Featherweight
+06/08/2013,Caio Magalhaes,Karlos Vemola,Red,Middleweight
+06/08/2013,Antonio Braga Neto,Anthony Smith,Red,Middleweight
+05/25/2013,Cain Velasquez,Antonio Silva,Red,UFC Heavyweight Title
+05/25/2013,Junior Dos Santos,Mark Hunt,Red,Heavyweight
+05/25/2013,Glover Teixeira,James Te Huna,Red,Light Heavyweight
+05/25/2013,Gray Maynard,TJ Grant,Blue,Lightweight
+05/25/2013,Donald Cerrone,KJ Noons,Red,Lightweight
+05/25/2013,Mike Pyle,Rick Story,Red,Welterweight
+05/25/2013,Dennis Bermudez,Max Holloway,Red,Featherweight
+05/25/2013,Colton Smith,Robert Whittaker,Blue,Welterweight
+05/25/2013,Khabib Nurmagomedov,Abel Trujillo,Red,Lightweight
+05/25/2013,Stephen Thompson,Nah-Shon Burrell,Red,Welterweight
+05/25/2013,Brian Bowles,George Roop,Blue,Bantamweight
+05/25/2013,Jeremy Stephens,Estevan Payan,Red,Featherweight
+05/18/2013,Vitor Belfort,Luke Rockhold,Red,Middleweight
+05/18/2013,Jacare Souza,Chris Camozzi,Red,Middleweight
+05/18/2013,Rafael Dos Anjos,Evan Dunham,Red,Lightweight
+05/18/2013,Rafael Natal,Joao Zeferino,Red,Middleweight
+05/18/2013,Hacran Dias,Nik Lentz,Blue,Featherweight
+05/18/2013,Francisco Trinaldo,Mike Rio,Red,Lightweight
+05/18/2013,Gleison Tibau,John Cholish,Red,Lightweight
+05/18/2013,Paulo Thiago,Michel Prazeres,Red,Welterweight
+05/18/2013,Iuri Alcantara,Iliarde Santos,Red,Bantamweight
+05/18/2013,Fabio Maldonado,Roger Hollett,Red,Light Heavyweight
+05/18/2013,John Lineker,Azamat Gashimov,Red,Flyweight
+05/18/2013,Jussier Formiga,Chris Cariaso,Red,Flyweight
+05/18/2013,Lucas Martins,Jeremy Larsen,Red,Lightweight
+04/27/2013,Jon Jones,Chael Sonnen,Red,UFC Light Heavyweight Title
+04/27/2013,Michael Bisping,Alan Belcher,Red,Middleweight
+04/27/2013,Roy Nelson,Cheick Kongo,Red,Heavyweight
+04/27/2013,Phil Davis,Vinny Magalhaes,Red,Light Heavyweight
+04/27/2013,Rustam Khabilov,Yancy Medeiros,Red,Lightweight
+04/27/2013,Gian Villante,Ovince Saint Preux,Blue,Light Heavyweight
+04/27/2013,Sara McMann,Sheila Gaff,Red,Women's Bantamweight
+04/27/2013,Bryan Caraway,Johnny Bedford,Red,Bantamweight
+04/27/2013,Leonard Garcia,Cody McKenzie,Blue,Featherweight
+04/27/2013,Steven Siler,Kurt Holobaugh,Red,Featherweight
+04/20/2013,Benson Henderson,Gilbert Melendez,Red,UFC Lightweight Title
+04/20/2013,Frank Mir,Daniel Cormier,Blue,Heavyweight
+04/20/2013,Nate Diaz,Josh Thomson,Blue,Lightweight
+04/20/2013,Matt Brown,Jordan Mein,Red,Welterweight
+04/20/2013,Chad Mendes,Darren Elkins,Red,Featherweight
+04/20/2013,Francis Carmont,Lorenz Larkin,Red,Middleweight
+04/20/2013,Ramsey Nijem,Myles Jury,Blue,Lightweight
+04/20/2013,Joseph Benavidez,Darren Uyenoyama,Red,Flyweight
+04/20/2013,Tim Means,Jorge Masvidal,Blue,Lightweight
+04/20/2013,TJ Dillashaw,Hugo Viana,Red,Bantamweight
+04/20/2013,Anthony Njokuani,Roger Bowling,Red,Lightweight
+04/20/2013,Clifford Starks,Yoel Romero,Blue,Middleweight
+04/13/2013,Urijah Faber,Scott Jorgensen,Red,Bantamweight
+04/13/2013,Uriah Hall,Kelvin Gastelum,Blue,Ultimate Fighter 17 Middleweight Tournament Title
+04/13/2013,Miesha Tate,Cat Zingano,Blue,Women's Bantamweight
+04/13/2013,Travis Browne,Gabriel Gonzaga,Red,Heavyweight
+04/13/2013,Robert McDaniel,Gilbert Smith,Red,Middleweight
+04/13/2013,Josh Samman,Kevin Casey,Red,Middleweight
+04/13/2013,Luke Barnatt,Collin Hart,Red,Middleweight
+04/13/2013,Dylan Andrews,Jimmy Quinlan,Red,Middleweight
+04/13/2013,Bristol Marunde,Clint Hester,Blue,Middleweight
+04/13/2013,Cole Miller,Bart Palaszewski,Red,Featherweight
+04/13/2013,Sam Sicilia,Maximo Blanco,Blue,Featherweight
+04/13/2013,Justin Lawrence,Daniel Pineda,Blue,Featherweight
+04/06/2013,Gegard Mousasi,Ilir Latifi,Red,Light Heavyweight
+04/06/2013,Ryan Couture,Ross Pearson,Blue,Lightweight
+04/06/2013,Matt Mitrione,Philip De Fries,Red,Heavyweight
+04/06/2013,Brad Pickett,Mike Easton,Red,Bantamweight
+04/06/2013,Diego Brandao,Pablo Garza,Red,Featherweight
+04/06/2013,Akira Corassani,Robert Peralta,Red,Featherweight
+04/06/2013,Reza Madadi,Michael Johnson,Red,Lightweight
+04/06/2013,Tor Troeng,Adam Cella,Red,Middleweight
+04/06/2013,Chris Spang,Adlan Amagov,Blue,Welterweight
+04/06/2013,Marcus Brimage,Conor McGregor,Blue,Featherweight
+04/06/2013,Ben Alloway,Ryan LaFlare,Blue,Welterweight
+04/06/2013,Michael Kuiper,Tom Lawlor,Blue,Middleweight
+04/06/2013,Papy Abedi,Besam Yousef,Red,Welterweight
+03/16/2013,Georges St-Pierre,Nick Diaz,Red,UFC Welterweight Title
+03/16/2013,Carlos Condit,Johny Hendricks,Blue,Welterweight
+03/16/2013,Jake Ellenberger,Nate Marquardt,Red,Welterweight
+03/16/2013,Nick Ring,Chris Camozzi,Blue,Middleweight
+03/16/2013,Mike Ricci,Colin Fletcher,Red,Lightweight
+03/16/2013,Patrick Cote,Bobby Voelker,Red,Welterweight
+03/16/2013,Antonio Carvalho,Darren Elkins,Blue,Featherweight
+03/16/2013,Dan Miller,Jordan Mein,Blue,Welterweight
+03/16/2013,John Makdessi,Daron Cruickshank,Red,Lightweight
+03/16/2013,Rick Story,Quinn Mulhern,Red,Welterweight
+03/16/2013,TJ Dillashaw,Issei Tamura,Red,Bantamweight
+03/16/2013,George Roop,Reuben Duran,Red,Bantamweight
+03/02/2013,Wanderlei Silva,Brian Stann,Red,Light Heavyweight
+03/02/2013,Stefan Struve,Mark Hunt,Blue,Heavyweight
+03/02/2013,Takanori Gomi,Diego Sanchez,Blue,Lightweight
+03/02/2013,Yushin Okami,Hector Lombard,Red,Middleweight
+03/02/2013,Mizuto Hirota,Rani Yahya,Blue,Featherweight
+03/02/2013,Dong Hyun Kim,Siyar Bahadurzada,Red,Welterweight
+03/02/2013,Riki Fukuda,Brad Tavares,Blue,Middleweight
+03/02/2013,Takeya Mizugaki,Bryan Caraway,Red,Bantamweight
+03/02/2013,Cristiano Marcello,Kazuki Tokudome,Blue,Lightweight
+03/02/2013,Marcelo Guimaraes,Hyun Gyu Lim,Blue,Welterweight
+02/23/2013,Ronda Rousey,Liz Carmouche,Red,UFC Women's Bantamweight Title
+02/23/2013,Lyoto Machida,Dan Henderson,Red,Light Heavyweight
+02/23/2013,Urijah Faber,Ivan Menjivar,Red,Bantamweight
+02/23/2013,Court McGee,Josh Neer,Red,Welterweight
+02/23/2013,Josh Koscheck,Robbie Lawler,Blue,Welterweight
+02/23/2013,Brendan Schaub,Lavar Johnson,Red,Heavyweight
+02/23/2013,Michael Chiesa,Anton Kuivanen,Red,Lightweight
+02/23/2013,Dennis Bermudez,Matt Grice,Red,Featherweight
+02/23/2013,Sam Stout,Caros Fodor,Red,Lightweight
+02/23/2013,Kenny Robertson,Brock Jardine,Red,Welterweight
+02/23/2013,Jon Manley,Neil Magny,Blue,Welterweight
+02/23/2013,Nah-Shon Burrell,Yuri Villefort,Red,Welterweight
+02/16/2013,Renan Barao,Michael McDonald,Red,UFC Interim Bantamweight Title
+02/16/2013,Cub Swanson,Dustin Poirier,Red,Featherweight
+02/16/2013,Jimi Manuwa,Cyrille Diabate,Red,Light Heavyweight
+02/16/2013,Gunnar Nelson,Jorge Santiago,Red,Welterweight
+02/16/2013,James Te Huna,Ryan Jimmo,Red,Light Heavyweight
+02/16/2013,Terry Etim,Renee Forte,Blue,Lightweight
+02/16/2013,Paul Sass,Danny Castillo,Blue,Lightweight
+02/16/2013,Andy Ogle,Josh Grispi,Red,Featherweight
+02/16/2013,Tom Watson,Stanislav Nedkov,Red,Middleweight
+02/16/2013,Vaughan Lee,Motonobu Tezuka,Red,Bantamweight
+02/16/2013,Phil Harris,Ulysses Gomez,Red,Flyweight
+02/02/2013,Jose Aldo,Frankie Edgar,Red,UFC Featherweight Title
+02/02/2013,Rashad Evans,Rogerio Nogueira,Blue,Light Heavyweight
+02/02/2013,Alistair Overeem,Antonio Silva,Blue,Heavyweight
+02/02/2013,Jon Fitch,Demian Maia,Blue,Welterweight
+02/02/2013,Joseph Benavidez,Ian McCall,Red,Flyweight
+02/02/2013,Gleison Tibau,Evan Dunham,Blue,Lightweight
+02/02/2013,Tyron Woodley,Jay Hieron,Red,Welterweight
+02/02/2013,Jacob Volkmann,Bobby Green,Blue,Lightweight
+02/02/2013,Yves Edwards,Isaac Vallie-Flagg,Blue,Lightweight
+02/02/2013,Chico Camus,Dustin Kimura,Blue,Bantamweight
+02/02/2013,Edwin Figueroa,Francisco Rivera,Blue,Bantamweight
+01/26/2013,Demetrious Johnson,John Dodson,Red,UFC Flyweight Title
+01/26/2013,Quinton Jackson,Glover Teixeira,Blue,Light Heavyweight
+01/26/2013,Anthony Pettis,Donald Cerrone,Red,Lightweight
+01/26/2013,Erik Koch,Ricardo Lamas,Blue,Featherweight
+01/26/2013,TJ Grant,Matt Wiman,Red,Lightweight
+01/26/2013,Clay Guida,Hatsu Hioki,Red,Featherweight
+01/26/2013,Mike Stumpf,Pascal Krauss,Blue,Welterweight
+01/26/2013,Ryan Bader,Vladimir Matyushenko,Red,Light Heavyweight
+01/26/2013,Mike Russow,Shawn Jordan,Blue,Heavyweight
+01/26/2013,Rafael Natal,Sean Spencer,Red,Middleweight
+01/26/2013,Simeon Thoresen,David Mitchell,Blue,Welterweight
+01/19/2013,Vitor Belfort,Michael Bisping,Red,Middleweight
+01/19/2013,Daniel Sarafian,CB Dollaway,Blue,Middleweight
+01/19/2013,Gabriel Gonzaga,Ben Rothwell,Red,Heavyweight
+01/19/2013,Thiago Tavares,Khabib Nurmagomedov,Blue,Lightweight
+01/19/2013,Godofredo Pepey,Milton Vieira,Red,Featherweight
+01/19/2013,Ronny Markes,Andrew Craig,Red,Middleweight
+01/19/2013,Diego Nunes,Nik Lentz,Blue,Featherweight
+01/19/2013,Edson Barboza,Lucas Martins,Red,Lightweight
+01/19/2013,Wagner Prado,Ildemar Alcantara,Blue,Light Heavyweight
+01/19/2013,Francisco Trinaldo,CJ Keith,Red,Lightweight
+12/29/2012,Junior Dos Santos,Cain Velasquez,Blue,UFC Heavyweight Title
+12/29/2012,Jim Miller,Joe Lauzon,Red,Lightweight
+12/29/2012,Tim Boetsch,Constantinos Philippou,Blue,Middleweight
+12/29/2012,Yushin Okami,Alan Belcher,Red,Middleweight
+12/29/2012,Chris Leben,Derek Brunson,Blue,Middleweight
+12/29/2012,Brad Pickett,Eddie Wineland,Blue,Bantamweight
+12/29/2012,Erik Perez,Byron Bloodworth,Red,Bantamweight
+12/29/2012,Melvin Guillard,Jamie Varner,Blue,Lightweight
+12/29/2012,Michael Johnson,Myles Jury,Blue,Lightweight
+12/29/2012,Philip De Fries,Todd Duffee,Blue,Heavyweight
+12/29/2012,Leonard Garcia,Max Holloway,Blue,Featherweight
+12/29/2012,Chris Cariaso,John Moraga,Blue,Flyweight
+12/15/2012,Roy Nelson,Matt Mitrione,Red,Heavyweight
+12/15/2012,Colton Smith,Mike Ricci,Red,Ultimate Fighter 16 Welterweight Tournament Title
+12/15/2012,Pat Barry,Shane del Rosario,Red,Heavyweight
+12/15/2012,Dustin Poirier,Jonathan Brookins,Red,Featherweight
+12/15/2012,Mike Pyle,James Head,Red,Welterweight
+12/15/2012,Johnny Bedford,Marcos Vinicius,Red,Bantamweight
+12/15/2012,Vinc Pichel,Rustam Khabilov,Blue,Lightweight
+12/15/2012,TJ Waldburger,Nick Catone,Red,Welterweight
+12/15/2012,Reuben Duran,Hugo Viana,Blue,Bantamweight
+12/15/2012,Mike Rio,John Cofer,Red,Lightweight
+12/15/2012,Jared Papazian,Tim Elliott,Blue,Flyweight
+12/14/2012,George Sotiropoulos,Ross Pearson,Blue,Lightweight
+12/14/2012,Robert Whittaker,Brad Scott,Red,Ultimate Fighter Australia vs. UK Welterweight Tournament Title
+12/14/2012,Colin Fletcher,Norman Parke,Blue,Ultimate Fighter Australia vs. UK Lightweight Tournament Title
+12/14/2012,Hector Lombard,Rousimar Palhares,Red,Middleweight
+12/14/2012,Chad Mendes,Yaotzin Meza,Red,Featherweight
+12/14/2012,Mike Pierce,Seth Baczynski,Red,Welterweight
+12/14/2012,Ben Alloway,Manuel Rodriguez,Red,Welterweight
+12/14/2012,Brendan Loughnane,Mike Wilkinson,Blue,Lightweight
+12/14/2012,Nick Penner,Cody Donovan,Blue,Light Heavyweight
+12/08/2012,Benson Henderson,Nate Diaz,Red,UFC Lightweight Title
+12/08/2012,Mauricio Rua,Alexander Gustafsson,Blue,Light Heavyweight
+12/08/2012,BJ Penn,Rory MacDonald,Blue,Welterweight
+12/08/2012,Mike Swick,Matt Brown,Blue,Welterweight
+12/08/2012,Yves Edwards,Jeremy Stephens,Red,Lightweight
+12/08/2012,Raphael Assuncao,Mike Easton,Red,Bantamweight
+12/08/2012,Ramsey Nijem,Joe Proctor,Red,Lightweight
+12/08/2012,Daron Cruickshank,Henry Martinez,Red,Lightweight
+12/08/2012,Marcus LeVesseur,Abel Trujillo,Blue,Lightweight
+12/08/2012,Dennis Siver,Nam Phan,Red,Featherweight
+12/08/2012,Scott Jorgensen,John Albert,Red,Bantamweight
+11/17/2012,Georges St-Pierre,Carlos Condit,Red,UFC Welterweight Title
+11/17/2012,Johny Hendricks,Martin Kampmann,Red,Welterweight
+11/17/2012,Francis Carmont,Tom Lawlor,Red,Middleweight
+11/17/2012,Mark Bocek,Rafael Dos Anjos,Blue,Lightweight
+11/17/2012,Mark Hominick,Pablo Garza,Blue,Featherweight
+11/17/2012,Patrick Cote,Alessio Sakara,Red,Middleweight
+11/17/2012,Cyrille Diabate,Chad Griggs,Red,Light Heavyweight
+11/17/2012,Sam Stout,John Makdessi,Blue,Lightweight
+11/17/2012,Antonio Carvalho,Rodrigo Damm,Red,Featherweight
+11/17/2012,Matthew Riddle,John Maguire,Red,Welterweight
+11/17/2012,Ivan Menjivar,Azamat Gashimov,Red,Bantamweight
+11/17/2012,Steven Siler,Darren Elkins,Blue,Featherweight
+11/10/2012,Rich Franklin,Cung Le,Blue,Middleweight
+11/10/2012,Dong Hyun Kim,Paulo Thiago,Red,Welterweight
+11/10/2012,Takanori Gomi,Mac Danzig,Red,Lightweight
+11/10/2012,Zhang Tiequan,Jon Tuck,Blue,Lightweight
+11/10/2012,Takeya Mizugaki,Jeff Hougland,Red,Bantamweight
+11/10/2012,Alex Caceres,Motonobu Tezuka,Red,Bantamweight
+11/10/2012,Yasuhiro Urushitani,John Lineker,Blue,Flyweight
+11/10/2012,Riki Fukuda,Tom DeBlass,Red,Middleweight
+10/13/2012,Anderson Silva,Stephan Bonnar,Red,Light Heavyweight
+10/13/2012,Antonio Rodrigo Nogueira,Dave Herman,Red,Heavyweight
+10/13/2012,Glover Teixeira,Fabio Maldonado,Red,Light Heavyweight
+10/13/2012,Jon Fitch,Erick Silva,Red,Welterweight
+10/13/2012,Phil Davis,Wagner Prado,Red,Light Heavyweight
+10/13/2012,Demian Maia,Rick Story,Red,Welterweight
+10/13/2012,Rony Jason,Sam Sicilia,Red,Featherweight
+10/13/2012,Gleison Tibau,Francisco Trinaldo,Red,Lightweight
+10/13/2012,Diego Brandao,Joey Gambino,Red,Featherweight
+10/13/2012,Sergio Moraes,Renee Forte,Red,Welterweight
+10/13/2012,Luiz Cane,Chris Camozzi,Blue,Middleweight
+10/13/2012,Cristiano Marcello,Reza Madadi,Red,Lightweight
+10/05/2012,Travis Browne,Antonio Silva,Blue,Heavyweight
+10/05/2012,Jake Ellenberger,Jay Hieron,Red,Welterweight
+10/05/2012,John Dodson,Jussier Formiga,Red,Flyweight
+10/05/2012,Josh Neer,Justin Edwards,Blue,Welterweight
+10/05/2012,Michael Johnson,Danny Castillo,Red,Lightweight
+10/05/2012,Aaron Simpson,Mike Pierce,Blue,Welterweight
+10/05/2012,Marcus LeVesseur,Carlo Prater,Red,Lightweight
+10/05/2012,Jacob Volkmann,Shane Roller,Red,Lightweight
+10/05/2012,Bart Palaszewski,Diego Nunes,Blue,Featherweight
+10/05/2012,Darren Uyenoyama,Phil Harris,Red,Flyweight
+09/29/2012,Stefan Struve,Stipe Miocic,Red,Heavyweight
+09/29/2012,Dan Hardy,Amir Sadollah,Red,Welterweight
+09/29/2012,Brad Pickett,Yves Jabouin,Red,Bantamweight
+09/29/2012,Paul Sass,Matt Wiman,Blue,Lightweight
+09/29/2012,John Hathaway,John Maguire,Red,Welterweight
+09/29/2012,Che Mills,Duane Ludwig,Red,Welterweight
+09/29/2012,Kyle Kingsbury,Jimi Manuwa,Blue,Light Heavyweight
+09/29/2012,Andy Ogle,Akira Corassani,Blue,Featherweight
+09/29/2012,Tom Watson,Brad Tavares,Blue,Middleweight
+09/29/2012,DaMarques Johnson,Gunnar Nelson,Blue,Catch Weight
+09/29/2012,Jason Young,Robert Peralta,Blue,Featherweight
+09/22/2012,Jon Jones,Vitor Belfort,Red,UFC Light Heavyweight Title
+09/22/2012,Joseph Benavidez,Demetrious Johnson,Blue,UFC Flyweight Title
+09/22/2012,Michael Bisping,Brian Stann,Red,Middleweight
+09/22/2012,Matt Hamill,Roger Hollett,Red,Light Heavyweight
+09/22/2012,Cub Swanson,Charles Oliveira,Red,Featherweight
+09/22/2012,Igor Pokrajac,Vinny Magalhaes,Blue,Light Heavyweight
+09/22/2012,TJ Grant,Evan Dunham,Red,Lightweight
+09/22/2012,Sean Pierson,Lance Benoist,Red,Welterweight
+09/22/2012,Jimy Hettes,Marcus Brimage,Blue,Featherweight
+09/22/2012,Seth Baczynski,Simeon Thoresen,Red,Welterweight
+09/22/2012,Mitch Gagnon,Walel Watson,Red,Bantamweight
+09/22/2012,Kyle Noke,Charlie Brenneman,Red,Welterweight
+08/11/2012,Benson Henderson,Frankie Edgar,Red,UFC Lightweight Title
+08/11/2012,Donald Cerrone,Melvin Guillard,Red,Lightweight
+08/11/2012,Yushin Okami,Buddy Roberts,Red,Middleweight
+08/11/2012,Justin Lawrence,Max Holloway,Blue,Featherweight
+08/11/2012,Dennis Bermudez,Tommy Hayden,Red,Featherweight
+08/11/2012,Jared Hamman,Michael Kuiper,Blue,Middleweight
+08/11/2012,Ken Stone,Erik Perez,Blue,Bantamweight
+08/11/2012,Dustin Pague,Chico Camus,Blue,Bantamweight
+08/11/2012,Nik Lentz,Eiji Mitsuoka,Red,Featherweight
+08/04/2012,Mauricio Rua,Brandon Vera,Red,Light Heavyweight
+08/04/2012,Lyoto Machida,Ryan Bader,Red,Light Heavyweight
+08/04/2012,Joe Lauzon,Jamie Varner,Red,Lightweight
+08/04/2012,Mike Swick,DaMarques Johnson,Red,Welterweight
+08/04/2012,Cole Miller,Nam Phan,Blue,Featherweight
+08/04/2012,Josh Grispi,Rani Yahya,Blue,Featherweight
+08/04/2012,Philip De Fries,Oli Thompson,Red,Heavyweight
+08/04/2012,Manvel Gamburyan,Michihiro Omigawa,Red,Featherweight
+08/04/2012,John Moraga,Ulysses Gomez,Red,Flyweight
+07/21/2012,Urijah Faber,Renan Barao,Blue,UFC Interim Bantamweight Title
+07/21/2012,Hector Lombard,Tim Boetsch,Blue,Middleweight
+07/21/2012,Cheick Kongo,Shawn Jordan,Red,Heavyweight
+07/21/2012,Brian Ebersole,James Head,Blue,Welterweight
+07/21/2012,Court McGee,Nick Ring,Blue,Middleweight
+07/21/2012,Anthony Perosh,Ryan Jimmo,Blue,Light Heavyweight
+07/21/2012,Bryan Caraway,Mitch Gagnon,Red,Bantamweight
+07/21/2012,Antonio Carvalho,Daniel Pineda,Red,Featherweight
+07/21/2012,Mitch Clarke,Anton Kuivanen,Blue,Lightweight
+07/11/2012,Mark Munoz,Chris Weidman,Blue,Middleweight
+07/11/2012,James Te Huna,Joey Beltran,Red,Light Heavyweight
+07/11/2012,Aaron Simpson,Kenny Robertson,Red,Welterweight
+07/11/2012,Karlos Vemola,Francis Carmont,Blue,Middleweight
+07/11/2012,TJ Dillashaw,Vaughan Lee,Red,Bantamweight
+07/11/2012,Rafael Dos Anjos,Anthony Njokuani,Red,Lightweight
+07/11/2012,Damacio Page,Alex Caceres,Blue,Bantamweight
+07/11/2012,Chris Cariaso,Josh Ferguson,Red,Flyweight
+07/11/2012,Rafael Natal,Andrew Craig,Blue,Middleweight
+07/11/2012,Marcelo Guimaraes,Dan Stittgen,Red,Welterweight
+07/11/2012,Raphael Assuncao,Issei Tamura,Red,Bantamweight
+07/07/2012,Anderson Silva,Chael Sonnen,Red,UFC Middleweight Title
+07/07/2012,Forrest Griffin,Tito Ortiz,Red,Light Heavyweight
+07/07/2012,Cung Le,Patrick Cote,Red,Middleweight
+07/07/2012,Dong Hyun Kim,Demian Maia,Blue,Welterweight
+07/07/2012,Chad Mendes,Cody McKenzie,Red,Featherweight
+07/07/2012,Ivan Menjivar,Mike Easton,Blue,Bantamweight
+07/07/2012,Melvin Guillard,Fabricio Camoes,Red,Lightweight
+07/07/2012,Gleison Tibau,Khabib Nurmagomedov,Blue,Lightweight
+07/07/2012,Constantinos Philippou,Riki Fukuda,Red,Middleweight
+07/07/2012,John Alessio,Shane Roller,Blue,Lightweight
+07/07/2012,Rafaello Oliveira,Yoislandy Izquierdo,Red,Lightweight
+06/23/2012,Wanderlei Silva,Rich Franklin,Blue,Catch Weight
+06/23/2012,Cezar Ferreira,Sergio Moraes,Red,Ultimate Fighter Brazil 1 Middleweight Tournament Title
+06/23/2012,Godofredo Pepey,Rony Jason,Blue,Ultimate Fighter Brazil 1 Featherweight Tournament Title
+06/23/2012,Fabricio Werdum,Mike Russow,Red,Heavyweight
+06/23/2012,Iuri Alcantara,Hacran Dias,Blue,Featherweight
+06/23/2012,Anistavio Medeiros,Rodrigo Damm,Blue,Featherweight
+06/23/2012,Delson Heleno,Francisco Trinaldo,Blue,Middleweight
+06/23/2012,John Teixeira,Hugo Viana,Blue,Featherweight
+06/23/2012,Thiago Perpetuo,Leonardo Mafra,Red,Middleweight
+06/23/2012,Marcos Vinicius,Wagner Campos,Red,Featherweight
+06/22/2012,Gray Maynard,Clay Guida,Red,Lightweight
+06/22/2012,Sam Stout,Spencer Fisher,Red,Lightweight
+06/22/2012,Brian Ebersole,TJ Waldburger,Red,Welterweight
+06/22/2012,Ross Pearson,Cub Swanson,Blue,Featherweight
+06/22/2012,Hatsu Hioki,Ricardo Lamas,Blue,Featherweight
+06/22/2012,Ramsey Nijem,CJ Keith,Red,Lightweight
+06/22/2012,Rick Story,Brock Jardine,Red,Welterweight
+06/22/2012,Steven Siler,Joey Gambino,Red,Featherweight
+06/22/2012,Nick Catone,Chris Camozzi,Blue,Middleweight
+06/22/2012,Matt Brown,Luis Ramos,Red,Welterweight
+06/22/2012,Dan Miller,Ricardo Funch,Red,Welterweight
+06/22/2012,Ken Stone,Dustin Pague,Red,Bantamweight
+06/08/2012,Demetrious Johnson,Ian McCall,Red,Flyweight
+06/08/2012,Erick Silva,Charlie Brenneman,Red,Welterweight
+06/08/2012,Mike Pyle,Josh Neer,Red,Welterweight
+06/08/2012,Eddie Wineland,Scott Jorgensen,Red,Bantamweight
+06/08/2012,Mike Pierce,Carlos Eduardo Rocha,Red,Welterweight
+06/08/2012,Seth Baczynski,Lance Benoist,Red,Welterweight
+06/08/2012,Leonard Garcia,Matt Grice,Blue,Featherweight
+06/08/2012,Dustin Pague,Jared Papazian,Red,Bantamweight
+06/08/2012,Tim Means,Justin Salas,Red,Lightweight
+06/08/2012,Buddy Roberts,Caio Magalhaes,Red,Middleweight
+06/08/2012,Henry Martinez,Bernardo Magalhaes,Red,Lightweight
+06/08/2012,Jake Hecht,Sean Pierson,Blue,Welterweight
+06/01/2012,Jake Ellenberger,Martin Kampmann,Blue,Welterweight
+06/01/2012,Michael Chiesa,Al Iaquinta,Red,Ultimate Fighter 15 Lightweight Tournament Title
+06/01/2012,Jonathan Brookins,Charles Oliveira,Blue,Featherweight
+06/01/2012,Max Holloway,Pat Schilling,Red,Featherweight
+06/01/2012,Justin Lawrence,John Cofer,Red,Lightweight
+06/01/2012,Daron Cruickshank,Chris Tickle,Red,Lightweight
+06/01/2012,Myles Jury,Chris Saunders,Red,Lightweight
+06/01/2012,Cristiano Marcello,Sam Sicilia,Blue,Lightweight
+06/01/2012,Joe Proctor,Jeremy Larsen,Red,Lightweight
+06/01/2012,John Albert,Erik Perez,Blue,Bantamweight
+05/26/2012,Junior Dos Santos,Frank Mir,Red,UFC Heavyweight Title
+05/26/2012,Cain Velasquez,Antonio Silva,Red,Heavyweight
+05/26/2012,Roy Nelson,Dave Herman,Red,Heavyweight
+05/26/2012,Stipe Miocic,Shane del Rosario,Red,Heavyweight
+05/26/2012,Stefan Struve,Lavar Johnson,Red,Heavyweight
+05/26/2012,Diego Brandao,Darren Elkins,Blue,Featherweight
+05/26/2012,Edson Barboza,Jamie Varner,Blue,Lightweight
+05/26/2012,Jason Miller,CB Dollaway,Blue,Middleweight
+05/26/2012,Dan Hardy,Duane Ludwig,Red,Welterweight
+05/26/2012,Jacob Volkmann,Paul Sass,Blue,Lightweight
+05/26/2012,Kyle Kingsbury,Glover Teixeira,Blue,Light Heavyweight
+05/26/2012,Mike Brown,Daniel Pineda,Red,Featherweight
+05/15/2012,Chan Sung Jung,Dustin Poirier,Red,Featherweight
+05/15/2012,Amir Sadollah,Jorge Lopez,Red,Welterweight
+05/15/2012,Donald Cerrone,Jeremy Stephens,Red,Lightweight
+05/15/2012,Yves Jabouin,Jeff Hougland,Red,Bantamweight
+05/15/2012,Igor Pokrajac,Fabio Maldonado,Red,Light Heavyweight
+05/15/2012,Jason MacDonald,Tom Lawlor,Blue,Middleweight
+05/15/2012,Brad Tavares,Dongi Yang,Red,Middleweight
+05/15/2012,Cody McKenzie,Marcus LeVesseur,Red,Lightweight
+05/15/2012,TJ Grant,Carlo Prater,Red,Lightweight
+05/15/2012,Rafael Dos Anjos,Kamal Shalorus,Red,Lightweight
+05/15/2012,Jeff Curran,Johnny Eduardo,Blue,Bantamweight
+05/15/2012,Alex Soto,Francisco Rivera,Blue,Bantamweight
+05/05/2012,Nate Diaz,Jim Miller,Red,Lightweight
+05/05/2012,Josh Koscheck,Johny Hendricks,Blue,Welterweight
+05/05/2012,Rousimar Palhares,Alan Belcher,Blue,Middleweight
+05/05/2012,Pat Barry,Lavar Johnson,Blue,Heavyweight
+05/05/2012,Tony Ferguson,Michael Johnson,Blue,Lightweight
+05/05/2012,John Dodson,Tim Elliott,Red,Flyweight
+05/05/2012,John Hathaway,Pascal Krauss,Red,Welterweight
+05/05/2012,Louis Gaudinot,John Lineker,Red,Flyweight
+05/05/2012,Danny Castillo,John Cholish,Red,Lightweight
+05/05/2012,Dennis Bermudez,Pablo Garza,Red,Featherweight
+05/05/2012,Roland Delorme,Nick Denis,Red,Bantamweight
+05/05/2012,Mike Massenzio,Karlos Vemola,Blue,Middleweight
+04/21/2012,Jon Jones,Rashad Evans,Red,UFC Light Heavyweight Title
+04/21/2012,Rory MacDonald,Che Mills,Red,Welterweight
+04/21/2012,Brendan Schaub,Ben Rothwell,Blue,Heavyweight
+04/21/2012,Miguel Torres,Michael McDonald,Blue,Bantamweight
+04/21/2012,Mark Hominick,Eddie Yagin,Blue,Featherweight
+04/21/2012,Mark Bocek,John Alessio,Red,Lightweight
+04/21/2012,Travis Browne,Chad Griggs,Red,Heavyweight
+04/21/2012,Matt Brown,Stephen Thompson,Red,Welterweight
+04/21/2012,John Makdessi,Anthony Njokuani,Blue,Lightweight
+04/21/2012,Mac Danzig,Efrain Escudero,Red,Lightweight
+04/21/2012,Keith Wisniewski,Chris Clements,Blue,Welterweight
+04/21/2012,Marcus Brimage,Maximo Blanco,Red,Featherweight
+04/14/2012,Alexander Gustafsson,Thiago Silva,Red,Light Heavyweight
+04/14/2012,Brian Stann,Alessio Sakara,Red,Middleweight
+04/14/2012,Paulo Thiago,Siyar Bahadurzada,Blue,Welterweight
+04/14/2012,Dennis Siver,Diego Nunes,Red,Featherweight
+04/14/2012,DaMarques Johnson,John Maguire,Blue,Welterweight
+04/14/2012,Brad Pickett,Damacio Page,Red,Bantamweight
+04/14/2012,Papy Abedi,James Head,Blue,Welterweight
+04/14/2012,Cyrille Diabate,Tom DeBlass,Red,Light Heavyweight
+04/14/2012,Francis Carmont,Magnus Cedenblad,Red,Middleweight
+04/14/2012,Reza Madadi,Yoislandy Izquierdo,Red,Lightweight
+04/14/2012,Simeon Thoresen,Besam Yousef,Red,Welterweight
+04/14/2012,Jason Young,Eric Wisely,Red,Featherweight
+03/02/2012,Thiago Alves,Martin Kampmann,Blue,Welterweight
+03/02/2012,Joseph Benavidez,Yasuhiro Urushitani,Red,Flyweight
+03/02/2012,Court McGee,Constantinos Philippou,Blue,Middleweight
+03/02/2012,James Te Huna,Aaron Rosa,Red,Light Heavyweight
+03/02/2012,Anthony Perosh,Nick Penner,Red,Light Heavyweight
+03/02/2012,Cole Miller,Steven Siler,Blue,Featherweight
+03/02/2012,Kyle Noke,Andrew Craig,Blue,Middleweight
+03/02/2012,TJ Waldburger,Jake Hecht,Red,Welterweight
+03/02/2012,Mackens Semerzier,Daniel Pineda,Blue,Featherweight
+03/02/2012,Oli Thompson,Shawn Jordan,Blue,Heavyweight
+02/25/2012,Frankie Edgar,Benson Henderson,Blue,UFC Lightweight Title
+02/25/2012,Quinton Jackson,Ryan Bader,Blue,Light Heavyweight
+02/25/2012,Mark Hunt,Cheick Kongo,Red,Heavyweight
+02/25/2012,Yoshihiro Akiyama,Jake Shields,Blue,Welterweight
+02/25/2012,Yushin Okami,Tim Boetsch,Blue,Middleweight
+02/25/2012,Hatsu Hioki,Bart Palaszewski,Red,Featherweight
+02/25/2012,Anthony Pettis,Joe Lauzon,Red,Lightweight
+02/25/2012,Takanori Gomi,Eiji Mitsuoka,Red,Lightweight
+02/25/2012,Norifumi Yamamoto,Vaughan Lee,Blue,Bantamweight
+02/25/2012,Riki Fukuda,Steve Cantwell,Red,Middleweight
+02/25/2012,Takeya Mizugaki,Chris Cariaso,Blue,Bantamweight
+02/25/2012,Zhang Tiequan,Issei Tamura,Blue,Featherweight
+02/15/2012,Diego Sanchez,Jake Ellenberger,Blue,Welterweight
+02/15/2012,Stefan Struve,Dave Herman,Red,Heavyweight
+02/15/2012,Aaron Simpson,Ronny Markes,Blue,Middleweight
+02/15/2012,Stipe Miocic,Philip De Fries,Red,Heavyweight
+02/15/2012,TJ Dillashaw,Walel Watson,Red,Bantamweight
+02/15/2012,Ivan Menjivar,John Albert,Red,Bantamweight
+02/15/2012,Jonathan Brookins,Vagner Rocha,Red,Featherweight
+02/15/2012,Anton Kuivanen,Justin Salas,Blue,Lightweight
+02/15/2012,Tim Means,Bernardo Magalhaes,Red,Lightweight
+02/04/2012,Nick Diaz,Carlos Condit,Blue,UFC Interim Welterweight Title
+02/04/2012,Roy Nelson,Fabricio Werdum,Blue,Heavyweight
+02/04/2012,Josh Koscheck,Mike Pierce,Red,Welterweight
+02/04/2012,Renan Barao,Scott Jorgensen,Red,Bantamweight
+02/04/2012,Ed Herman,Clifford Starks,Red,Middleweight
+02/04/2012,Dustin Poirier,Max Holloway,Red,Featherweight
+02/04/2012,Alex Caceres,Edwin Figueroa,Blue,Bantamweight
+02/04/2012,Matt Brown,Chris Cope,Red,Welterweight
+02/04/2012,Matthew Riddle,Henry Martinez,Red,Welterweight
+02/04/2012,Rafael Natal,Michael Kuiper,Red,Middleweight
+02/04/2012,Dan Stittgen,Stephen Thompson,Blue,Welterweight
+01/28/2012,Rashad Evans,Phil Davis,Red,Light Heavyweight
+01/28/2012,Chael Sonnen,Michael Bisping,Red,Middleweight
+01/28/2012,Demian Maia,Chris Weidman,Blue,Middleweight
+01/28/2012,Evan Dunham,Nik Lentz,Red,Lightweight
+01/28/2012,Mike Russow,Jon Olav Einemo,Red,Heavyweight
+01/28/2012,Cub Swanson,George Roop,Red,Featherweight
+01/28/2012,Charles Oliveira,Eric Wisely,Red,Featherweight
+01/28/2012,Michael Johnson,Shane Roller,Red,Lightweight
+01/28/2012,Joey Beltran,Lavar Johnson,Blue,Heavyweight
+01/28/2012,Chris Camozzi,Dustin Jacoby,Red,Middleweight
+01/20/2012,Melvin Guillard,Jim Miller,Blue,Lightweight
+01/20/2012,Duane Ludwig,Josh Neer,Blue,Welterweight
+01/20/2012,Mike Easton,Jared Papazian,Red,Bantamweight
+01/20/2012,Pat Barry,Christian Morecraft,Red,Heavyweight
+01/20/2012,Jorge Rivera,Eric Schafer,Red,Middleweight
+01/20/2012,Kamal Shalorus,Khabib Nurmagomedov,Blue,Lightweight
+01/20/2012,Charlie Brenneman,Daniel Roberts,Red,Welterweight
+01/20/2012,Fabricio Camoes,Tommy Hayden,Red,Lightweight
+01/20/2012,Daniel Pineda,Pat Schilling,Red,Featherweight
+01/20/2012,Joseph Sandoval,Nick Denis,Blue,Bantamweight
+01/14/2012,Jose Aldo,Chad Mendes,Red,UFC Featherweight Title
+01/14/2012,Vitor Belfort,Anthony Johnson,Red,Middleweight
+01/14/2012,Rousimar Palhares,Mike Massenzio,Red,Middleweight
+01/14/2012,Erick Silva,Carlo Prater,Blue,Welterweight
+01/14/2012,Edson Barboza,Terry Etim,Red,Lightweight
+01/14/2012,Thiago Tavares,Sam Stout,Red,Lightweight
+01/14/2012,Gabriel Gonzaga,Ednaldo Oliveira,Red,Heavyweight
+01/14/2012,Iuri Alcantara,Michihiro Omigawa,Red,Featherweight
+01/14/2012,Ricardo Funch,Mike Pyle,Blue,Welterweight
+01/14/2012,Felipe Arantes,Antonio Carvalho,Red,Featherweight
+12/30/2011,Brock Lesnar,Alistair Overeem,Blue,Heavyweight
+12/30/2011,Nate Diaz,Donald Cerrone,Red,Lightweight
+12/30/2011,Jon Fitch,Johny Hendricks,Blue,Welterweight
+12/30/2011,Vladimir Matyushenko,Alexander Gustafsson,Blue,Light Heavyweight
+12/30/2011,Nam Phan,Jimy Hettes,Blue,Featherweight
+12/30/2011,Ross Pearson,Junior Assuncao,Red,Featherweight
+12/30/2011,Anthony Njokuani,Danny Castillo,Blue,Lightweight
+12/30/2011,Dong Hyun Kim,Sean Pierson,Red,Welterweight
+12/30/2011,Jacob Volkmann,Efrain Escudero,Red,Lightweight
+12/30/2011,Manvel Gamburyan,Diego Nunes,Blue,Featherweight
+12/10/2011,Jon Jones,Lyoto Machida,Red,UFC Light Heavyweight Title
+12/10/2011,Frank Mir,Antonio Rodrigo Nogueira,Red,Heavyweight
+12/10/2011,Tito Ortiz,Rogerio Nogueira,Blue,Light Heavyweight
+12/10/2011,Claude Patrick,Brian Ebersole,Blue,Welterweight
+12/10/2011,Mark Hominick,Chan Sung Jung,Blue,Featherweight
+12/10/2011,Krzysztof Soszynski,Igor Pokrajac,Blue,Light Heavyweight
+12/10/2011,Jared Hamman,Constantinos Philippou,Blue,Middleweight
+12/10/2011,John Makdessi,Dennis Hallman,Blue,Lightweight
+12/10/2011,Walel Watson,Yves Jabouin,Blue,Bantamweight
+12/10/2011,Mark Bocek,Nik Lentz,Red,Lightweight
+12/10/2011,Rich Attonito,Jake Hecht,Blue,Welterweight
+12/10/2011,Mitch Clarke,John Cholish,Blue,Lightweight
+12/03/2011,Michael Bisping,Jason Miller,Red,Middleweight
+12/03/2011,Diego Brandao,Dennis Bermudez,Red,Ultimate Fighter 14 Featherweight Tournament Title
+12/03/2011,TJ Dillashaw,John Dodson,Blue,Ultimate Fighter 14 Bantamweight Tournament Title
+12/03/2011,Tony Ferguson,Yves Edwards,Red,Lightweight
+12/03/2011,Louis Gaudinot,Johnny Bedford,Blue,Bantamweight
+12/03/2011,Marcus Brimage,Stephen Bass,Red,Featherweight
+12/03/2011,Dustin Pague,John Albert,Blue,Bantamweight
+12/03/2011,Roland Delorme,Josh Ferguson,Red,Bantamweight
+12/03/2011,Steven Siler,Josh Clopton,Red,Featherweight
+12/03/2011,Bryan Caraway,Dustin Neace,Red,Featherweight
+11/19/2011,Mauricio Rua,Dan Henderson,Blue,Light Heavyweight
+11/19/2011,Wanderlei Silva,Cung Le,Red,Middleweight
+11/19/2011,Urijah Faber,Brian Bowles,Red,Bantamweight
+11/19/2011,Rick Story,Martin Kampmann,Blue,Welterweight
+11/19/2011,Stephan Bonnar,Kyle Kingsbury,Red,Light Heavyweight
+11/19/2011,Ryan Bader,Jason Brilz,Red,Light Heavyweight
+11/19/2011,Michael McDonald,Alex Soto,Red,Bantamweight
+11/19/2011,Tom Lawlor,Chris Weidman,Blue,Middleweight
+11/19/2011,Gleison Tibau,Rafael Dos Anjos,Red,Lightweight
+11/19/2011,Miguel Torres,Nick Pace,Red,Bantamweight
+11/19/2011,Matt Brown,Seth Baczynski,Blue,Welterweight
+11/19/2011,Danny Castillo,Shamar Bailey,Red,Lightweight
+11/12/2011,Cain Velasquez,Junior Dos Santos,Blue,UFC Heavyweight Title
+11/12/2011,Clay Guida,Benson Henderson,Blue,Lightweight
+11/12/2011,Dustin Poirier,Pablo Garza,Red,Featherweight
+11/12/2011,Cub Swanson,Ricardo Lamas,Blue,Featherweight
+11/12/2011,DaMarques Johnson,Clay Harvison,Red,Welterweight
+11/12/2011,Norifumi Yamamoto,Darren Uyenoyama,Blue,Bantamweight
+11/12/2011,Alex Caceres,Cole Escovedo,Red,Bantamweight
+11/12/2011,Mike Pierce,Paul Bradley,Red,Welterweight
+11/12/2011,Aaron Rosa,Matt Lucas,Red,Light Heavyweight
+11/05/2011,Chris Leben,Mark Munoz,Blue,Middleweight
+11/05/2011,Brad Pickett,Renan Barao,Blue,Bantamweight
+11/05/2011,Thiago Alves,Papy Abedi,Red,Welterweight
+11/05/2011,Cyrille Diabate,Anthony Perosh,Blue,Light Heavyweight
+11/05/2011,Terry Etim,Edward Faaloloto,Red,Lightweight
+11/05/2011,John Maguire,Justin Edwards,Red,Welterweight
+11/05/2011,Rob Broughton,Philip De Fries,Blue,Heavyweight
+11/05/2011,Michihiro Omigawa,Jason Young,Red,Featherweight
+11/05/2011,Chris Cope,Che Mills,Blue,Welterweight
+11/05/2011,Chris Cariaso,Vaughan Lee,Red,Bantamweight
+10/29/2011,BJ Penn,Nick Diaz,Blue,Welterweight
+10/29/2011,Cheick Kongo,Matt Mitrione,Red,Heavyweight
+10/29/2011,Mirko Filipovic,Roy Nelson,Blue,Heavyweight
+10/29/2011,Scott Jorgensen,Jeff Curran,Red,Bantamweight
+10/29/2011,Hatsu Hioki,George Roop,Red,Featherweight
+10/29/2011,Dennis Siver,Donald Cerrone,Blue,Lightweight
+10/29/2011,Tyson Griffin,Bart Palaszewski,Blue,Featherweight
+10/29/2011,Brandon Vera,Eliot Marshall,Red,Light Heavyweight
+10/29/2011,Ramsey Nijem,Danny Downes,Red,Lightweight
+10/29/2011,Chris Camozzi,Francis Carmont,Blue,Middleweight
+10/29/2011,Dustin Jacoby,Clifford Starks,Blue,Middleweight
+10/08/2011,Frankie Edgar,Gray Maynard,Red,UFC Lightweight Title
+10/08/2011,Jose Aldo,Kenny Florian,Red,UFC Featherweight Title
+10/08/2011,Chael Sonnen,Brian Stann,Red,Middleweight
+10/08/2011,Leonard Garcia,Nam Phan,Blue,Featherweight
+10/08/2011,Melvin Guillard,Joe Lauzon,Blue,Lightweight
+10/08/2011,Demian Maia,Jorge Santiago,Red,Middleweight
+10/08/2011,Anthony Pettis,Jeremy Stephens,Red,Lightweight
+10/08/2011,Joey Beltran,Stipe Miocic,Blue,Heavyweight
+10/08/2011,Zhang Tiequan,Darren Elkins,Blue,Featherweight
+10/08/2011,Aaron Simpson,Eric Schafer,Red,Middleweight
+10/08/2011,Steve Cantwell,Mike Massenzio,Blue,Middleweight
+10/01/2011,Dominick Cruz,Demetrious Johnson,Red,UFC Bantamweight Title
+10/01/2011,Pat Barry,Stefan Struve,Blue,Heavyweight
+10/01/2011,Anthony Johnson,Charlie Brenneman,Red,Welterweight
+10/01/2011,Matt Wiman,Mac Danzig,Red,Lightweight
+10/01/2011,Yves Edwards,Rafaello Oliveira,Red,Lightweight
+10/01/2011,Michael Johnson,Paul Sass,Blue,Lightweight
+10/01/2011,Mike Easton,Byron Bloodworth,Red,Bantamweight
+10/01/2011,Shane Roller,TJ Grant,Blue,Lightweight
+10/01/2011,Josh Neer,Keith Wisniewski,Red,Welterweight
+10/01/2011,Walel Watson,Joseph Sandoval,Red,Bantamweight
+09/24/2011,Jon Jones,Quinton Jackson,Red,UFC Light Heavyweight Title
+09/24/2011,Matt Hughes,Josh Koscheck,Blue,Welterweight
+09/24/2011,Ben Rothwell,Mark Hunt,Blue,Heavyweight
+09/24/2011,Travis Browne,Rob Broughton,Red,Heavyweight
+09/24/2011,Nate Diaz,Takanori Gomi,Red,Lightweight
+09/24/2011,Tony Ferguson,Aaron Riley,Red,Lightweight
+09/24/2011,Nick Ring,Tim Boetsch,Blue,Middleweight
+09/24/2011,Junior Assuncao,Eddie Yagin,Red,Featherweight
+09/24/2011,Takeya Mizugaki,Cole Escovedo,Red,Bantamweight
+09/24/2011,James Te Huna,Ricardo Romero,Red,Light Heavyweight
+09/17/2011,Jake Shields,Jake Ellenberger,Blue,Welterweight
+09/17/2011,Court McGee,Dongi Yang,Red,Middleweight
+09/17/2011,Jonathan Brookins,Erik Koch,Blue,Featherweight
+09/17/2011,Alan Belcher,Jason MacDonald,Red,Middleweight
+09/17/2011,Cody McKenzie,Vagner Rocha,Blue,Lightweight
+09/17/2011,Evan Dunham,Shamar Bailey,Red,Lightweight
+09/17/2011,Matthew Riddle,Lance Benoist,Blue,Welterweight
+09/17/2011,Ken Stone,Donny Walker,Red,Bantamweight
+09/17/2011,Clay Harvison,Seth Baczynski,Blue,Welterweight
+09/17/2011,TJ Waldburger,Mike Stumpf,Red,Welterweight
+09/17/2011,Robert Peralta,Mike Lullo,Red,Featherweight
+09/17/2011,Justin Edwards,Jorge Lopez,Red,Welterweight
+08/27/2011,Anderson Silva,Yushin Okami,Red,UFC Middleweight Title
+08/27/2011,Mauricio Rua,Forrest Griffin,Red,Light Heavyweight
+08/27/2011,Ross Pearson,Edson Barboza,Blue,Lightweight
+08/27/2011,Antonio Rodrigo Nogueira,Brendan Schaub,Red,Heavyweight
+08/27/2011,Luiz Cane,Stanislav Nedkov,Blue,Light Heavyweight
+08/27/2011,Thiago Tavares,Spencer Fisher,Red,Lightweight
+08/27/2011,Rousimar Palhares,Dan Miller,Red,Middleweight
+08/27/2011,Paulo Thiago,David Mitchell,Red,Welterweight
+08/27/2011,Raphael Assuncao,Johnny Eduardo,Red,Bantamweight
+08/27/2011,Erick Silva,Luis Ramos,Red,Welterweight
+08/27/2011,Iuri Alcantara,Felipe Arantes,Red,Featherweight
+08/27/2011,Yves Jabouin,Ian Loveland,Red,Bantamweight
+08/14/2011,Dan Hardy,Chris Lytle,Blue,Welterweight
+08/14/2011,Jim Miller,Benson Henderson,Blue,Lightweight
+08/14/2011,Donald Cerrone,Charles Oliveira,Red,Lightweight
+08/14/2011,Amir Sadollah,Duane Ludwig,Blue,Welterweight
+08/14/2011,CB Dollaway,Jared Hamman,Blue,Middleweight
+08/14/2011,Joseph Benavidez,Eddie Wineland,Red,Bantamweight
+08/14/2011,Ed Herman,Kyle Noke,Red,Middleweight
+08/14/2011,Ronny Markes,Karlos Vemola,Red,Light Heavyweight
+08/14/2011,Jimy Hettes,Alex Caceres,Red,Featherweight
+08/14/2011,Cole Miller,TJ O'Brien,Red,Lightweight
+08/14/2011,Jacob Volkmann,Danny Castillo,Red,Lightweight
+08/14/2011,Edwin Figueroa,Jason Reinhardt,Red,Bantamweight
+08/06/2011,Rashad Evans,Tito Ortiz,Red,Light Heavyweight
+08/06/2011,Vitor Belfort,Yoshihiro Akiyama,Red,Middleweight
+08/06/2011,Dennis Hallman,Brian Ebersole,Blue,Welterweight
+08/06/2011,Jorge Rivera,Constantinos Philippou,Blue,Middleweight
+08/06/2011,Rory MacDonald,Mike Pyle,Red,Welterweight
+08/06/2011,Matt Hamill,Alexander Gustafsson,Blue,Light Heavyweight
+08/06/2011,Chad Mendes,Rani Yahya,Red,Featherweight
+08/06/2011,Ivan Menjivar,Nick Pace,Red,Bantamweight
+08/06/2011,Johny Hendricks,Mike Pierce,Red,Welterweight
+08/06/2011,Mike Brown,Nam Phan,Red,Featherweight
+08/06/2011,Rafael Natal,Paul Bradley,Red,Middleweight
+07/02/2011,Dominick Cruz,Urijah Faber,Red,UFC Bantamweight Title
+07/02/2011,Wanderlei Silva,Chris Leben,Blue,Middleweight
+07/02/2011,Dennis Siver,Matt Wiman,Red,Lightweight
+07/02/2011,Tito Ortiz,Ryan Bader,Red,Light Heavyweight
+07/02/2011,Carlos Condit,Dong Hyun Kim,Red,Welterweight
+07/02/2011,Melvin Guillard,Shane Roller,Red,Lightweight
+07/02/2011,George Sotiropoulos,Rafael Dos Anjos,Blue,Lightweight
+07/02/2011,Brian Bowles,Takeya Mizugaki,Red,Bantamweight
+07/02/2011,Brad Tavares,Aaron Simpson,Blue,Middleweight
+07/02/2011,Anthony Njokuani,Andre Winner,Red,Lightweight
+07/02/2011,Jeff Hougland,Donny Walker,Red,Bantamweight
+06/26/2011,Cheick Kongo,Pat Barry,Red,Heavyweight
+06/26/2011,Charlie Brenneman,Rick Story,Red,Welterweight
+06/26/2011,Matt Brown,John Howard,Red,Welterweight
+06/26/2011,Christian Morecraft,Matt Mitrione,Blue,Heavyweight
+06/26/2011,Tyson Griffin,Manvel Gamburyan,Red,Featherweight
+06/26/2011,Joe Stevenson,Javier Vazquez,Blue,Featherweight
+06/26/2011,Joe Lauzon,Curt Warburton,Red,Lightweight
+06/26/2011,Daniel Roberts,Rich Attonito,Blue,Welterweight
+06/26/2011,Ricardo Lamas,Matt Grice,Red,Featherweight
+06/26/2011,Michael Johnson,Edward Faaloloto,Red,Lightweight
+06/11/2011,Shane Carwin,Junior Dos Santos,Blue,Heavyweight
+06/11/2011,Kenny Florian,Diego Nunes,Red,Featherweight
+06/11/2011,Mark Munoz,Demian Maia,Red,Middleweight
+06/11/2011,Dave Herman,Jon Olav Einemo,Red,Heavyweight
+06/11/2011,Vagner Rocha,Donald Cerrone,Blue,Lightweight
+06/11/2011,Yves Edwards,Sam Stout,Blue,Lightweight
+06/11/2011,Jesse Bongfeldt,Chris Weidman,Blue,Middleweight
+06/11/2011,Mike Massenzio,Krzysztof Soszynski,Blue,Light Heavyweight
+06/11/2011,Nick Ring,James Head,Red,Middleweight
+06/11/2011,Dustin Poirier,Jason Young,Red,Featherweight
+06/11/2011,Joey Beltran,Aaron Rosa,Red,Heavyweight
+06/11/2011,Darren Elkins,Michihiro Omigawa,Red,Featherweight
+06/04/2011,Ramsey Nijem,Tony Ferguson,Blue,Ultimate Fighter 13 Welterweight Tournament Title
+06/04/2011,Clay Guida,Anthony Pettis,Red,Lightweight
+06/04/2011,Ed Herman,Tim Credeur,Red,Middleweight
+06/04/2011,Fabio Maldonado,Kyle Kingsbury,Blue,Light Heavyweight
+06/04/2011,Chuck O'Neil,Chris Cope,Blue,Welterweight
+06/04/2011,Danny Downes,Jeremy Stephens,Blue,Lightweight
+06/04/2011,Josh Grispi,George Roop,Blue,Featherweight
+06/04/2011,Ryan McGillivray,Shamar Bailey,Blue,Welterweight
+06/04/2011,Clay Harvison,Justin Edwards,Red,Welterweight
+06/04/2011,Scott Jorgensen,Ken Stone,Red,Bantamweight
+06/04/2011,Reuben Duran,Francisco Rivera,Red,Bantamweight
+05/28/2011,Quinton Jackson,Matt Hamill,Red,Light Heavyweight
+05/28/2011,Frank Mir,Roy Nelson,Red,Heavyweight
+05/28/2011,Stefan Struve,Travis Browne,Blue,Heavyweight
+05/28/2011,Thiago Alves,Rick Story,Blue,Welterweight
+05/28/2011,Brian Stann,Jorge Santiago,Red,Middleweight
+05/28/2011,Miguel Torres,Demetrious Johnson,Blue,Bantamweight
+05/28/2011,Kendall Grove,Tim Boetsch,Blue,Middleweight
+05/28/2011,Gleison Tibau,Rafaello Oliveira,Red,Lightweight
+05/28/2011,Michael McDonald,Chris Cariaso,Red,Bantamweight
+05/28/2011,Cole Escovedo,Renan Barao,Blue,Bantamweight
+04/30/2011,Georges St-Pierre,Jake Shields,Red,UFC Welterweight Title
+04/30/2011,Jose Aldo,Mark Hominick,Red,UFC Featherweight Title
+04/30/2011,Lyoto Machida,Randy Couture,Red,Light Heavyweight
+04/30/2011,Vladimir Matyushenko,Jason Brilz,Red,Light Heavyweight
+04/30/2011,Mark Bocek,Benson Henderson,Blue,Lightweight
+04/30/2011,Nate Diaz,Rory MacDonald,Blue,Welterweight
+04/30/2011,Jake Ellenberger,Sean Pierson,Red,Welterweight
+04/30/2011,Daniel Roberts,Claude Patrick,Blue,Welterweight
+04/30/2011,Ivan Menjivar,Charlie Valencia,Red,Bantamweight
+04/30/2011,Jason MacDonald,Ryan Jensen,Red,Middleweight
+04/30/2011,John Makdessi,Kyle Watson,Red,Lightweight
+04/30/2011,Yves Jabouin,Pablo Garza,Blue,Featherweight
+03/26/2011,Phil Davis,Rogerio Nogueira,Red,Light Heavyweight
+03/26/2011,Anthony Johnson,Dan Hardy,Red,Welterweight
+03/26/2011,DaMarques Johnson,Amir Sadollah,Blue,Welterweight
+03/26/2011,Chan Sung Jung,Leonard Garcia,Red,Featherweight
+03/26/2011,Jon Madsen,Mike Russow,Blue,Heavyweight
+03/26/2011,Alex Caceres,Mackens Semerzier,Blue,Featherweight
+03/26/2011,John Hathaway,Kris McCray,Red,Welterweight
+03/26/2011,Michael McDonald,Edwin Figueroa,Red,Bantamweight
+03/26/2011,Sean McCorkle,Christian Morecraft,Blue,Heavyweight
+03/26/2011,Johny Hendricks,TJ Waldburger,Red,Welterweight
+03/26/2011,Mario Miranda,Aaron Simpson,Blue,Middleweight
+03/26/2011,Waylon Lowe,Nik Lentz,Blue,Lightweight
+03/19/2011,Mauricio Rua,Jon Jones,Blue,UFC Light Heavyweight Title
+03/19/2011,Urijah Faber,Eddie Wineland,Red,Bantamweight
+03/19/2011,Jim Miller,Kamal Shalorus,Red,Lightweight
+03/19/2011,Dan Miller,Nate Marquardt,Blue,Middleweight
+03/19/2011,Mirko Filipovic,Brendan Schaub,Blue,Heavyweight
+03/19/2011,Luiz Cane,Eliot Marshall,Red,Light Heavyweight
+03/19/2011,Edson Barboza,Anthony Njokuani,Red,Lightweight
+03/19/2011,Ricardo Almeida,Mike Pyle,Blue,Welterweight
+03/19/2011,Kurt Pellegrino,Gleison Tibau,Blue,Lightweight
+03/19/2011,Joseph Benavidez,Ian Loveland,Red,Bantamweight
+03/19/2011,Constantinos Philippou,Nick Catone,Blue,Catch Weight
+03/19/2011,Erik Koch,Raphael Assuncao,Red,Featherweight
+03/03/2011,Diego Sanchez,Martin Kampmann,Red,Welterweight
+03/03/2011,CB Dollaway,Mark Munoz,Blue,Middleweight
+03/03/2011,Alessio Sakara,Chris Weidman,Blue,Middleweight
+03/03/2011,Brian Bowles,Damacio Page,Red,Bantamweight
+03/03/2011,Steve Cantwell,Cyrille Diabate,Blue,Light Heavyweight
+03/03/2011,Joe Stevenson,Danny Castillo,Blue,Lightweight
+03/03/2011,Thiago Tavares,Shane Roller,Blue,Lightweight
+03/03/2011,Takeya Mizugaki,Reuben Duran,Red,Bantamweight
+03/03/2011,Rob Kimmons,Dongi Yang,Blue,Middleweight
+03/03/2011,David Branch,Rousimar Palhares,Blue,Middleweight
+03/03/2011,Igor Pokrajac,Todd Brown,Red,Light Heavyweight
+02/26/2011,Michael Bisping,Jorge Rivera,Red,Middleweight
+02/26/2011,George Sotiropoulos,Dennis Siver,Blue,Lightweight
+02/26/2011,Brian Ebersole,Chris Lytle,Red,Welterweight
+02/26/2011,Chris Camozzi,Kyle Noke,Blue,Middleweight
+02/26/2011,Ross Pearson,Spencer Fisher,Red,Lightweight
+02/26/2011,Alexander Gustafsson,James Te Huna,Red,Light Heavyweight
+02/26/2011,Nick Ring,Riki Fukuda,Red,Middleweight
+02/26/2011,Tom Blackledge,Anthony Perosh,Blue,Light Heavyweight
+02/26/2011,Zhang Tiequan,Jason Reinhardt,Red,Featherweight
+02/26/2011,Mark Hunt,Chris Tuchscherer,Red,Heavyweight
+02/26/2011,Maciej Jewtuszko,Curt Warburton,Blue,Lightweight
+02/05/2011,Anderson Silva,Vitor Belfort,Red,UFC Middleweight Title
+02/05/2011,Forrest Griffin,Rich Franklin,Red,Light Heavyweight
+02/05/2011,Jon Jones,Ryan Bader,Red,Light Heavyweight
+02/05/2011,Jake Ellenberger,Carlos Eduardo Rocha,Red,Welterweight
+02/05/2011,Miguel Torres,Antonio Banuelos,Red,Bantamweight
+02/05/2011,Donald Cerrone,Paul Kelly,Red,Lightweight
+02/05/2011,Chad Mendes,Michihiro Omigawa,Red,Featherweight
+02/05/2011,Norifumi Yamamoto,Demetrious Johnson,Blue,Bantamweight
+02/05/2011,Paul Taylor,Gabe Ruediger,Red,Lightweight
+02/05/2011,Kyle Kingsbury,Ricardo Romero,Red,Light Heavyweight
+02/05/2011,Mike Pierce,Kenny Robertson,Red,Welterweight
+01/22/2011,Melvin Guillard,Evan Dunham,Red,Lightweight
+01/22/2011,Matt Mitrione,Tim Hague,Red,Heavyweight
+01/22/2011,Mark Hominick,George Roop,Red,Featherweight
+01/22/2011,Pat Barry,Joey Beltran,Red,Heavyweight
+01/22/2011,Cole Miller,Matt Wiman,Blue,Lightweight
+01/22/2011,Cody McKenzie,Yves Edwards,Blue,Lightweight
+01/22/2011,DaMarques Johnson,Mike Guymon,Red,Welterweight
+01/22/2011,Rani Yahya,Mike Brown,Red,Featherweight
+01/22/2011,Waylon Lowe,Willamy Freire,Red,Lightweight
+01/22/2011,Charlie Brenneman,Amilcar Alves,Red,Welterweight
+01/22/2011,Will Campuzano,Chris Cariaso,Blue,Bantamweight
+01/01/2011,Chris Leben,Brian Stann,Blue,Middleweight
+01/01/2011,Nate Diaz,Dong Hyun Kim,Blue,Welterweight
+01/01/2011,Clay Guida,Takanori Gomi,Red,Lightweight
+01/01/2011,Jeremy Stephens,Marcus Davis,Red,Lightweight
+01/01/2011,Dustin Poirier,Josh Grispi,Red,Featherweight
+01/01/2011,Phil Baroni,Brad Tavares,Blue,Middleweight
+01/01/2011,Mike Brown,Diego Nunes,Blue,Featherweight
+01/01/2011,Daniel Roberts,Greg Soto,Red,Welterweight
+01/01/2011,Jacob Volkmann,Antonio McKee,Red,Lightweight
+12/11/2010,Georges St-Pierre,Josh Koscheck,Red,UFC Welterweight Title
+12/11/2010,Stefan Struve,Sean McCorkle,Red,Heavyweight
+12/11/2010,Jim Miller,Charles Oliveira,Red,Lightweight
+12/11/2010,Joe Stevenson,Mac Danzig,Blue,Lightweight
+12/11/2010,Thiago Alves,John Howard,Red,Welterweight
+12/11/2010,Joe Doerksen,Dan Miller,Blue,Middleweight
+12/11/2010,Mark Bocek,Dustin Hazelett,Red,Lightweight
+12/11/2010,Matthew Riddle,Sean Pierson,Blue,Welterweight
+12/11/2010,TJ Grant,Ricardo Almeida,Blue,Welterweight
+12/11/2010,Pat Audinwood,John Makdessi,Blue,Lightweight
+12/04/2010,Jonathan Brookins,Michael Johnson,Red,Ultimate Fighter 12 Lightweight Tournament Title
+12/04/2010,Stephan Bonnar,Igor Pokrajac,Red,Light Heavyweight
+12/04/2010,Kendall Grove,Demian Maia,Blue,Middleweight
+12/04/2010,Johny Hendricks,Rick Story,Blue,Welterweight
+12/04/2010,Nam Phan,Leonard Garcia,Blue,Featherweight
+12/04/2010,Cody McKenzie,Aaron Wilkinson,Red,Lightweight
+12/04/2010,Ian Loveland,Tyler Toner,Red,Featherweight
+12/04/2010,Sako Chivitchian,Kyle Watson,Blue,Lightweight
+12/04/2010,Will Campuzano,Nick Pace,Blue,Bantamweight
+12/04/2010,Fredson Paixao,Pablo Garza,Blue,Featherweight
+12/04/2010,Rich Attonito,David Branch,Blue,Middleweight
+11/20/2010,Quinton Jackson,Lyoto Machida,Red,Light Heavyweight
+11/20/2010,Matt Hughes,BJ Penn,Blue,Welterweight
+11/20/2010,Gerald Harris,Maiquel Falcao,Blue,Middleweight
+11/20/2010,Phil Davis,Tim Boetsch,Red,Light Heavyweight
+11/20/2010,George Sotiropoulos,Joe Lauzon,Red,Lightweight
+11/20/2010,Matt Brown,Brian Foster,Blue,Welterweight
+11/20/2010,Aaron Simpson,Mark Munoz,Blue,Middleweight
+11/20/2010,Karo Parisyan,Dennis Hallman,Blue,Welterweight
+11/20/2010,Mike Lullo,Edson Barboza,Blue,Lightweight
+11/20/2010,Paul Kelly,TJ O'Brien,Red,Lightweight
+11/20/2010,Tyson Griffin,Nik Lentz,Blue,Lightweight
+11/13/2010,Nate Marquardt,Yushin Okami,Blue,Middleweight
+11/13/2010,Dennis Siver,Andre Winner,Red,Lightweight
+11/13/2010,Amir Sadollah,Peter Sobotta,Red,Welterweight
+11/13/2010,Krzysztof Soszynski,Goran Reljic,Red,Light Heavyweight
+11/13/2010,Duane Ludwig,Nick Osipczak,Red,Welterweight
+11/13/2010,Vladimir Matyushenko,Alexandre Ferreira,Red,Light Heavyweight
+11/13/2010,Pascal Krauss,Mark Scanlon,Red,Welterweight
+11/13/2010,Kyle Noke,Rob Kimmons,Red,Middleweight
+11/13/2010,Seth Petruzelli,Karlos Vemola,Blue,Light Heavyweight
+11/13/2010,Kris McCray,Carlos Eduardo Rocha,Blue,Welterweight
+10/23/2010,Brock Lesnar,Cain Velasquez,Blue,UFC Heavyweight Title
+10/23/2010,Jake Shields,Martin Kampmann,Red,Welterweight
+10/23/2010,Diego Sanchez,Paulo Thiago,Red,Welterweight
+10/23/2010,Tito Ortiz,Matt Hamill,Blue,Light Heavyweight
+10/23/2010,Brendan Schaub,Gabriel Gonzaga,Red,Heavyweight
+10/23/2010,Court McGee,Ryan Jensen,Red,Middleweight
+10/23/2010,Patrick Cote,Tom Lawlor,Blue,Middleweight
+10/23/2010,Mike Guymon,Daniel Roberts,Blue,Welterweight
+10/23/2010,Sam Stout,Paul Taylor,Red,Lightweight
+10/23/2010,Chris Camozzi,Dongi Yang,Red,Middleweight
+10/23/2010,Jon Madsen,Gilbert Yvel,Red,Heavyweight
+10/16/2010,Michael Bisping,Yoshihiro Akiyama,Red,Middleweight
+10/16/2010,Dan Hardy,Carlos Condit,Blue,Welterweight
+10/16/2010,John Hathaway,Mike Pyle,Blue,Welterweight
+10/16/2010,James Wilks,Claude Patrick,Blue,Welterweight
+10/16/2010,Cyrille Diabate,Alexander Gustafsson,Blue,Light Heavyweight
+10/16/2010,Rob Broughton,Vinicius Queiroz,Red,Heavyweight
+10/16/2010,Paul Sass,Mark Holst,Red,Lightweight
+10/16/2010,Spencer Fisher,Curt Warburton,Red,Lightweight
+10/16/2010,James McSweeney,Fabio Maldonado,Blue,Light Heavyweight
+09/25/2010,Frank Mir,Mirko Filipovic,Red,Heavyweight
+09/25/2010,Rogerio Nogueira,Ryan Bader,Blue,Light Heavyweight
+09/25/2010,Matt Serra,Chris Lytle,Blue,Welterweight
+09/25/2010,Sean Sherk,Evan Dunham,Red,Lightweight
+09/25/2010,Melvin Guillard,Jeremy Stephens,Red,Lightweight
+09/25/2010,CB Dollaway,Joe Doerksen,Red,Middleweight
+09/25/2010,Matt Mitrione,Joey Beltran,Red,Heavyweight
+09/25/2010,Thiago Tavares,Pat Audinwood,Red,Lightweight
+09/25/2010,Steve Lopez,Waylon Lowe,Blue,Lightweight
+09/25/2010,TJ Grant,Julio Paulino,Red,Welterweight
+09/25/2010,Mark Hunt,Sean McCorkle,Blue,Heavyweight
+09/15/2010,Nate Marquardt,Rousimar Palhares,Red,Middleweight
+09/15/2010,Efrain Escudero,Charles Oliveira,Blue,Lightweight
+09/15/2010,Jim Miller,Gleison Tibau,Red,Lightweight
+09/15/2010,Cole Miller,Ross Pearson,Red,Lightweight
+09/15/2010,Yves Edwards,John Gunderson,Red,Lightweight
+09/15/2010,Jared Hamman,Kyle Kingsbury,Blue,Light Heavyweight
+09/15/2010,Tomasz Drwal,David Branch,Blue,Middleweight
+09/15/2010,Rich Attonito,Rafael Natal,Red,Middleweight
+09/15/2010,TJ Waldburger,David Mitchell,Red,Welterweight
+09/15/2010,Brian Foster,Forrest Petz,Red,Welterweight
+08/28/2010,Frankie Edgar,BJ Penn,Red,UFC Lightweight Title
+08/28/2010,Randy Couture,James Toney,Red,Heavyweight
+08/28/2010,Demian Maia,Mario Miranda,Red,Middleweight
+08/28/2010,Kenny Florian,Gray Maynard,Blue,Lightweight
+08/28/2010,Nate Diaz,Marcus Davis,Red,Welterweight
+08/28/2010,Joe Lauzon,Gabe Ruediger,Red,Lightweight
+08/28/2010,Andre Winner,Nik Lentz,Blue,Lightweight
+08/28/2010,Dan Miller,John Salter,Red,Middleweight
+08/28/2010,Nick Osipczak,Greg Soto,Blue,Welterweight
+08/28/2010,Mike Pierce,Amilcar Alves,Red,Welterweight
+08/07/2010,Anderson Silva,Chael Sonnen,Red,UFC Middleweight Title
+08/07/2010,Jon Fitch,Thiago Alves,Red,Welterweight
+08/07/2010,Clay Guida,Rafael Dos Anjos,Red,Lightweight
+08/07/2010,Matt Hughes,Ricardo Almeida,Red,Welterweight
+08/07/2010,Roy Nelson,Junior Dos Santos,Blue,Heavyweight
+08/07/2010,Dustin Hazelett,Rick Story,Blue,Welterweight
+08/07/2010,Rodney Wallace,Phil Davis,Blue,Light Heavyweight
+08/07/2010,Johny Hendricks,Charlie Brenneman,Red,Welterweight
+08/07/2010,Todd Brown,Tim Boetsch,Blue,Light Heavyweight
+08/07/2010,Stefan Struve,Christian Morecraft,Red,Heavyweight
+08/07/2010,Ben Saunders,Dennis Hallman,Blue,Welterweight
+08/01/2010,Jon Jones,Vladimir Matyushenko,Red,Light Heavyweight
+08/01/2010,Mark Munoz,Yushin Okami,Blue,Middleweight
+08/01/2010,John Howard,Jake Ellenberger,Blue,Welterweight
+08/01/2010,Tyson Griffin,Takanori Gomi,Blue,Lightweight
+08/01/2010,Paul Kelly,Jacob Volkmann,Blue,Lightweight
+08/01/2010,DaMarques Johnson,Matthew Riddle,Blue,Welterweight
+08/01/2010,James Irvin,Igor Pokrajac,Blue,Light Heavyweight
+08/01/2010,Brian Stann,Mike Massenzio,Red,Middleweight
+08/01/2010,Darren Elkins,Charles Oliveira,Blue,Lightweight
+08/01/2010,Rob Kimmons,Steve Steinbeiss,Red,Middleweight
+07/03/2010,Brock Lesnar,Shane Carwin,Red,UFC Heavyweight Title
+07/03/2010,Chris Leben,Yoshihiro Akiyama,Red,Middleweight
+07/03/2010,Chris Lytle,Matt Brown,Red,Welterweight
+07/03/2010,Krzysztof Soszynski,Stephan Bonnar,Blue,Light Heavyweight
+07/03/2010,George Sotiropoulos,Kurt Pellegrino,Red,Lightweight
+07/03/2010,Brendan Schaub,Chris Tuchscherer,Red,Heavyweight
+07/03/2010,Seth Petruzelli,Ricardo Romero,Blue,Light Heavyweight
+07/03/2010,Kendall Grove,Goran Reljic,Red,Middleweight
+07/03/2010,Gerald Harris,David Branch,Red,Middleweight
+07/03/2010,Forrest Petz,Daniel Roberts,Blue,Welterweight
+07/03/2010,Jon Madsen,Karlos Vemola,Red,Heavyweight
+06/19/2010,Court McGee,Kris McCray,Red,Ultimate Fighter 11 Middleweight Tournament Title
+06/19/2010,Keith Jardine,Matt Hamill,Blue,Light Heavyweight
+06/19/2010,Chris Leben,Aaron Simpson,Red,Middleweight
+06/19/2010,Spencer Fisher,Dennis Siver,Blue,Lightweight
+06/19/2010,Jamie Yager,Rich Attonito,Blue,Middleweight
+06/19/2010,John Gunderson,Mark Holst,Red,Lightweight
+06/19/2010,Brad Tavares,Seth Baczynski,Red,Middleweight
+06/19/2010,Josh Bryant,Kyle Noke,Blue,Middleweight
+06/19/2010,Chris Camozzi,James Hammortree,Red,Middleweight
+06/19/2010,James McSweeney,Travis Browne,Blue,Heavyweight
+06/12/2010,Chuck Liddell,Rich Franklin,Blue,Light Heavyweight
+06/12/2010,Mirko Filipovic,Pat Barry,Red,Heavyweight
+06/12/2010,Paulo Thiago,Martin Kampmann,Blue,Welterweight
+06/12/2010,Ben Rothwell,Gilbert Yvel,Red,Heavyweight
+06/12/2010,Carlos Condit,Rory MacDonald,Red,Welterweight
+06/12/2010,Tyson Griffin,Evan Dunham,Blue,Lightweight
+06/12/2010,Mac Danzig,Matt Wiman,Blue,Lightweight
+06/12/2010,David Loiseau,Mario Miranda,Blue,Middleweight
+06/12/2010,James Wilks,Peter Sobotta,Red,Welterweight
+06/12/2010,Ricardo Funch,Claude Patrick,Blue,Welterweight
+06/12/2010,Mike Pyle,Jesse Lennox,Red,Welterweight
+05/29/2010,Quinton Jackson,Rashad Evans,Blue,Light Heavyweight
+05/29/2010,Michael Bisping,Dan Miller,Red,Middleweight
+05/29/2010,Todd Duffee,Mike Russow,Blue,Heavyweight
+05/29/2010,Jason Brilz,Rogerio Nogueira,Blue,Light Heavyweight
+05/29/2010,Diego Sanchez,John Hathaway,Blue,Welterweight
+05/29/2010,Amir Sadollah,Dong Hyun Kim,Blue,Welterweight
+05/29/2010,Efrain Escudero,Dan Lauzon,Red,Lightweight
+05/29/2010,Melvin Guillard,Waylon Lowe,Red,Lightweight
+05/29/2010,Luiz Cane,Cyrille Diabate,Blue,Light Heavyweight
+05/29/2010,Aaron Riley,Joe Brammer,Red,Lightweight
+05/29/2010,Jesse Forbes,Ryan Jensen,Blue,Middleweight
+05/08/2010,Lyoto Machida,Mauricio Rua,Blue,UFC Light Heavyweight Title
+05/08/2010,Josh Koscheck,Paul Daley,Red,Welterweight
+05/08/2010,Sam Stout,Jeremy Stephens,Blue,Lightweight
+05/08/2010,Kevin Ferguson,Matt Mitrione,Blue,Heavyweight
+05/08/2010,Patrick Cote,Alan Belcher,Blue,Middleweight
+05/08/2010,Tom Lawlor,Joe Doerksen,Blue,Middleweight
+05/08/2010,Marcus Davis,Jonathan Goulet,Red,Welterweight
+05/08/2010,TJ Grant,Johny Hendricks,Blue,Welterweight
+05/08/2010,Joey Beltran,Tim Hague,Red,Heavyweight
+05/08/2010,Yoshiyuki Yoshida,Mike Guymon,Blue,Welterweight
+05/08/2010,Jason MacDonald,John Salter,Blue,Middleweight
+04/10/2010,Anderson Silva,Demian Maia,Red,UFC Middleweight Title
+04/10/2010,BJ Penn,Frankie Edgar,Blue,UFC Lightweight Title
+04/10/2010,Matt Hughes,Renzo Gracie,Red,Welterweight
+04/10/2010,Terry Etim,Rafael Dos Anjos,Blue,Lightweight
+04/10/2010,Kendall Grove,Mark Munoz,Blue,Middleweight
+04/10/2010,Alexander Gustafsson,Phil Davis,Blue,Light Heavyweight
+04/10/2010,Nick Osipczak,Rick Story,Blue,Welterweight
+04/10/2010,DaMarques Johnson,Brad Blackburn,Red,Welterweight
+04/10/2010,Paul Kelly,Matt Veach,Red,Lightweight
+04/10/2010,Jon Madsen,Mostapha Al-Turk,Red,Heavyweight
+03/31/2010,Kenny Florian,Takanori Gomi,Red,Lightweight
+03/31/2010,Roy Nelson,Stefan Struve,Red,Heavyweight
+03/31/2010,Nate Quarry,Jorge Rivera,Blue,Middleweight
+03/31/2010,Ross Pearson,Dennis Siver,Red,Lightweight
+03/31/2010,Andre Winner,Rafaello Oliveira,Red,Lightweight
+03/31/2010,Jacob Volkmann,Ronys Torres,Red,Lightweight
+03/31/2010,Rob Emerson,Nik Lentz,Blue,Lightweight
+03/31/2010,Caol Uno,Gleison Tibau,Blue,Lightweight
+03/31/2010,Yushin Okami,Lucio Linhares,Red,Middleweight
+03/31/2010,Gerald Harris,Mario Miranda,Red,Middleweight
+03/31/2010,Charlie Brenneman,Jason High,Red,Welterweight
+03/27/2010,Georges St-Pierre,Dan Hardy,Red,UFC Welterweight Title
+03/27/2010,Frank Mir,Shane Carwin,Blue,UFC Interim Heavyweight Title
+03/27/2010,Kurt Pellegrino,Fabricio Camoes,Red,Lightweight
+03/27/2010,Ben Saunders,Jon Fitch,Blue,Welterweight
+03/27/2010,Jim Miller,Mark Bocek,Red,Lightweight
+03/27/2010,Nate Diaz,Rory Markham,Red,Welterweight
+03/27/2010,Ricardo Almeida,Matt Brown,Red,Welterweight
+03/27/2010,Rousimar Palhares,Tomasz Drwal,Red,Middleweight
+03/27/2010,Rodney Wallace,Jared Hamman,Blue,Light Heavyweight
+03/27/2010,Matthew Riddle,Greg Soto,Red,Welterweight
+03/21/2010,Brandon Vera,Jon Jones,Blue,Light Heavyweight
+03/21/2010,Junior Dos Santos,Gabriel Gonzaga,Red,Heavyweight
+03/21/2010,Cheick Kongo,Paul Buentello,Red,Heavyweight
+03/21/2010,Alessio Sakara,James Irvin,Red,Middleweight
+03/21/2010,Clay Guida,Shannon Gugerty,Red,Lightweight
+03/21/2010,Eliot Marshall,Vladimir Matyushenko,Blue,Light Heavyweight
+03/21/2010,Duane Ludwig,Darren Elkins,Blue,Lightweight
+03/21/2010,John Howard,Daniel Roberts,Red,Welterweight
+03/21/2010,Brendan Schaub,Chase Gormley,Red,Heavyweight
+03/21/2010,Mike Pierce,Julio Paulino,Red,Welterweight
+03/21/2010,Eric Schafer,Jason Brilz,Blue,Light Heavyweight
+02/20/2010,Cain Velasquez,Antonio Rodrigo Nogueira,Red,Heavyweight
+02/20/2010,Wanderlei Silva,Michael Bisping,Red,Middleweight
+02/20/2010,George Sotiropoulos,Joe Stevenson,Red,Lightweight
+02/20/2010,Ryan Bader,Keith Jardine,Red,Light Heavyweight
+02/20/2010,Mirko Filipovic,Anthony Perosh,Red,Heavyweight
+02/20/2010,Krzysztof Soszynski,Stephan Bonnar,Red,Light Heavyweight
+02/20/2010,Chris Lytle,Brian Foster,Red,Welterweight
+02/20/2010,CB Dollaway,Goran Reljic,Red,Middleweight
+02/20/2010,James Te Huna,Igor Pokrajac,Red,Light Heavyweight
+02/06/2010,Randy Couture,Mark Coleman,Red,Light Heavyweight
+02/06/2010,Chael Sonnen,Nate Marquardt,Red,Middleweight
+02/06/2010,Paulo Thiago,Mike Swick,Red,Welterweight
+02/06/2010,Demian Maia,Dan Miller,Red,Middleweight
+02/06/2010,Matt Serra,Frank Trigg,Red,Welterweight
+02/06/2010,Mac Danzig,Justin Buchholz,Red,Lightweight
+02/06/2010,Melvin Guillard,Ronys Torres,Red,Lightweight
+02/06/2010,Rob Emerson,Phillipe Nover,Red,Lightweight
+02/06/2010,Phil Davis,Brian Stann,Red,Light Heavyweight
+02/06/2010,Chris Tuchscherer,Tim Hague,Red,Heavyweight
+02/06/2010,Joey Beltran,Rolles Gracie,Red,Heavyweight
+01/11/2010,Gray Maynard,Nate Diaz,Red,Lightweight
+01/11/2010,Evan Dunham,Efrain Escudero,Red,Lightweight
+01/11/2010,Aaron Simpson,Tom Lawlor,Red,Middleweight
+01/11/2010,Amir Sadollah,Brad Blackburn,Red,Welterweight
+01/11/2010,Chris Leben,Jay Silva,Red,Middleweight
+01/11/2010,Rick Story,Jesse Lennox,Red,Welterweight
+01/11/2010,Rory MacDonald,Mike Guymon,Red,Welterweight
+01/11/2010,Rafael Dos Anjos,Kyle Bradley,Red,Lightweight
+01/11/2010,Gerald Harris,John Salter,Red,Middleweight
+01/11/2010,Nick Catone,Jesse Forbes,Red,Middleweight
+01/02/2010,Rashad Evans,Thiago Silva,Red,Light Heavyweight
+01/02/2010,Paul Daley,Dustin Hazelett,Red,Welterweight
+01/02/2010,Sam Stout,Joe Lauzon,Red,Lightweight
+01/02/2010,Jim Miller,Duane Ludwig,Red,Lightweight
+01/02/2010,Junior Dos Santos,Gilbert Yvel,Red,Heavyweight
+01/02/2010,Martin Kampmann,Jacob Volkmann,Red,Welterweight
+01/02/2010,Cole Miller,Dan Lauzon,Red,Lightweight
+01/02/2010,Mark Munoz,Ryan Jensen,Red,Middleweight
+01/02/2010,Jake Ellenberger,Mike Pyle,Red,Welterweight
+01/02/2010,Rafaello Oliveira,John Gunderson,Red,Lightweight
+12/12/2009,BJ Penn,Diego Sanchez,Red,UFC Lightweight Title
+12/12/2009,Frank Mir,Cheick Kongo,Red,Heavyweight
+12/12/2009,Jon Fitch,Mike Pierce,Red,Welterweight
+12/12/2009,Kenny Florian,Clay Guida,Red,Lightweight
+12/12/2009,Stefan Struve,Paul Buentello,Red,Heavyweight
+12/12/2009,Alan Belcher,Wilson Gouveia,Red,Catch Weight
+12/12/2009,Matt Wiman,Shane Nelson,Red,Lightweight
+12/12/2009,Johny Hendricks,Ricardo Funch,Red,Welterweight
+12/12/2009,Rousimar Palhares,Lucio Linhares,Red,Middleweight
+12/12/2009,DaMarques Johnson,Edgar Garcia,Red,Welterweight
+12/12/2009,TJ Grant,Kevin Burns,Red,Welterweight
+12/05/2009,Roy Nelson,Brendan Schaub,Red,Ultimate Fighter 10 Heavyweight Tournament Title
+12/05/2009,Matt Hamill,Jon Jones,Red,Light Heavyweight
+12/05/2009,Kevin Ferguson,Houston Alexander,Red,Catch Weight
+12/05/2009,Frankie Edgar,Matt Veach,Red,Lightweight
+12/05/2009,Matt Mitrione,Marcus Jones,Red,Heavyweight
+12/05/2009,James McSweeney,Darrill Schoonover,Red,Heavyweight
+12/05/2009,Jon Madsen,Justin Wren,Red,Heavyweight
+12/05/2009,Brian Stann,Rodney Wallace,Red,Light Heavyweight
+12/05/2009,John Howard,Dennis Hallman,Red,Welterweight
+12/05/2009,Mark Bocek,Joe Brammer,Red,Lightweight
+11/21/2009,Forrest Griffin,Tito Ortiz,Red,Light Heavyweight
+11/21/2009,Josh Koscheck,Anthony Johnson,Red,Welterweight
+11/21/2009,Paulo Thiago,Jacob Volkmann,Red,Welterweight
+11/21/2009,Rogerio Nogueira,Luiz Cane,Red,Light Heavyweight
+11/21/2009,Amir Sadollah,Phil Baroni,Red,Welterweight
+11/21/2009,Ben Saunders,Marcus Davis,Red,Welterweight
+11/21/2009,Kendall Grove,Jake Rosholt,Red,Middleweight
+11/21/2009,Brian Foster,Brock Larson,Red,Welterweight
+11/21/2009,George Sotiropoulos,Jason Dent,Red,Lightweight
+11/14/2009,Randy Couture,Brandon Vera,Red,Light Heavyweight
+11/14/2009,Dan Hardy,Mike Swick,Red,Welterweight
+11/14/2009,Michael Bisping,Denis Kang,Red,Middleweight
+11/14/2009,Matt Brown,James Wilks,Red,Welterweight
+11/14/2009,Ross Pearson,Aaron Riley,Red,Lightweight
+11/14/2009,John Hathaway,Paul Taylor,Red,Welterweight
+11/14/2009,Terry Etim,Shannon Gugerty,Red,Lightweight
+11/14/2009,Nick Osipczak,Matthew Riddle,Red,Welterweight
+11/14/2009,Dennis Siver,Paul Kelly,Red,Lightweight
+11/14/2009,Alexander Gustafsson,Jared Hamman,Red,Light Heavyweight
+11/14/2009,Andre Winner,Rolando Delgado,Red,Lightweight
+10/24/2009,Lyoto Machida,Mauricio Rua,Red,UFC Light Heavyweight Title
+10/24/2009,Cain Velasquez,Ben Rothwell,Red,Heavyweight
+10/24/2009,Gleison Tibau,Josh Neer,Red,Lightweight
+10/24/2009,Joe Stevenson,Spencer Fisher,Red,Lightweight
+10/24/2009,Anthony Johnson,Yoshiyuki Yoshida,Red,Welterweight
+10/24/2009,Ryan Bader,Eric Schafer,Red,Light Heavyweight
+10/24/2009,Pat Barry,Antoni Hardonk,Red,Heavyweight
+10/24/2009,Chael Sonnen,Yushin Okami,Red,Middleweight
+10/24/2009,Jorge Rivera,Rob Kimmons,Red,Middleweight
+10/24/2009,Kyle Kingsbury,Razak Al-Hassan,Red,Light Heavyweight
+10/24/2009,Stefan Struve,Chase Gormley,Red,Heavyweight
+09/19/2009,Vitor Belfort,Rich Franklin,Red,Catch Weight
+09/19/2009,Junior Dos Santos,Mirko Filipovic,Red,Heavyweight
+09/19/2009,Paul Daley,Martin Kampmann,Red,Welterweight
+09/19/2009,Josh Koscheck,Frank Trigg,Red,Welterweight
+09/19/2009,Tyson Griffin,Hermes Franca,Red,Lightweight
+09/19/2009,Efrain Escudero,Cole Miller,Red,Lightweight
+09/19/2009,Tomasz Drwal,Drew McFedries,Red,Middleweight
+09/19/2009,Jim Miller,Steve Lopez,Red,Lightweight
+09/19/2009,Nik Lentz,Rafaello Oliveira,Red,Lightweight
+09/19/2009,Rick Story,Brian Foster,Red,Welterweight
+09/19/2009,Eliot Marshall,Jason Brilz,Red,Light Heavyweight
+09/19/2009,Vladimir Matyushenko,Igor Pokrajac,Red,Light Heavyweight
+09/19/2009,Rafael Dos Anjos,Rob Emerson,Red,Lightweight
+09/16/2009,Nate Diaz,Melvin Guillard,Red,Lightweight
+09/16/2009,Gray Maynard,Roger Huerta,Red,Lightweight
+09/16/2009,Carlos Condit,Jake Ellenberger,Red,Welterweight
+09/16/2009,Nate Quarry,Tim Credeur,Red,Middleweight
+09/16/2009,Brian Stann,Steve Cantwell,Red,Light Heavyweight
+09/16/2009,Mike Pyle,Chris Wilson,Red,Welterweight
+09/16/2009,CB Dollaway,Jay Silva,Red,Middleweight
+09/16/2009,Jeremy Stephens,Justin Buchholz,Red,Lightweight
+09/16/2009,Mike Pierce,Brock Larson,Red,Welterweight
+09/16/2009,Ryan Jensen,Steve Steinbeiss,Red,Middleweight
+08/29/2009,Antonio Rodrigo Nogueira,Randy Couture,Red,Heavyweight
+08/29/2009,Thiago Silva,Keith Jardine,Red,Light Heavyweight
+08/29/2009,Jake Rosholt,Chris Leben,Red,Middleweight
+08/29/2009,Nate Marquardt,Demian Maia,Red,Middleweight
+08/29/2009,Brandon Vera,Krzysztof Soszynski,Red,Light Heavyweight
+08/29/2009,Aaron Simpson,Ed Herman,Red,Middleweight
+08/29/2009,Gabriel Gonzaga,Chris Tuchscherer,Red,Heavyweight
+08/29/2009,Mike Russow,Justin McCully,Red,Heavyweight
+08/29/2009,Todd Duffee,Tim Hague,Red,Heavyweight
+08/29/2009,Mark Munoz,Nick Catone,Red,Middleweight
+08/29/2009,Evan Dunham,Marcus Aurelio,Red,Lightweight
+08/08/2009,BJ Penn,Kenny Florian,Red,UFC Lightweight Title
+08/08/2009,Anderson Silva,Forrest Griffin,Red,Light Heavyweight
+08/08/2009,Aaron Riley,Shane Nelson,Red,Lightweight
+08/08/2009,Johny Hendricks,Amir Sadollah,Red,Welterweight
+08/08/2009,Ricardo Almeida,Kendall Grove,Red,Middleweight
+08/08/2009,Kurt Pellegrino,Josh Neer,Red,Lightweight
+08/08/2009,John Howard,Tamdan McCrory,Red,Welterweight
+08/08/2009,Alessio Sakara,Thales Leites,Red,Middleweight
+08/08/2009,Matthew Riddle,Dan Cramer,Red,Welterweight
+08/08/2009,George Sotiropoulos,George Roop,Red,Lightweight
+08/08/2009,Jesse Lennox,Danillo Villefort,Red,Welterweight
+07/11/2009,Jon Fitch,Paulo Thiago,Red,Welterweight
+07/11/2009,Brock Lesnar,Frank Mir,Red,UFC Heavyweight Title
+07/11/2009,Georges St-Pierre,Thiago Alves,Red,UFC Welterweight Title
+07/11/2009,Dan Henderson,Michael Bisping,Red,Middleweight
+07/11/2009,Yoshihiro Akiyama,Alan Belcher,Red,Middleweight
+07/11/2009,Mark Coleman,Stephan Bonnar,Red,Light Heavyweight
+07/11/2009,Jim Miller,Mac Danzig,Red,Lightweight
+07/11/2009,Jon Jones,Jake O'Brien,Red,Light Heavyweight
+07/11/2009,Dong Hyun Kim,TJ Grant,Red,Welterweight
+07/11/2009,Tom Lawlor,CB Dollaway,Red,Middleweight
+07/11/2009,Shannon Gugerty,Matt Grice,Red,Lightweight
+06/20/2009,Diego Sanchez,Clay Guida,Red,Lightweight
+06/20/2009,James Wilks,DaMarques Johnson,Red,Ultimate Fighter 9 Welterweight Tournament Title
+06/20/2009,Chris Lytle,Kevin Burns,Red,Welterweight
+06/20/2009,Ross Pearson,Andre Winner,Red,Ultimate Fighter 9 Lightweight Tournament Title
+06/20/2009,Joe Stevenson,Nate Diaz,Red,Lightweight
+06/20/2009,Melvin Guillard,Gleison Tibau,Red,Lightweight
+06/20/2009,Brad Blackburn,Edgar Garcia,Red,Welterweight
+06/20/2009,Tomasz Drwal,Mike Ciesnolevicz,Red,Light Heavyweight
+06/20/2009,Nick Osipczak,Frank Lester,Red,Welterweight
+06/20/2009,Jason Dent,Cameron Dollar,Red,Lightweight
+06/13/2009,Rich Franklin,Wanderlei Silva,Red,Catch Weight
+06/13/2009,Cain Velasquez,Cheick Kongo,Red,Heavyweight
+06/13/2009,Mirko Filipovic,Mostapha Al-Turk,Red,Heavyweight
+06/13/2009,Mike Swick,Ben Saunders,Red,Welterweight
+06/13/2009,Spencer Fisher,Caol Uno,Red,Lightweight
+06/13/2009,Dan Hardy,Marcus Davis,Red,Welterweight
+06/13/2009,Terry Etim,Justin Buchholz,Red,Lightweight
+06/13/2009,Dennis Siver,Dale Hartt,Red,Lightweight
+06/13/2009,Paul Taylor,Peter Sobotta,Red,Welterweight
+06/13/2009,Paul Kelly,Rolando Delgado,Red,Lightweight
+06/13/2009,Stefan Struve,Denis Stojnic,Red,Heavyweight
+06/13/2009,John Hathaway,Rick Story,Red,Welterweight
+05/23/2009,Lyoto Machida,Rashad Evans,Red,UFC Light Heavyweight Title
+05/23/2009,Matt Hughes,Matt Serra,Red,Welterweight
+05/23/2009,Drew McFedries,Xavier Foupa-Pokam,Red,Middleweight
+05/23/2009,Chael Sonnen,Dan Miller,Red,Middleweight
+05/23/2009,Frankie Edgar,Sean Sherk,Red,Lightweight
+05/23/2009,Brock Larson,Mike Pyle,Red,Welterweight
+05/23/2009,Tim Hague,Pat Barry,Red,Heavyweight
+05/23/2009,Kyle Bradley,Phillipe Nover,Red,Lightweight
+05/23/2009,Krzysztof Soszynski,Andre Gusmao,Red,Light Heavyweight
+05/23/2009,Yoshiyuki Yoshida,Brandon Wolff,Red,Welterweight
+05/23/2009,George Roop,David Kaplan,Red,Lightweight
+04/18/2009,Anderson Silva,Thales Leites,Red,UFC Middleweight Title
+04/18/2009,Sam Stout,Matt Wiman,Red,Lightweight
+04/18/2009,Mauricio Rua,Chuck Liddell,Red,Light Heavyweight
+04/18/2009,Krzysztof Soszynski,Brian Stann,Red,Light Heavyweight
+04/18/2009,Cheick Kongo,Antoni Hardonk,Red,Heavyweight
+04/18/2009,Luiz Cane,Steve Cantwell,Red,Light Heavyweight
+04/18/2009,Denis Kang,Xavier Foupa-Pokam,Red,Middleweight
+04/18/2009,Nate Quarry,Jason MacDonald,Red,Middleweight
+04/18/2009,Ed Herman,David Loiseau,Red,Middleweight
+04/18/2009,Mark Bocek,David Bielkheden,Red,Lightweight
+04/18/2009,TJ Grant,Ryo Chonan,Red,Welterweight
+04/18/2009,Eliot Marshall,Vinny Magalhaes,Red,Light Heavyweight
+04/01/2009,Martin Kampmann,Carlos Condit,Red,Welterweight
+04/01/2009,Ryan Bader,Carmelo Marrero,Red,Light Heavyweight
+04/01/2009,Tyson Griffin,Rafael Dos Anjos,Red,Lightweight
+04/01/2009,Cole Miller,Junie Browning,Red,Lightweight
+04/01/2009,Gleison Tibau,Jeremy Stephens,Red,Lightweight
+04/01/2009,Ricardo Almeida,Matt Horwich,Red,Middleweight
+04/01/2009,Brock Larson,Jesse Sanders,Red,Welterweight
+04/01/2009,Tim Credeur,Nick Catone,Red,Middleweight
+04/01/2009,Jorge Rivera,Nissen Osterneck,Red,Middleweight
+04/01/2009,Rob Kimmons,Joe Vedepo,Red,Middleweight
+04/01/2009,Aaron Simpson,Tim McKenzie,Red,Middleweight
+03/07/2009,Quinton Jackson,Keith Jardine,Red,Light Heavyweight
+03/07/2009,Shane Carwin,Gabriel Gonzaga,Red,Heavyweight
+03/07/2009,Matt Brown,Pete Sell,Red,Welterweight
+03/07/2009,Matt Hamill,Mark Munoz,Red,Light Heavyweight
+03/07/2009,Gray Maynard,Jim Miller,Red,Lightweight
+03/07/2009,Tamdan McCrory,Ryan Madigan,Red,Welterweight
+03/07/2009,Kendall Grove,Jason Day,Red,Middleweight
+03/07/2009,Jason Brilz,Tim Boetsch,Red,Light Heavyweight
+03/07/2009,Brandon Vera,Michael Patt,Red,Light Heavyweight
+03/07/2009,Shane Nelson,Aaron Riley,Red,Lightweight
+02/21/2009,Diego Sanchez,Joe Stevenson,Red,Lightweight
+02/21/2009,Dan Hardy,Rory Markham,Red,Welterweight
+02/21/2009,Nate Marquardt,Wilson Gouveia,Red,Middleweight
+02/21/2009,Demian Maia,Chael Sonnen,Red,Middleweight
+02/21/2009,Paulo Thiago,Josh Koscheck,Red,Welterweight
+02/21/2009,Terry Etim,Brian Cobb,Red,Lightweight
+02/21/2009,Junior Dos Santos,Stefan Struve,Red,Heavyweight
+02/21/2009,Evan Dunham,Per Eklund,Red,Lightweight
+02/21/2009,Mike Ciesnolevicz,Neil Grove,Red,Heavyweight
+02/21/2009,Paul Kelly,Troy Mandaloniz,Red,Welterweight
+02/07/2009,Joe Lauzon,Jeremy Stephens,Red,Lightweight
+02/07/2009,Cain Velasquez,Denis Stojnic,Red,Heavyweight
+02/07/2009,Josh Neer,Mac Danzig,Red,Lightweight
+02/07/2009,Anthony Johnson,Luigi Fioravanti,Red,Welterweight
+02/07/2009,Kurt Pellegrino,Rob Emerson,Red,Lightweight
+02/07/2009,Dan Miller,Jake Rosholt,Red,Middleweight
+02/07/2009,Matt Veach,Matt Grice,Red,Lightweight
+02/07/2009,Gleison Tibau,Rich Clementi,Red,Lightweight
+02/07/2009,Nick Catone,Derek Downey,Red,Middleweight
+02/07/2009,Matthew Riddle,Steve Bruno,Red,Welterweight
+01/31/2009,Georges St-Pierre,BJ Penn,Red,UFC Welterweight Title
+01/31/2009,Lyoto Machida,Thiago Silva,Red,Light Heavyweight
+01/31/2009,Jon Jones,Stephan Bonnar,Red,Light Heavyweight
+01/31/2009,Clay Guida,Nate Diaz,Red,Lightweight
+01/31/2009,Jon Fitch,Akihiro Gono,Red,Welterweight
+01/31/2009,Thiago Tavares,Manvel Gamburyan,Red,Lightweight
+01/31/2009,John Howard,Chris Wilson,Red,Welterweight
+01/31/2009,Jake O'Brien,Christian Wellisch,Red,Light Heavyweight
+01/31/2009,Dan Cramer,Matt Arroyo,Red,Welterweight
+01/17/2009,Dan Henderson,Rich Franklin,Red,Light Heavyweight
+01/17/2009,Mauricio Rua,Mark Coleman,Red,Light Heavyweight
+01/17/2009,Rousimar Palhares,Jeremy Horn,Red,Middleweight
+01/17/2009,Alan Belcher,Denis Kang,Red,Middleweight
+01/17/2009,Marcus Davis,Chris Lytle,Red,Welterweight
+01/17/2009,John Hathaway,Tom Egan,Red,Welterweight
+01/17/2009,Martin Kampmann,Alexandre Barros,Red,Welterweight
+01/17/2009,Eric Schafer,Antonio Mendes,Red,Light Heavyweight
+01/17/2009,Tomasz Drwal,Ivan Serati,Red,Light Heavyweight
+01/17/2009,Dennis Siver,Nate Mohr,Red,Lightweight
+12/27/2008,Rashad Evans,Forrest Griffin,Red,UFC Light Heavyweight Title
+12/27/2008,Frank Mir,Antonio Rodrigo Nogueira,Red,UFC Interim Heavyweight Title
+12/27/2008,CB Dollaway,Mike Massenzio,Red,Middleweight
+12/27/2008,Quinton Jackson,Wanderlei Silva,Red,Light Heavyweight
+12/27/2008,Cheick Kongo,Mostapha Al-Turk,Red,Heavyweight
+12/27/2008,Yushin Okami,Dean Lister,Red,Middleweight
+12/27/2008,Antoni Hardonk,Mike Wessel,Red,Heavyweight
+12/27/2008,Matt Hamill,Reese Andy,Red,Light Heavyweight
+12/27/2008,Brad Blackburn,Ryo Chonan,Red,Welterweight
+12/27/2008,Pat Barry,Dan Evensen,Red,Heavyweight
+12/13/2008,Efrain Escudero,Phillipe Nover,Red,Ultimate Fighter 8 Lightweight Tournament Title
+12/13/2008,Ryan Bader,Vinny Magalhaes,Red,Ultimate Fighter 8 Light Heavyweight Tournament Title
+12/13/2008,Anthony Johnson,Kevin Burns,Red,Welterweight
+12/13/2008,Wilson Gouveia,Jason MacDonald,Red,Middleweight
+12/13/2008,Junie Browning,David Kaplan,Red,Lightweight
+12/13/2008,Krzysztof Soszynski,Shane Primm,Red,Light Heavyweight
+12/13/2008,Eliot Marshall,Jules Bruchez,Red,Light Heavyweight
+12/13/2008,Tom Lawlor,Kyle Kingsbury,Red,Light Heavyweight
+12/13/2008,Shane Nelson,George Roop,Red,Lightweight
+12/13/2008,Rolando Delgado,John Polakowski,Red,Lightweight
+12/10/2008,Josh Koscheck,Yoshiyuki Yoshida,Red,Welterweight
+12/10/2008,Mike Swick,Jonathan Goulet,Red,Welterweight
+12/10/2008,Steve Cantwell,Razak Al-Hassan,Red,Light Heavyweight
+12/10/2008,Tim Credeur,Nate Loughran,Red,Middleweight
+12/10/2008,Jim Miller,Matt Wiman,Red,Lightweight
+12/10/2008,Luigi Fioravanti,Brodie Farber,Red,Catch Weight
+12/10/2008,Steve Bruno,Johnny Rees,Red,Welterweight
+12/10/2008,Ben Saunders,Brandon Wolff,Red,Welterweight
+12/10/2008,Dale Hartt,Corey Hill,Red,Lightweight
+12/10/2008,Justin McCully,Eddie Sanchez,Red,Heavyweight
+11/15/2008,Brock Lesnar,Randy Couture,Red,UFC Heavyweight Title
+11/15/2008,Kenny Florian,Joe Stevenson,Red,Lightweight
+11/15/2008,Dustin Hazelett,Tamdan McCrory,Red,Welterweight
+11/15/2008,Gabriel Gonzaga,Josh Hendricks,Red,Heavyweight
+11/15/2008,Demian Maia,Nate Quarry,Red,Middleweight
+11/15/2008,Aaron Riley,Jorge Gurgel,Red,Lightweight
+11/15/2008,Jeremy Stephens,Rafael Dos Anjos,Red,Lightweight
+11/15/2008,Mark Bocek,Alvin Robinson,Red,Lightweight
+11/15/2008,Matt Brown,Ryan Thomas,Red,Welterweight
+10/25/2008,Anderson Silva,Patrick Cote,Red,UFC Middleweight Title
+10/25/2008,Thiago Alves,Josh Koscheck,Red,Welterweight
+10/25/2008,Gray Maynard,Rich Clementi,Red,Lightweight
+10/25/2008,Junior Dos Santos,Fabricio Werdum,Red,Heavyweight
+10/25/2008,Sean Sherk,Tyson Griffin,Red,Lightweight
+10/25/2008,Thales Leites,Drew McFedries,Red,Middleweight
+10/25/2008,Spencer Fisher,Shannon Gugerty,Red,Lightweight
+10/25/2008,Dan Miller,Matt Horwich,Red,Middleweight
+10/25/2008,Hermes Franca,Marcus Aurelio,Red,Lightweight
+10/25/2008,Pete Sell,Joshua Burkman,Red,Welterweight
+10/18/2008,Michael Bisping,Chris Leben,Red,Middleweight
+10/18/2008,Keith Jardine,Brandon Vera,Red,Light Heavyweight
+10/18/2008,Luiz Cane,Rameau Thierry Sokoudjou,Red,Light Heavyweight
+10/18/2008,Chris Lytle,Paul Taylor,Red,Welterweight
+10/18/2008,Marcus Davis,Paul Kelly,Red,Welterweight
+10/18/2008,Dan Hardy,Akihiro Gono,Red,Welterweight
+10/18/2008,Shane Carwin,Neil Wain,Red,Heavyweight
+10/18/2008,David Bielkheden,Jess Liaudin,Red,Lightweight
+10/18/2008,Terry Etim,Sam Stout,Red,Lightweight
+10/18/2008,Jim Miller,David Baron,Red,Lightweight
+10/18/2008,Per Eklund,Samy Schiavo,Red,Lightweight
+09/17/2008,Nate Diaz,Josh Neer,Red,Lightweight
+09/17/2008,Clay Guida,Mac Danzig,Red,Lightweight
+09/17/2008,Alan Belcher,Ed Herman,Red,Middleweight
+09/17/2008,Eric Schafer,Houston Alexander,Red,Light Heavyweight
+09/17/2008,Alessio Sakara,Joe Vedepo,Red,Middleweight
+09/17/2008,Wilson Gouveia,Ryan Jensen,Red,Middleweight
+09/17/2008,Joe Lauzon,Kyle Bradley,Red,Lightweight
+09/17/2008,Jason Brilz,Brad Morris,Red,Light Heavyweight
+09/17/2008,Mike Massenzio,Drew McFedries,Red,Middleweight
+09/17/2008,Dan Miller,Rob Kimmons,Red,Middleweight
+09/06/2008,Rashad Evans,Chuck Liddell,Red,Light Heavyweight
+09/06/2008,Rich Franklin,Matt Hamill,Red,Light Heavyweight
+09/06/2008,Dan Henderson,Rousimar Palhares,Red,Middleweight
+09/06/2008,Nate Marquardt,Martin Kampmann,Red,Middleweight
+09/06/2008,Dong Hyun Kim,Matt Brown,Red,Welterweight
+09/06/2008,Kurt Pellegrino,Thiago Tavares,Red,Lightweight
+09/06/2008,Tim Boetsch,Michael Patt,Red,Light Heavyweight
+09/06/2008,Jason MacDonald,Jason Lambert,Red,Middleweight
+09/06/2008,Ryo Chonan,Roan Carneiro,Red,Welterweight
+08/09/2008,Georges St-Pierre,Jon Fitch,Red,UFC Welterweight Title
+08/09/2008,Brock Lesnar,Heath Herring,Red,Heavyweight
+08/09/2008,Rob Emerson,Manvel Gamburyan,Red,Lightweight
+08/09/2008,Kenny Florian,Roger Huerta,Red,Lightweight
+08/09/2008,Demian Maia,Jason MacDonald,Red,Middleweight
+08/09/2008,Tamdan McCrory,Luke Cummo,Red,Welterweight
+08/09/2008,Cheick Kongo,Dan Evensen,Red,Heavyweight
+08/09/2008,Jon Jones,Andre Gusmao,Red,Light Heavyweight
+08/09/2008,Chris Wilson,Steve Bruno,Red,Welterweight
+08/09/2008,Ben Saunders,Ryan Thomas,Red,Welterweight
+07/19/2008,Anderson Silva,James Irvin,Red,Light Heavyweight
+07/19/2008,Brandon Vera,Reese Andy,Red,Light Heavyweight
+07/19/2008,Frankie Edgar,Hermes Franca,Red,Lightweight
+07/19/2008,Cain Velasquez,Jake O'Brien,Red,Heavyweight
+07/19/2008,Kevin Burns,Anthony Johnson,Red,Welterweight
+07/19/2008,CB Dollaway,Jesse Taylor,Red,Middleweight
+07/19/2008,Tim Credeur,Cale Yarbrough,Red,Middleweight
+07/19/2008,Rory Markham,Brodie Farber,Red,Welterweight
+07/19/2008,Nate Loughran,Johnny Rees,Red,Middleweight
+07/19/2008,Brad Blackburn,James Giboo,Red,Welterweight
+07/19/2008,Shannon Gugerty,Dale Hartt,Red,Lightweight
+07/05/2008,Forrest Griffin,Quinton Jackson,Red,UFC Light Heavyweight Title
+07/05/2008,Patrick Cote,Ricardo Almeida,Red,Middleweight
+07/05/2008,Joe Stevenson,Gleison Tibau,Red,Lightweight
+07/05/2008,Josh Koscheck,Chris Lytle,Red,Welterweight
+07/05/2008,Tyson Griffin,Marcus Aurelio,Red,Lightweight
+07/05/2008,Gabriel Gonzaga,Justin McCully,Red,Heavyweight
+07/05/2008,Cole Miller,Jorge Gurgel,Red,Lightweight
+07/05/2008,Melvin Guillard,Dennis Siver,Red,Lightweight
+07/05/2008,Justin Buchholz,Corey Hill,Red,Lightweight
+06/21/2008,Kendall Grove,Evan Tanner,Red,Middleweight
+06/21/2008,Amir Sadollah,CB Dollaway,Red,Ultimate Fighter 7 Middleweight Tournament Title
+06/21/2008,Diego Sanchez,Luigi Fioravanti,Red,Welterweight
+06/21/2008,Spencer Fisher,Jeremy Stephens,Red,Lightweight
+06/21/2008,Matthew Riddle,Dante Rivera,Red,Middleweight
+06/21/2008,Dustin Hazelett,Joshua Burkman,Red,Welterweight
+06/21/2008,Drew McFedries,Marvin Eastman,Red,Middleweight
+06/21/2008,Matt Brown,Matt Arroyo,Red,Welterweight
+06/21/2008,Dean Lister,Jeremy Horn,Red,Middleweight
+06/21/2008,Rob Kimmons,Rob Yundt,Red,Middleweight
+06/07/2008,Thiago Alves,Matt Hughes,Red,Welterweight
+06/07/2008,Michael Bisping,Jason Day,Red,Middleweight
+06/07/2008,Mike Swick,Marcus Davis,Red,Welterweight
+06/07/2008,Thales Leites,Nate Marquardt,Red,Middleweight
+06/07/2008,Fabricio Werdum,Brandon Vera,Red,Heavyweight
+06/07/2008,Martin Kampmann,Jorge Rivera,Red,Middleweight
+06/07/2008,Matt Wiman,Thiago Tavares,Red,Lightweight
+06/07/2008,Kevin Burns,Roan Carneiro,Red,Welterweight
+06/07/2008,Luiz Cane,Jason Lambert,Red,Light Heavyweight
+06/07/2008,Paul Taylor,Jess Liaudin,Red,Welterweight
+06/07/2008,Antoni Hardonk,Eddie Sanchez,Red,Heavyweight
+05/24/2008,BJ Penn,Sean Sherk,Red,UFC Lightweight Title
+05/24/2008,Wanderlei Silva,Keith Jardine,Red,Light Heavyweight
+05/24/2008,Goran Reljic,Wilson Gouveia,Red,Light Heavyweight
+05/24/2008,Lyoto Machida,Tito Ortiz,Red,Light Heavyweight
+05/24/2008,Thiago Silva,Antonio Mendes,Red,Light Heavyweight
+05/24/2008,Rousimar Palhares,Ivan Salaverry,Red,Middleweight
+05/24/2008,Rameau Thierry Sokoudjou,Kazuhiro Nakamura,Red,Light Heavyweight
+05/24/2008,Rich Clementi,Terry Etim,Red,Lightweight
+05/24/2008,Yoshiyuki Yoshida,War Machine,Red,Welterweight
+05/24/2008,Dong Hyun Kim,Jason Tan,Red,Welterweight
+05/24/2008,Shane Carwin,Christian Wellisch,Red,Heavyweight
+04/19/2008,Georges St-Pierre,Matt Serra,Red,UFC Welterweight Title
+04/19/2008,Rich Franklin,Travis Lutter,Red,Middleweight
+04/19/2008,Nate Quarry,Kalib Starnes,Red,Middleweight
+04/19/2008,Michael Bisping,Charles McCarthy,Red,Middleweight
+04/19/2008,Mac Danzig,Mark Bocek,Red,Lightweight
+04/19/2008,Jason MacDonald,Joe Doerksen,Red,Middleweight
+04/19/2008,Jason Day,Alan Belcher,Red,Middleweight
+04/19/2008,Demian Maia,Ed Herman,Red,Middleweight
+04/19/2008,Rich Clementi,Sam Stout,Red,Lightweight
+04/19/2008,Cain Velasquez,Brad Morris,Red,Heavyweight
+04/19/2008,Jonathan Goulet,Kuniyoshi Hironaka,Red,Welterweight
+04/02/2008,Kenny Florian,Joe Lauzon,Red,Lightweight
+04/02/2008,Gray Maynard,Frankie Edgar,Red,Lightweight
+04/02/2008,Thiago Alves,Karo Parisyan,Red,Welterweight
+04/02/2008,Matt Hamill,Tim Boetsch,Red,Light Heavyweight
+04/02/2008,Nate Diaz,Kurt Pellegrino,Red,Lightweight
+04/02/2008,James Irvin,Houston Alexander,Red,Light Heavyweight
+04/02/2008,Josh Neer,Din Thomas,Red,Lightweight
+04/02/2008,Marcus Aurelio,Ryan Roberts,Red,Lightweight
+04/02/2008,Manvel Gamburyan,Jeff Cox,Red,Lightweight
+04/02/2008,Clay Guida,Samy Schiavo,Red,Lightweight
+04/02/2008,George Sotiropoulos,Roman Mitichyan,Red,Welterweight
+04/02/2008,Anthony Johnson,Tommy Speer,Red,Welterweight
+03/01/2008,Anderson Silva,Dan Henderson,Red,UFC Middleweight Title
+03/01/2008,Heath Herring,Cheick Kongo,Red,Heavyweight
+03/01/2008,Chris Leben,Alessio Sakara,Red,Middleweight
+03/01/2008,Yushin Okami,Evan Tanner,Red,Middleweight
+03/01/2008,Jon Fitch,Chris Wilson,Red,Welterweight
+03/01/2008,Andrei Arlovski,Jake O'Brien,Red,Heavyweight
+03/01/2008,Luigi Fioravanti,Luke Cummo,Red,Welterweight
+03/01/2008,Josh Koscheck,Dustin Hazelett,Red,Welterweight
+03/01/2008,Diego Sanchez,David Bielkheden,Red,Welterweight
+03/01/2008,Jorge Gurgel,John Halverson,Red,Lightweight
+02/02/2008,Antonio Rodrigo Nogueira,Tim Sylvia,Red,UFC Interim Heavyweight Title
+02/02/2008,Frank Mir,Brock Lesnar,Red,Heavyweight
+02/02/2008,Nate Marquardt,Jeremy Horn,Red,Middleweight
+02/02/2008,Ricardo Almeida,Rob Yundt,Red,Middleweight
+02/02/2008,Tyson Griffin,Gleison Tibau,Red,Lightweight
+02/02/2008,Chris Lytle,Kyle Bradley,Red,Welterweight
+02/02/2008,Tim Boetsch,David Heath,Red,Light Heavyweight
+02/02/2008,Marvin Eastman,Terry Martin,Red,Middleweight
+02/02/2008,Rob Emerson,Keita Nakamura,Red,Lightweight
+01/23/2008,Mike Swick,Joshua Burkman,Red,Welterweight
+01/23/2008,Patrick Cote,Drew McFedries,Red,Middleweight
+01/23/2008,Thiago Tavares,Michihiro Omigawa,Red,Lightweight
+01/23/2008,Nate Diaz,Alvin Robinson,Red,Lightweight
+01/23/2008,Kurt Pellegrino,Alberto Crane,Red,Lightweight
+01/23/2008,Gray Maynard,Dennis Siver,Red,Lightweight
+01/23/2008,Jeremy Stephens,Cole Miller,Red,Lightweight
+01/23/2008,Corey Hill,Joe Veres,Red,Lightweight
+01/23/2008,Matt Wiman,Justin Buchholz,Red,Lightweight
+01/19/2008,BJ Penn,Joe Stevenson,Red,UFC Lightweight Title
+01/19/2008,Fabricio Werdum,Gabriel Gonzaga,Red,Heavyweight
+01/19/2008,Marcus Davis,Jess Liaudin,Red,Welterweight
+01/19/2008,Wilson Gouveia,Jason Lambert,Red,Light Heavyweight
+01/19/2008,Jorge Rivera,Kendall Grove,Red,Middleweight
+01/19/2008,Antoni Hardonk,Colin Robinson,Red,Heavyweight
+01/19/2008,Paul Kelly,Paul Taylor,Red,Welterweight
+01/19/2008,Alessio Sakara,James Lee,Red,Light Heavyweight
+01/19/2008,Sam Stout,Per Eklund,Red,Lightweight
+12/29/2007,Georges St-Pierre,Matt Hughes,Red,UFC Interim Welterweight Title
+12/29/2007,Chuck Liddell,Wanderlei Silva,Red,Light Heavyweight
+12/29/2007,Eddie Sanchez,Soa Palelei,Red,Heavyweight
+12/29/2007,Lyoto Machida,Rameau Thierry Sokoudjou,Red,Light Heavyweight
+12/29/2007,Rich Clementi,Melvin Guillard,Red,Lightweight
+12/29/2007,James Irvin,Luiz Cane,Red,Light Heavyweight
+12/29/2007,Manvel Gamburyan,Nate Mohr,Red,Lightweight
+12/29/2007,Dean Lister,Jordan Radev,Red,Middleweight
+12/29/2007,Roan Carneiro,Tony DeSouza,Red,Welterweight
+12/29/2007,Mark Bocek,Doug Evans,Red,Lightweight
+12/08/2007,Roger Huerta,Clay Guida,Red,Lightweight
+12/08/2007,Mac Danzig,Tommy Speer,Red,Ultimate Fighter 6 Welterweight Tournament Title
+12/08/2007,War Machine,Jared Rollins,Red,Welterweight
+12/08/2007,George Sotiropoulos,Billy Miles,Red,Welterweight
+12/08/2007,Ben Saunders,Dan Barrera,Red,Welterweight
+12/08/2007,Troy Mandaloniz,Richie Hightower,Red,Welterweight
+12/08/2007,Matt Arroyo,John Kolosci,Red,Welterweight
+12/08/2007,Roman Mitichyan,Dorian Price,Red,Welterweight
+12/08/2007,Jonathan Goulet,Paul Georgieff,Red,Welterweight
+11/17/2007,Rashad Evans,Michael Bisping,Red,Light Heavyweight
+11/17/2007,Thiago Silva,Houston Alexander,Red,Light Heavyweight
+11/17/2007,Karo Parisyan,Ryo Chonan,Red,Welterweight
+11/17/2007,Ed Herman,Joe Doerksen,Red,Middleweight
+11/17/2007,Frankie Edgar,Spencer Fisher,Red,Lightweight
+11/17/2007,Thiago Alves,Chris Lytle,Red,Welterweight
+11/17/2007,Joe Lauzon,Jason Reinhardt,Red,Lightweight
+11/17/2007,Marcus Aurelio,Luke Caudillo,Red,Lightweight
+11/17/2007,Akihiro Gono,Tamdan McCrory,Red,Welterweight
+10/20/2007,Anderson Silva,Rich Franklin,Red,UFC Middleweight Title
+10/20/2007,Tim Sylvia,Brandon Vera,Red,Heavyweight
+10/20/2007,Alvin Robinson,Jorge Gurgel,Red,Lightweight
+10/20/2007,Stephan Bonnar,Eric Schafer,Red,Light Heavyweight
+10/20/2007,Alan Belcher,Kalib Starnes,Red,Middleweight
+10/20/2007,Yushin Okami,Jason MacDonald,Red,Middleweight
+10/20/2007,Demian Maia,Ryan Jensen,Red,Middleweight
+10/20/2007,Joshua Burkman,Forrest Petz,Red,Welterweight
+10/20/2007,Matt Grice,Jason Black,Red,Lightweight
+09/22/2007,Keith Jardine,Chuck Liddell,Red,Light Heavyweight
+09/22/2007,Forrest Griffin,Mauricio Rua,Red,Light Heavyweight
+09/22/2007,Jon Fitch,Diego Sanchez,Red,Welterweight
+09/22/2007,Lyoto Machida,Kazuhiro Nakamura,Red,Light Heavyweight
+09/22/2007,Tyson Griffin,Thiago Tavares,Red,Lightweight
+09/22/2007,Rich Clementi,Anthony Johnson,Red,Welterweight
+09/22/2007,Jeremy Stephens,Diego Saraiva,Red,Lightweight
+09/22/2007,Christian Wellisch,Scott Junk,Red,Heavyweight
+09/22/2007,Matt Wiman,Michihiro Omigawa,Red,Lightweight
+09/19/2007,Kenny Florian,Din Thomas,Red,Lightweight
+09/19/2007,Chris Leben,Terry Martin,Red,Middleweight
+09/19/2007,Nate Diaz,Junior Assuncao,Red,Lightweight
+09/19/2007,Nate Quarry,Pete Sell,Red,Middleweight
+09/19/2007,Luke Cummo,Edilberto de Oliveira,Red,Welterweight
+09/19/2007,Cole Miller,Leonard Garcia,Red,Lightweight
+09/19/2007,Gray Maynard,Joe Veres,Red,Lightweight
+09/19/2007,Thiago Alves,Kuniyoshi Hironaka,Red,Welterweight
+09/19/2007,Dustin Hazelett,Jonathan Goulet,Red,Welterweight
+09/08/2007,Quinton Jackson,Dan Henderson,Red,UFC Light Heavyweight Title
+09/08/2007,Michael Bisping,Matt Hamill,Red,Light Heavyweight
+09/08/2007,Cheick Kongo,Mirko Filipovic,Red,Heavyweight
+09/08/2007,Marcus Davis,Paul Taylor,Red,Welterweight
+09/08/2007,Houston Alexander,Alessio Sakara,Red,Light Heavyweight
+09/08/2007,Gleison Tibau,Terry Etim,Red,Lightweight
+09/08/2007,Thiago Silva,Tomasz Drwal,Red,Light Heavyweight
+09/08/2007,Dennis Siver,Naoyuki Kotani,Red,Lightweight
+09/08/2007,Jess Liaudin,Anthony Torres,Red,Welterweight
+08/25/2007,Randy Couture,Gabriel Gonzaga,Red,UFC Heavyweight Title
+08/25/2007,Georges St-Pierre,Josh Koscheck,Red,Welterweight
+08/25/2007,Roger Huerta,Alberto Crane,Red,Lightweight
+08/25/2007,Joe Stevenson,Kurt Pellegrino,Red,Lightweight
+08/25/2007,Patrick Cote,Kendall Grove,Red,Middleweight
+08/25/2007,Renato Sobral,David Heath,Red,Light Heavyweight
+08/25/2007,Frank Mir,Antoni Hardonk,Red,Heavyweight
+08/25/2007,Thales Leites,Ryan Jensen,Red,Middleweight
+08/25/2007,Clay Guida,Marcus Aurelio,Red,Lightweight
+07/07/2007,Kenny Florian,Alvin Robinson,Red,Lightweight
+07/07/2007,Anderson Silva,Nate Marquardt,Red,UFC Middleweight Title
+07/07/2007,Sean Sherk,Hermes Franca,Red,UFC Lightweight Title
+07/07/2007,Antonio Rodrigo Nogueira,Heath Herring,Red,Heavyweight
+07/07/2007,Stephan Bonnar,Mike Nickels,Red,Light Heavyweight
+07/07/2007,Jorge Gurgel,Diego Saraiva,Red,Lightweight
+07/07/2007,Chris Lytle,Jason Gilliam,Red,Welterweight
+07/07/2007,Frankie Edgar,Mark Bocek,Red,Lightweight
+06/23/2007,BJ Penn,Jens Pulver,Red,Lightweight
+06/23/2007,Nate Diaz,Manvel Gamburyan,Red,Ultimate Fighter 5 Lightweight Tournament Title
+06/23/2007,Thales Leites,Floyd Sword,Red,Middleweight
+06/23/2007,Roger Huerta,Doug Evans,Red,Lightweight
+06/23/2007,Joe Lauzon,Brandon Melendez,Red,Lightweight
+06/23/2007,Cole Miller,Andy Wang,Red,Lightweight
+06/23/2007,Leonard Garcia,Allen Berube,Red,Lightweight
+06/23/2007,Matt Wiman,Brian Geraghty,Red,Lightweight
+06/16/2007,Rich Franklin,Yushin Okami,Red,Middleweight
+06/16/2007,Forrest Griffin,Hector Ramirez,Red,Light Heavyweight
+06/16/2007,Jason MacDonald,Rory Singer,Red,Middleweight
+06/16/2007,Tyson Griffin,Clay Guida,Red,Lightweight
+06/16/2007,Ed Herman,Scott Smith,Red,Middleweight
+06/16/2007,Marcus Davis,Jason Tan,Red,Welterweight
+06/16/2007,Eddie Sanchez,Colin Robinson,Red,Heavyweight
+06/16/2007,Dustin Hazelett,Stevie Lynch,Red,Welterweight
+06/12/2007,Spencer Fisher,Sam Stout,Red,Lightweight
+06/12/2007,Jon Fitch,Roan Carneiro,Red,Welterweight
+06/12/2007,Drew McFedries,Jordan Radev,Red,Middleweight
+06/12/2007,Thiago Tavares,Jason Black,Red,Lightweight
+06/12/2007,Forrest Petz,Luigi Fioravanti,Red,Welterweight
+06/12/2007,Tamdan McCrory,Pete Spratt,Red,Welterweight
+06/12/2007,Gleison Tibau,Jeff Cox,Red,Lightweight
+06/12/2007,Anthony Johnson,Chad Reiner,Red,Welterweight
+06/12/2007,Nate Mohr,Luke Caudillo,Red,Lightweight
+05/26/2007,Quinton Jackson,Chuck Liddell,Red,UFC Light Heavyweight Title
+05/26/2007,Karo Parisyan,Joshua Burkman,Red,Welterweight
+05/26/2007,Terry Martin,Ivan Salaverry,Red,Middleweight
+05/26/2007,Houston Alexander,Keith Jardine,Red,Light Heavyweight
+05/26/2007,Kalib Starnes,Chris Leben,Red,Middleweight
+05/26/2007,Thiago Silva,James Irvin,Red,Light Heavyweight
+05/26/2007,Alan Belcher,Sean Salmon,Red,Light Heavyweight
+05/26/2007,Din Thomas,Jeremy Stephens,Red,Lightweight
+05/26/2007,Wilson Gouveia,Carmelo Marrero,Red,Light Heavyweight
+04/21/2007,Gabriel Gonzaga,Mirko Filipovic,Red,Heavyweight
+04/21/2007,Andrei Arlovski,Fabricio Werdum,Red,Heavyweight
+04/21/2007,Michael Bisping,Elvis Sinosic,Red,Light Heavyweight
+04/21/2007,Lyoto Machida,David Heath,Red,Light Heavyweight
+04/21/2007,Cheick Kongo,Assuerio Silva,Red,Heavyweight
+04/21/2007,Terry Etim,Matt Grice,Red,Lightweight
+04/21/2007,Junior Assuncao,David Lee,Red,Lightweight
+04/21/2007,Alessio Sakara,Victor Valimaki,Red,Light Heavyweight
+04/21/2007,Jess Liaudin,Dennis Siver,Red,Welterweight
+04/21/2007,Paul Taylor,Edilberto de Oliveira,Red,Welterweight
+04/07/2007,Matt Serra,Georges St-Pierre,Red,UFC Welterweight Title
+04/07/2007,Josh Koscheck,Diego Sanchez,Red,Welterweight
+04/07/2007,Roger Huerta,Leonard Garcia,Red,Lightweight
+04/07/2007,Yushin Okami,Mike Swick,Red,Middleweight
+04/07/2007,Kendall Grove,Alan Belcher,Red,Middleweight
+04/07/2007,Heath Herring,Brad Imes,Red,Heavyweight
+04/07/2007,Thales Leites,Pete Sell,Red,Middleweight
+04/07/2007,Marcus Davis,Pete Spratt,Red,Welterweight
+04/07/2007,Luke Cummo,Josh Haynes,Red,Welterweight
+04/05/2007,Joe Stevenson,Melvin Guillard,Red,Lightweight
+04/05/2007,Justin McCully,Antoni Hardonk,Red,Heavyweight
+04/05/2007,Kenny Florian,Dokonjonosuke Mishima,Red,Lightweight
+04/05/2007,Wilson Gouveia,Seth Petruzelli,Red,Light Heavyweight
+04/05/2007,Drew Fickett,Keita Nakamura,Red,Welterweight
+04/05/2007,Kurt Pellegrino,Nate Mohr,Red,Lightweight
+04/05/2007,Kuniyoshi Hironaka,Forrest Petz,Red,Welterweight
+04/05/2007,Roan Carneiro,Rich Clementi,Red,Welterweight
+04/05/2007,Thiago Tavares,Naoyuki Kotani,Red,Lightweight
+03/03/2007,Randy Couture,Tim Sylvia,Red,UFC Heavyweight Title
+03/03/2007,Martin Kampmann,Drew McFedries,Red,Middleweight
+03/03/2007,Rich Franklin,Jason MacDonald,Red,Middleweight
+03/03/2007,Matt Hughes,Chris Lytle,Red,Welterweight
+03/03/2007,Jason Lambert,Renato Sobral,Red,Light Heavyweight
+03/03/2007,Matt Hamill,Rex Holman,Red,Light Heavyweight
+03/03/2007,Jon Fitch,Luigi Fioravanti,Red,Welterweight
+03/03/2007,Gleison Tibau,Jason Dent,Red,Lightweight
+03/03/2007,Jamie Varner,Jason Gilliam,Red,Lightweight
+02/03/2007,Anderson Silva,Travis Lutter,Red,Middleweight
+02/03/2007,Mirko Filipovic,Eddie Sanchez,Red,Heavyweight
+02/03/2007,Roger Huerta,John Halverson,Red,Lightweight
+02/03/2007,Quinton Jackson,Marvin Eastman,Red,Light Heavyweight
+02/03/2007,Patrick Cote,Scott Smith,Red,Middleweight
+02/03/2007,Terry Martin,Jorge Rivera,Red,Middleweight
+02/03/2007,Frankie Edgar,Tyson Griffin,Red,Lightweight
+02/03/2007,Lyoto Machida,Sam Hoger,Red,Light Heavyweight
+02/03/2007,Dustin Hazelett,Diego Saraiva,Red,Lightweight
+01/25/2007,Rashad Evans,Sean Salmon,Red,Light Heavyweight
+01/25/2007,Jake O'Brien,Heath Herring,Red,Heavyweight
+01/25/2007,Hermes Franca,Spencer Fisher,Red,Lightweight
+01/25/2007,Nate Marquardt,Dean Lister,Red,Middleweight
+01/25/2007,Joshua Burkman,Chad Reiner,Red,Welterweight
+01/25/2007,Ed Herman,Chris Price,Red,Middleweight
+01/25/2007,Din Thomas,Clay Guida,Red,Lightweight
+01/25/2007,Rich Clementi,Ross Pointon,Red,Welterweight
+12/30/2006,Chuck Liddell,Tito Ortiz,Red,UFC Light Heavyweight Title
+12/30/2006,Keith Jardine,Forrest Griffin,Red,Light Heavyweight
+12/30/2006,Jason MacDonald,Chris Leben,Red,Middleweight
+12/30/2006,Andrei Arlovski,Marcio Cruz,Red,Heavyweight
+12/30/2006,Michael Bisping,Eric Schafer,Red,Light Heavyweight
+12/30/2006,Thiago Alves,Tony DeSouza,Red,Welterweight
+12/30/2006,Gabriel Gonzaga,Carmelo Marrero,Red,Heavyweight
+12/30/2006,Yushin Okami,Rory Singer,Red,Middleweight
+12/30/2006,Christian Wellisch,Anthony Perosh,Red,Heavyweight
+12/13/2006,Diego Sanchez,Joe Riggs,Red,Welterweight
+12/13/2006,Josh Koscheck,Jeff Joslin,Red,Welterweight
+12/13/2006,Karo Parisyan,Drew Fickett,Red,Welterweight
+12/13/2006,Marcus Davis,Shonie Carter,Red,Welterweight
+12/13/2006,David Heath,Victor Valimaki,Red,Light Heavyweight
+12/13/2006,Alan Belcher,Jorge Santiago,Red,Middleweight
+12/13/2006,Luigi Fioravanti,Dave Menne,Red,Welterweight
+12/13/2006,Brock Larson,Keita Nakamura,Red,Welterweight
+12/13/2006,Logan Clark,Steve Byrnes,Red,Middleweight
+11/18/2006,Georges St-Pierre,Matt Hughes,Red,UFC Welterweight Title
+11/18/2006,Tim Sylvia,Jeff Monson,Red,UFC Heavyweight Title
+11/18/2006,Drew McFedries,Alessio Sakara,Red,Light Heavyweight
+11/18/2006,Brandon Vera,Frank Mir,Red,Heavyweight
+11/18/2006,Joe Stevenson,Dokonjonosuke Mishima,Red,Lightweight
+11/18/2006,Nick Diaz,Gleison Tibau,Red,Welterweight
+11/18/2006,Antoni Hardonk,Sherman Pendergarst,Red,Heavyweight
+11/18/2006,James Irvin,Hector Ramirez,Red,Light Heavyweight
+11/18/2006,Jake O'Brien,Josh Shockman,Red,Heavyweight
+11/11/2006,Matt Serra,Chris Lytle,Red,Ultimate Fighter 4 Welterweight Tournament Title
+11/11/2006,Travis Lutter,Patrick Cote,Red,Ultimate Fighter 4 Middleweight Tournament Title
+11/11/2006,Din Thomas,Rich Clementi,Red,Lightweight
+11/11/2006,Jorge Rivera,Edwin DeWees,Red,Middleweight
+11/11/2006,Pete Spratt,Jeremy Jackson,Red,Welterweight
+11/11/2006,Scott Smith,Pete Sell,Red,Middleweight
+11/11/2006,Charles McCarthy,Gideon Ray,Red,Middleweight
+11/11/2006,Martin Kampmann,Thales Leites,Red,Middleweight
+10/14/2006,Anderson Silva,Rich Franklin,Red,UFC Middleweight Title
+10/14/2006,Sean Sherk,Kenny Florian,Red,UFC Lightweight Title
+10/14/2006,Jon Fitch,Kuniyoshi Hironaka,Red,Welterweight
+10/14/2006,Carmelo Marrero,Cheick Kongo,Red,Heavyweight
+10/14/2006,Spencer Fisher,Dan Lauzon,Red,Lightweight
+10/14/2006,Yushin Okami,Kalib Starnes,Red,Middleweight
+10/14/2006,Clay Guida,Justin James,Red,Lightweight
+10/14/2006,Kurt Pellegrino,Junior Assuncao,Red,Lightweight
+10/10/2006,Tito Ortiz,Ken Shamrock,Red,Light Heavyweight
+10/10/2006,Kendall Grove,Chris Price,Red,Middleweight
+10/10/2006,Jason MacDonald,Ed Herman,Red,Middleweight
+10/10/2006,Matt Hamill,Seth Petruzelli,Red,Light Heavyweight
+10/10/2006,Nate Marquardt,Crafton Wallace,Red,Middleweight
+10/10/2006,Tony DeSouza,Dustin Hazelett,Red,Welterweight
+10/10/2006,Rory Singer,Josh Haynes,Red,Middleweight
+10/10/2006,Thiago Alves,John Alessio,Red,Welterweight
+10/10/2006,Marcus Davis,Forrest Petz,Red,Welterweight
+09/23/2006,Matt Hughes,BJ Penn,Red,UFC Welterweight Title
+09/23/2006,Mike Swick,David Loiseau,Red,Middleweight
+09/23/2006,Melvin Guillard,Gabe Ruediger,Red,Lightweight
+09/23/2006,Rashad Evans,Jason Lambert,Red,Light Heavyweight
+09/23/2006,Joe Lauzon,Jens Pulver,Red,Lightweight
+09/23/2006,Roger Huerta,Jason Dent,Red,Lightweight
+09/23/2006,Eddie Sanchez,Mario Neto,Red,Heavyweight
+09/23/2006,Jorge Gurgel,Danny Abbadi,Red,Lightweight
+09/23/2006,Tyson Griffin,David Lee,Red,Lightweight
+08/26/2006,Chuck Liddell,Renato Sobral,Red,UFC Light Heavyweight Title
+08/26/2006,Forrest Griffin,Stephan Bonnar,Red,Light Heavyweight
+08/26/2006,Nick Diaz,Josh Neer,Red,Welterweight
+08/26/2006,Cheick Kongo,Christian Wellisch,Red,Heavyweight
+08/26/2006,Hermes Franca,Jamie Varner,Red,Lightweight
+08/26/2006,Eric Schafer,Rob MacDonald,Red,Light Heavyweight
+08/26/2006,Wilson Gouveia,Wes Combs,Red,Light Heavyweight
+08/26/2006,David Heath,Cory Walmsley,Red,Light Heavyweight
+08/26/2006,Yushin Okami,Alan Belcher,Red,Middleweight
+08/17/2006,Diego Sanchez,Karo Parisyan,Red,Welterweight
+08/17/2006,Chris Leben,Jorge Santiago,Red,Middleweight
+08/17/2006,Dean Lister,Yuki Sasaki,Red,Middleweight
+08/17/2006,Josh Koscheck,Jonathan Goulet,Red,Welterweight
+08/17/2006,Martin Kampmann,Crafton Wallace,Red,Middleweight
+08/17/2006,Joe Riggs,Jason Von Flue,Red,Welterweight
+08/17/2006,Jake O'Brien,Kristof Midoux,Red,Heavyweight
+08/17/2006,Forrest Petz,Sammy Morgan,Red,Welterweight
+08/17/2006,Anthony Torres,Pat Healy,Red,Welterweight
+07/08/2006,Tim Sylvia,Andrei Arlovski,Red,UFC Heavyweight Title
+07/08/2006,Joshua Burkman,Josh Neer,Red,Welterweight
+07/08/2006,Tito Ortiz,Ken Shamrock,Red,Light Heavyweight
+07/08/2006,Frank Mir,Dan Christison,Red,Heavyweight
+07/08/2006,Joe Stevenson,Yves Edwards,Red,Lightweight
+07/08/2006,Hermes Franca,Joe Jordan,Red,Catch Weight
+07/08/2006,Jeff Monson,Anthony Perosh,Red,Heavyweight
+07/08/2006,Cheick Kongo,Gilbert Aldana,Red,Heavyweight
+07/08/2006,Drew Fickett,Kurt Pellegrino,Red,Welterweight
+06/28/2006,Jonathan Goulet,Luke Cummo,Red,Welterweight
+06/28/2006,Anderson Silva,Chris Leben,Red,Middleweight
+06/28/2006,Rashad Evans,Stephan Bonnar,Red,Light Heavyweight
+06/28/2006,Mark Hominick,Jorge Gurgel,Red,Lightweight
+06/28/2006,Josh Koscheck,Dave Menne,Red,Welterweight
+06/28/2006,Jason Lambert,Branden Lee Hinkle,Red,Light Heavyweight
+06/28/2006,Jon Fitch,Thiago Alves,Red,Welterweight
+06/28/2006,Rob MacDonald,Kristian Rothaermel,Red,Light Heavyweight
+06/28/2006,Jorge Santiago,Justin Levens,Red,Middleweight
+06/24/2006,Kenny Florian,Sam Stout,Red,Lightweight
+06/24/2006,Michael Bisping,Josh Haynes,Red,Ultimate Fighter 3 Light Heavyweight Tournament Title
+06/24/2006,Kendall Grove,Ed Herman,Red,Ultimate Fighter 3 Middleweight Tournament Title
+06/24/2006,Keith Jardine,Wilson Gouveia,Red,Light Heavyweight
+06/24/2006,Rory Singer,Ross Pointon,Red,Middleweight
+06/24/2006,Kalib Starnes,Danny Abbadi,Red,Middleweight
+06/24/2006,Luigi Fioravanti,Solomon Hutcherson,Red,Middleweight
+06/24/2006,Matt Hamill,Jesse Forbes,Red,Light Heavyweight
+06/24/2006,Mike Nickels,Wes Combs,Red,Light Heavyweight
+05/27/2006,Matt Hughes,Royce Gracie,Red,Catch Weight
+05/27/2006,Dean Lister,Alessio Sakara,Red,Light Heavyweight
+05/27/2006,Diego Sanchez,John Alessio,Red,Welterweight
+05/27/2006,Brandon Vera,Assuerio Silva,Red,Heavyweight
+05/27/2006,Mike Swick,Joe Riggs,Red,Middleweight
+05/27/2006,Jeremy Horn,Chael Sonnen,Red,Middleweight
+05/27/2006,Spencer Fisher,Matt Wiman,Red,Lightweight
+05/27/2006,Gabriel Gonzaga,Fabiano Scherner,Red,Heavyweight
+05/27/2006,Melvin Guillard,Rick Davis,Red,Lightweight
+04/15/2006,Tim Sylvia,Andrei Arlovski,Red,UFC Heavyweight Title
+04/15/2006,Sean Sherk,Nick Diaz,Red,Welterweight
+04/15/2006,Tito Ortiz,Forrest Griffin,Red,Light Heavyweight
+04/15/2006,Evan Tanner,Justin Levens,Red,Middleweight
+04/15/2006,Jeff Monson,Marcio Cruz,Red,Heavyweight
+04/15/2006,Karo Parisyan,Nick Thompson,Red,Welterweight
+04/15/2006,David Terrell,Scott Smith,Red,Middleweight
+04/15/2006,Jason Lambert,Terry Martin,Red,Light Heavyweight
+04/15/2006,Thiago Alves,Derrick Noble,Red,Welterweight
+04/06/2006,Stephan Bonnar,Keith Jardine,Red,Light Heavyweight
+04/06/2006,Rashad Evans,Sam Hoger,Red,Light Heavyweight
+04/06/2006,Josh Neer,Joe Stevenson,Red,Welterweight
+04/06/2006,Chris Leben,Luigi Fioravanti,Red,Middleweight
+04/06/2006,Luke Cummo,Jason Von Flue,Red,Welterweight
+04/06/2006,Jon Fitch,Joshua Burkman,Red,Welterweight
+04/06/2006,Dan Christison,Brad Imes,Red,Heavyweight
+04/06/2006,Josh Koscheck,Ansar Chalangov,Red,Welterweight
+04/06/2006,Chael Sonnen,Trevor Prangley,Red,Middleweight
+03/04/2006,Rich Franklin,David Loiseau,Red,UFC Middleweight Title
+03/04/2006,Mike Swick,Steve Vigneault,Red,Middleweight
+03/04/2006,Georges St-Pierre,BJ Penn,Red,Welterweight
+03/04/2006,Nate Marquardt,Joe Doerksen,Red,Middleweight
+03/04/2006,Mark Hominick,Yves Edwards,Red,Lightweight
+03/04/2006,Sam Stout,Spencer Fisher,Red,Lightweight
+03/04/2006,Jason Lambert,Rob MacDonald,Red,Light Heavyweight
+03/04/2006,Tom Murphy,Icho Larenas,Red,Heavyweight
+02/04/2006,Chuck Liddell,Randy Couture,Red,UFC Light Heavyweight Title
+02/04/2006,Brandon Vera,Justin Eilers,Red,Heavyweight
+02/04/2006,Marcio Cruz,Frank Mir,Red,Heavyweight
+02/04/2006,Renato Sobral,Mike van Arsdale,Red,Light Heavyweight
+02/04/2006,Joe Riggs,Nick Diaz,Red,Welterweight
+02/04/2006,Alessio Sakara,Elvis Sinosic,Red,Light Heavyweight
+02/04/2006,Paul Buentello,Gilbert Aldana,Red,Heavyweight
+02/04/2006,Jeff Monson,Branden Lee Hinkle,Red,Heavyweight
+02/04/2006,Keith Jardine,Mike Whitehead,Red,Light Heavyweight
+01/16/2006,Tim Sylvia,Assuerio Silva,Red,Heavyweight
+01/16/2006,Stephan Bonnar,James Irvin,Red,Light Heavyweight
+01/16/2006,Joshua Burkman,Drew Fickett,Red,Welterweight
+01/16/2006,Chris Leben,Jorge Rivera,Red,Middleweight
+01/16/2006,Josh Neer,Melvin Guillard,Red,Welterweight
+01/16/2006,Duane Ludwig,Jonathan Goulet,Red,Welterweight
+01/16/2006,Spencer Fisher,Aaron Riley,Red,Welterweight
+01/16/2006,Jason Von Flue,Alex Karalexis,Red,Welterweight
+11/19/2005,Rich Franklin,Nate Quarry,Red,UFC Middleweight Title
+11/19/2005,Gabriel Gonzaga,Kevin Jordan,Red,Heavyweight
+11/19/2005,Matt Hughes,Joe Riggs,Red,Welterweight
+11/19/2005,Georges St-Pierre,Sean Sherk,Red,Welterweight
+11/19/2005,Jeremy Horn,Trevor Prangley,Red,Middleweight
+11/19/2005,Sam Hoger,Jeff Newton,Red,Light Heavyweight
+11/19/2005,Thiago Alves,Ansar Chalangov,Red,Welterweight
+11/19/2005,Nick Thompson,Keith Wisniewski,Red,Welterweight
+11/05/2005,Diego Sanchez,Nick Diaz,Red,Welterweight
+11/05/2005,Rashad Evans,Brad Imes,Red,Ultimate Fighter 2 Heavyweight Tournament Title
+11/05/2005,Joe Stevenson,Luke Cummo,Red,Ultimate Fighter 2 Welterweight Tournament Title
+11/05/2005,Kenny Florian,Kit Cope,Red,Welterweight
+11/05/2005,Joshua Burkman,Sammy Morgan,Red,Welterweight
+11/05/2005,Melvin Guillard,Marcus Davis,Red,Welterweight
+11/05/2005,Keith Jardine,Kerry Schall,Red,Heavyweight
+10/07/2005,Andrei Arlovski,Paul Buentello,Red,UFC Heavyweight Title
+10/07/2005,Branden Lee Hinkle,Sean Gannon,Red,Heavyweight
+10/07/2005,Forrest Griffin,Elvis Sinosic,Red,Light Heavyweight
+10/07/2005,Renato Sobral,Chael Sonnen,Red,Light Heavyweight
+10/07/2005,Joe Riggs,Chris Lytle,Red,Welterweight
+10/07/2005,Jorge Rivera,Dennis Hallman,Red,Middleweight
+10/07/2005,Marcio Cruz,Keigo Kunihara,Red,Heavyweight
+10/03/2005,David Loiseau,Evan Tanner,Red,Middleweight
+10/03/2005,Chris Leben,Edwin DeWees,Red,Middleweight
+10/03/2005,Brandon Vera,Fabiano Scherner,Red,Heavyweight
+10/03/2005,Drew Fickett,Josh Koscheck,Red,Welterweight
+10/03/2005,Spencer Fisher,Thiago Alves,Red,Welterweight
+10/03/2005,Jon Fitch,Brock Larson,Red,Middleweight
+10/03/2005,Jonathan Goulet,Jay Hieron,Red,Welterweight
+08/20/2005,Chuck Liddell,Jeremy Horn,Red,UFC Light Heavyweight Title
+08/20/2005,Tim Sylvia,Tra Telligman,Red,Heavyweight
+08/20/2005,Randy Couture,Mike van Arsdale,Red,Light Heavyweight
+08/20/2005,Diego Sanchez,Brian Gassaway,Red,Welterweight
+08/20/2005,Georges St-Pierre,Frank Trigg,Red,Welterweight
+08/20/2005,Matt Lindland,Joe Doerksen,Red,Middleweight
+08/20/2005,Trevor Prangley,Travis Lutter,Red,Middleweight
+08/20/2005,James Irvin,Terry Martin,Red,Light Heavyweight
+08/06/2005,Nate Marquardt,Ivan Salaverry,Red,Middleweight
+08/06/2005,Chris Leben,Patrick Cote,Red,Middleweight
+08/06/2005,Stephan Bonnar,Sam Hoger,Red,Light Heavyweight
+08/06/2005,Nate Quarry,Pete Sell,Red,Middleweight
+08/06/2005,Josh Koscheck,Pete Spratt,Red,Welterweight
+08/06/2005,Mike Swick,Gideon Ray,Red,Middleweight
+08/06/2005,Kenny Florian,Alex Karalexis,Red,Welterweight
+08/06/2005,Drew Fickett,Josh Neer,Red,Welterweight
+06/04/2005,Andrei Arlovski,Justin Eilers,Red,UFC Interim Heavyweight Title
+06/04/2005,Karo Parisyan,Matt Serra,Red,Welterweight
+06/04/2005,Rich Franklin,Evan Tanner,Red,UFC Middleweight Title
+06/04/2005,Forrest Griffin,Bill Mahood,Red,Light Heavyweight
+06/04/2005,Paul Buentello,Kevin Jordan,Red,Heavyweight
+06/04/2005,Nate Quarry,Shonie Carter,Red,Middleweight
+06/04/2005,David Loiseau,Charles McCarthy,Red,Middleweight
+06/04/2005,Nick Diaz,Koji Oishi,Red,Welterweight
+04/16/2005,Chuck Liddell,Randy Couture,Red,UFC Light Heavyweight Title
+04/16/2005,Renato Sobral,Travis Wiuff,Red,Light Heavyweight
+04/16/2005,Matt Hughes,Frank Trigg,Red,UFC Welterweight Title
+04/16/2005,Matt Lindland,Travis Lutter,Red,Middleweight
+04/16/2005,Georges St-Pierre,Jason Miller,Red,Welterweight
+04/16/2005,Ivan Salaverry,Joe Riggs,Red,Middleweight
+04/16/2005,Joe Doerksen,Patrick Cote,Red,Middleweight
+04/16/2005,Mike van Arsdale,John Marsh,Red,Heavyweight
+04/09/2005,Rich Franklin,Ken Shamrock,Red,Light Heavyweight
+04/09/2005,Forrest Griffin,Stephan Bonnar,Red,Ultimate Fighter 1 Light Heavyweight Tournament Title
+04/09/2005,Diego Sanchez,Kenny Florian,Red,Ultimate Fighter 1 Middleweight Tournament Title
+04/09/2005,Sam Hoger,Bobby Southworth,Red,Light Heavyweight
+04/09/2005,Chris Leben,Jason Thacker,Red,Middleweight
+04/09/2005,Josh Koscheck,Chris Sanford,Red,Middleweight
+04/09/2005,Nate Quarry,Lodune Sincaid,Red,Middleweight
+04/09/2005,Mike Swick,Alex Schoenauer,Red,Middleweight
+04/09/2005,Alex Karalexis,Josh Rafferty,Red,Welterweight
+02/05/2005,Tito Ortiz,Vitor Belfort,Red,Light Heavyweight
+02/05/2005,Pete Sell,Phil Baroni,Red,Middleweight
+02/05/2005,Andrei Arlovski,Tim Sylvia,Red,UFC Interim Heavyweight Title
+02/05/2005,Evan Tanner,David Terrell,Red,UFC Middleweight Title
+02/05/2005,Paul Buentello,Justin Eilers,Red,Heavyweight
+02/05/2005,Mike Kyle,James Irvin,Red,Heavyweight
+02/05/2005,David Loiseau,Gideon Ray,Red,Middleweight
+02/05/2005,Karo Parisyan,Chris Lytle,Red,Welterweight
+02/05/2005,Nick Diaz,Drew Fickett,Red,Welterweight
+10/22/2004,Tito Ortiz,Patrick Cote,Red,Light Heavyweight
+10/22/2004,Rich Franklin,Jorge Rivera,Red,Middleweight
+10/22/2004,Matt Hughes,Georges St-Pierre,Red,UFC Welterweight Title
+10/22/2004,Frank Trigg,Renato Verissimo,Red,Welterweight
+10/22/2004,Evan Tanner,Robbie Lawler,Red,Middleweight
+10/22/2004,Ivan Salaverry,Tony Fryklund,Red,Middleweight
+10/22/2004,Travis Lutter,Marvin Eastman,Red,Light Heavyweight
+08/21/2004,Randy Couture,Vitor Belfort,Red,UFC Light Heavyweight Title
+08/21/2004,Joe Riggs,Joe Doerksen,Red,Middleweight
+08/21/2004,Chuck Liddell,Vernon White,Red,Light Heavyweight
+08/21/2004,David Terrell,Matt Lindland,Red,Middleweight
+08/21/2004,Justin Eilers,Mike Kyle,Red,Heavyweight
+08/21/2004,Chris Lytle,Ronald Jhun,Red,Welterweight
+08/21/2004,Karo Parisyan,Nick Diaz,Red,Welterweight
+08/21/2004,Yves Edwards,Josh Thomson,Red,Lightweight
+06/19/2004,Ken Shamrock,Kimo Leopoldo,Red,Heavyweight
+06/19/2004,Frank Trigg,Dennis Hallman,Red,Welterweight
+06/19/2004,Frank Mir,Tim Sylvia,Red,UFC Heavyweight Title
+06/19/2004,Matt Hughes,Renato Verissimo,Red,Welterweight
+06/19/2004,Evan Tanner,Phil Baroni,Red,Middleweight
+06/19/2004,Matt Serra,Ivan Menjivar,Red,Lightweight
+06/19/2004,Georges St-Pierre,Jay Hieron,Red,Welterweight
+06/19/2004,Trevor Prangley,Curtis Stout,Red,Middleweight
+04/02/2004,Chuck Liddell,Tito Ortiz,Red,Light Heavyweight
+04/02/2004,Chris Lytle,Tiki Ghosn,Red,Welterweight
+04/02/2004,Yves Edwards,Hermes Franca,Red,Lightweight
+04/02/2004,Andrei Arlovski,Wesley Correira,Red,Heavyweight
+04/02/2004,Nick Diaz,Robbie Lawler,Red,Welterweight
+04/02/2004,Mike Kyle,Wes Sims,Red,Heavyweight
+04/02/2004,Jonathan Wiezorek,Wade Shipp,Red,Heavyweight
+04/02/2004,Genki Sudo,Mike Brown,Red,Lightweight
+01/31/2004,Vitor Belfort,Randy Couture,Red,UFC Light Heavyweight Title
+01/31/2004,Renato Verissimo,Carlos Newton,Red,Welterweight
+01/31/2004,BJ Penn,Matt Hughes,Red,UFC Welterweight Title
+01/31/2004,Frank Mir,Wes Sims,Red,Heavyweight
+01/31/2004,Lee Murray,Jorge Rivera,Red,Middleweight
+01/31/2004,Georges St-Pierre,Karo Parisyan,Red,Welterweight
+01/31/2004,Josh Thomson,Hermes Franca,Red,Lightweight
+01/31/2004,Matt Serra,Jeff Curran,Red,Lightweight
+11/21/2003,Matt Hughes,Frank Trigg,Red,UFC Welterweight Title
+11/21/2003,Matt Lindland,Falaniko Vitale,Red,Middleweight
+11/21/2003,Wesley Correira,David Abbott,Red,Heavyweight
+11/21/2003,Evan Tanner,Phil Baroni,Red,Middleweight
+11/21/2003,Robbie Lawler,Chris Lytle,Red,Welterweight
+11/21/2003,Pedro Rizzo,Ricco Rodriguez,Red,Heavyweight
+11/21/2003,Keith Rockel,Chris Liguori,Red,Middleweight
+11/21/2003,Yves Edwards,Nick Agallar,Red,Lightweight
+09/26/2003,Randy Couture,Tito Ortiz,Red,UFC Light Heavyweight Title
+09/26/2003,Andrei Arlovski,Vladimir Matyushenko,Red,Heavyweight
+09/26/2003,Tim Sylvia,Gan McGee,Red,UFC Heavyweight Title
+09/26/2003,Jorge Rivera,David Loiseau,Red,Middleweight
+09/26/2003,Rich Franklin,Edwin DeWees,Red,Light Heavyweight
+09/26/2003,Karo Parisyan,Dave Strasser,Red,Welterweight
+09/26/2003,Josh Thomson,Gerald Strebendt,Red,Lightweight
+09/26/2003,Nick Diaz,Jeremy Jackson,Red,Welterweight
+09/26/2003,Hermes Franca,Caol Uno,Red,Lightweight
+06/06/2003,Randy Couture,Chuck Liddell,Red,UFC Interim Light Heavyweight Title
+06/06/2003,Kimo Leopoldo,David Abbott,Red,Heavyweight
+06/06/2003,Vitor Belfort,Marvin Eastman,Red,Light Heavyweight
+06/06/2003,Frank Mir,Wes Sims,Red,Heavyweight
+06/06/2003,Yves Edwards,Eddie Ruiz,Red,Lightweight
+06/06/2003,Falaniko Vitale,Matt Lindland,Red,Middleweight
+06/06/2003,Pedro Rizzo,Tra Telligman,Red,Heavyweight
+04/25/2003,Matt Hughes,Sean Sherk,Red,UFC Welterweight Title
+04/25/2003,Pete Spratt,Robbie Lawler,Red,Welterweight
+04/25/2003,Dave Strasser,Romie Aram,Red,Welterweight
+04/25/2003,Wesley Correira,Sean Alvarez,Red,Heavyweight
+04/25/2003,Rich Franklin,Evan Tanner,Red,Light Heavyweight
+04/25/2003,Duane Ludwig,Genki Sudo,Red,Lightweight
+04/25/2003,Hermes Franca,Richard Crunkilton,Red,Lightweight
+04/25/2003,David Loiseau,Mark Weir,Red,Middleweight
+02/28/2003,Tim Sylvia,Ricco Rodriguez,Red,UFC Heavyweight Title
+02/28/2003,Frank Mir,David Abbott,Red,Heavyweight
+02/28/2003,Matt Lindland,Phil Baroni,Red,Middleweight
+02/28/2003,Vladimir Matyushenko,Pedro Rizzo,Red,Heavyweight
+02/28/2003,Din Thomas,Matt Serra,Red,Lightweight
+02/28/2003,Gan McGee,Alexandre Dantas,Red,Heavyweight
+02/28/2003,Yves Edwards,Rich Clementi,Red,Lightweight
+11/22/2002,Tito Ortiz,Ken Shamrock,Red,UFC Light Heavyweight Title
+11/22/2002,Chuck Liddell,Renato Sobral,Red,Light Heavyweight
+11/22/2002,Matt Hughes,Gil Castillo,Red,UFC Welterweight Title
+11/22/2002,Carlos Newton,Pete Spratt,Red,Welterweight
+11/22/2002,Robbie Lawler,Tiki Ghosn,Red,Welterweight
+11/22/2002,Andrei Arlovski,Ian Freeman,Red,Heavyweight
+11/22/2002,Vladimir Matyushenko,Travis Wiuff,Red,Heavyweight
+11/22/2002,Phillip Miller,Mark Weir,Red,Middleweight
+09/27/2002,Ricco Rodriguez,Randy Couture,Red,UFC Heavyweight Title
+09/27/2002,Tim Sylvia,Wesley Correira,Red,Heavyweight
+09/27/2002,BJ Penn,Matt Serra,Red,Lightweight
+09/27/2002,Caol Uno,Din Thomas,Red,Lightweight
+09/27/2002,Gan McGee,Pedro Rizzo,Red,Heavyweight
+09/27/2002,Phil Baroni,Dave Menne,Red,Middleweight
+09/27/2002,Matt Lindland,Ivan Salaverry,Red,Middleweight
+09/27/2002,Sean Sherk,Benji Radach,Red,Welterweight
+07/13/2002,Matt Hughes,Carlos Newton,Red,UFC Welterweight Title
+07/13/2002,Ian Freeman,Frank Mir,Red,Heavyweight
+07/13/2002,Mark Weir,Eugene Jackson,Red,Middleweight
+07/13/2002,Genki Sudo,Leigh Remedios,Red,Lightweight
+07/13/2002,Phillip Miller,James Zikic,Red,Light Heavyweight
+07/13/2002,Renato Sobral,Elvis Sinosic,Red,Light Heavyweight
+07/13/2002,Evan Tanner,Chris Haseman,Red,Light Heavyweight
+06/22/2002,Chuck Liddell,Vitor Belfort,Red,Light Heavyweight
+06/22/2002,Benji Radach,Nick Serra,Red,Welterweight
+06/22/2002,Pete Spratt,Zach Light,Red,Welterweight
+06/22/2002,Robbie Lawler,Steve Berger,Red,Welterweight
+06/22/2002,Tony Fryklund,Rodrigo Ruas,Red,Middleweight
+06/22/2002,Yves Edwards,Joao Pierini,Red,Lightweight
+05/10/2002,Murilo Bustamante,Matt Lindland,Red,UFC Middleweight Title
+05/10/2002,Ricco Rodriguez,Tsuyoshi Kohsaka,Red,Heavyweight
+05/10/2002,BJ Penn,Paul Creighton,Red,Lightweight
+05/10/2002,Phil Baroni,Amar Suloev,Red,Middleweight
+05/10/2002,Caol Uno,Yves Edwards,Red,Lightweight
+05/10/2002,Ivan Salaverry,Andrei Semenov,Red,Middleweight
+05/10/2002,Robbie Lawler,Aaron Riley,Red,Welterweight
+03/22/2002,Josh Barnett,Randy Couture,Red,UFC Heavyweight Title
+03/22/2002,Pedro Rizzo,Andrei Arlovski,Red,Heavyweight
+03/22/2002,Matt Hughes,Hayato Sakurai,Red,UFC Welterweight Title
+03/22/2002,Matt Lindland,Pat Miletich,Red,Middleweight
+03/22/2002,Evan Tanner,Elvis Sinosic,Red,Light Heavyweight
+03/22/2002,Frank Mir,Pete Williams,Red,Heavyweight
+03/22/2002,Matt Serra,Kelly Dullanty,Red,Lightweight
+03/22/2002,Sean Sherk,Jutaro Nakao,Red,Welterweight
+01/11/2002,Jens Pulver,BJ Penn,Red,UFC Lightweight Title
+01/11/2002,Ricco Rodriguez,Jeff Monson,Red,Heavyweight
+01/11/2002,Murilo Bustamante,Dave Menne,Red,UFC Middleweight Title
+01/11/2002,Chuck Liddell,Amar Suloev,Red,Light Heavyweight
+01/11/2002,Andrei Semenov,Ricardo Almeida,Red,Middleweight
+01/11/2002,Kevin Randleman,Renato Sobral,Red,Light Heavyweight
+01/11/2002,Gil Castillo,Chris Brennan,Red,Welterweight
+01/11/2002,Eugene Jackson,Keith Rockel,Red,Middleweight
+11/02/2001,Randy Couture,Pedro Rizzo,Red,UFC Heavyweight Title
+11/02/2001,Ricco Rodriguez,Pete Williams,Red,Heavyweight
+11/02/2001,Matt Hughes,Carlos Newton,Red,UFC Welterweight Title
+11/02/2001,BJ Penn,Caol Uno,Red,Lightweight
+11/02/2001,Josh Barnett,Bobby Hoffman,Red,Heavyweight
+11/02/2001,Evan Tanner,Homer Moore,Red,Light Heavyweight
+11/02/2001,Matt Lindland,Phil Baroni,Red,Middleweight
+11/02/2001,Frank Mir,Roberto Traven,Red,Heavyweight
+09/28/2001,Tito Ortiz,Vladimir Matyushenko,Red,UFC Light Heavyweight Title
+09/28/2001,Jens Pulver,Dennis Hallman,Red,UFC Lightweight Title
+09/28/2001,Chuck Liddell,Murilo Bustamante,Red,Light Heavyweight
+09/28/2001,Matt Serra,Yves Edwards,Red,Welterweight
+09/28/2001,Dave Menne,Gil Castillo,Red,UFC Middleweight Title
+09/28/2001,Jutaro Nakao,Tony DeSouza,Red,Welterweight
+09/28/2001,Ricardo Almeida,Eugene Jackson,Red,Middleweight
+09/28/2001,Din Thomas,Fabiano Iha,Red,Lightweight
+06/29/2001,Tito Ortiz,Elvis Sinosic,Red,UFC Light Heavyweight Title
+06/29/2001,BJ Penn,Din Thomas,Red,Lightweight
+06/29/2001,Josh Barnett,Semmy Schilt,Red,Heavyweight
+06/29/2001,Pat Miletich,Shonie Carter,Red,Welterweight
+06/29/2001,Caol Uno,Fabiano Iha,Red,Lightweight
+06/29/2001,Vladimir Matyushenko,Yuki Kondo,Red,Light Heavyweight
+06/29/2001,Ricco Rodriguez,Andrei Arlovski,Red,Heavyweight
+06/29/2001,Tony DeSouza,Paul Rodriguez,Red,Welterweight
+05/04/2001,Randy Couture,Pedro Rizzo,Red,UFC Heavyweight Title
+05/04/2001,Carlos Newton,Pat Miletich,Red,UFC Welterweight Title
+05/04/2001,Chuck Liddell,Kevin Randleman,Red,Light Heavyweight
+05/04/2001,Shonie Carter,Matt Serra,Red,Welterweight
+05/04/2001,Semmy Schilt,Pete Williams,Red,Heavyweight
+05/04/2001,Matt Lindland,Ricardo Almeida,Red,Light Heavyweight
+05/04/2001,BJ Penn,Joey Gilbert,Red,Lightweight
+05/04/2001,Tony DeSouza,Steve Berger,Red,Welterweight
+02/23/2001,Tito Ortiz,Evan Tanner,Red,UFC Light Heavyweight Title
+02/23/2001,Jens Pulver,Caol Uno,Red,UFC Lightweight Title
+02/23/2001,Fabiano Iha,Phil Johns,Red,Welterweight
+02/23/2001,Elvis Sinosic,Jeremy Horn,Red,Middleweight
+02/23/2001,Pedro Rizzo,Josh Barnett,Red,Heavyweight
+02/23/2001,Phil Baroni,Curtis Stout,Red,Middleweight
+02/23/2001,Sean Sherk,Tiki Ghosn,Red,Welterweight
+12/16/2000,Tito Ortiz,Yuki Kondo,Red,UFC Light Heavyweight Title
+12/16/2000,Pat Miletich,Kenichi Yamamoto,Red,UFC Welterweight Title
+12/16/2000,Matt Lindland,Yoji Anjo,Red,Middleweight
+12/16/2000,Fabiano Iha,Daiju Takase,Red,Welterweight
+12/16/2000,Evan Tanner,Lance Gibson,Red,Middleweight
+12/16/2000,Dennis Hallman,Matt Hughes,Red,Welterweight
+12/16/2000,Chuck Liddell,Jeff Monson,Red,Middleweight
+11/17/2000,Randy Couture,Kevin Randleman,Red,UFC Heavyweight Title
+11/17/2000,Renato Sobral,Maurice Smith,Red,Heavyweight
+11/17/2000,Josh Barnett,Gan McGee,Red,Super Heavyweight
+11/17/2000,Andrei Arlovski,Aaron Brink,Red,Heavyweight
+11/17/2000,Jens Pulver,John Lewis,Red,Lightweight
+11/17/2000,Mark Hughes,Alex Stiebling,Red,Middleweight
+11/17/2000,Ben Earwood,Chris Lytle,Red,Welterweight
+09/22/2000,Pedro Rizzo,Dan Severn,Red,Heavyweight
+09/22/2000,Maurice Smith,Bobby Hoffman,Red,Heavyweight
+09/22/2000,Jeremy Horn,Eugene Jackson,Red,Middleweight
+09/22/2000,Fabiano Iha,Laverne Clark,Red,Welterweight
+09/22/2000,Yuki Kondo,Alexandre Dantas,Red,Middleweight
+09/22/2000,Ian Freeman,Tedd Williams,Red,Heavyweight
+09/22/2000,Jeff Monson,Tim Lajcik,Red,Heavyweight
+06/09/2000,Kevin Randleman,Pedro Rizzo,Red,UFC Heavyweight Title
+06/09/2000,Tyrone Roberts,David Dodd,Red,Middleweight
+06/09/2000,Pat Miletich,John Alessio,Red,UFC Welterweight Title
+06/09/2000,Amaury Bitetti,Alex Andrade,Red,Middleweight
+06/09/2000,Matt Hughes,Marcelo Aguiar,Red,Welterweight
+06/09/2000,Jens Pulver,Joao Roque,Red,Lightweight
+06/09/2000,Ian Freeman,Nate Schroeder,Red,Heavyweight
+06/09/2000,Shonie Carter,Adrian Serrano,Red,Welterweight
+04/14/2000,Tito Ortiz,Wanderlei Silva,Red,UFC Light Heavyweight Title
+04/14/2000,Murilo Bustamante,Yoji Anjo,Red,Middleweight
+04/14/2000,Sanae Kikuta,Eugene Jackson,Red,Middleweight
+04/14/2000,Ron Waterman,Satoshi Honma,Red,Heavyweight
+04/14/2000,Ikuhisa Minowa,Joe Slick,Red,Middleweight
+04/14/2000,Laverne Clark,Koji Oishi,Red,Lightweight
+03/10/2000,Tedd Williams,Steve Judson,Red,Heavyweight
+03/10/2000,Lance Gibson,Jermaine Andre,Red,Middleweight
+03/10/2000,Dave Menne,Fabiano Iha,Red,Lightweight
+03/10/2000,Bob Cook,Tiki Ghosn,Red,Lightweight
+03/10/2000,Jens Pulver,David Velasquez,Red,Lightweight
+03/10/2000,Scott Adams,Ian Freeman,Red,Heavyweight
+03/10/2000,Shonie Carter,Brad Gumm,Red,Lightweight
+11/19/1999,Kevin Randleman,Pete Williams,Red,UFC Heavyweight Title
+11/19/1999,Pedro Rizzo,Tsuyoshi Kohsaka,Red,Heavyweight
+11/19/1999,Kenichi Yamamoto,Katsuhisa Fujii,Red,Ultimate Japan 2 Heavyweight Tournament Title
+11/19/1999,Joe Slick,Jason DeLucia,Red,Middleweight
+11/19/1999,Eugene Jackson,Keiichiro Yamamiya,Red,Middleweight
+11/19/1999,Kenichi Yamamoto,Daiju Takase,Red,Open Weight
+11/19/1999,Katsuhisa Fujii,Masutatsu Yano,Red,Open Weight
+09/24/1999,Frank Shamrock,Tito Ortiz,Red,UFC Light Heavyweight Title
+09/24/1999,Jeremy Horn,Jason Godsey,Red,Heavyweight
+09/24/1999,Brad Kohler,Steve Judson,Red,Heavyweight
+09/24/1999,Chuck Liddell,Paul Jones,Red,Middleweight
+09/24/1999,Matt Hughes,Valeri Ignatov,Red,Lightweight
+09/24/1999,John Lewis,Lowell Anderson,Red,Middleweight
+07/16/1999,Maurice Smith,Marco Ruas,Red,Heavyweight
+07/16/1999,Pat Miletich,Andre Pederneiras,Red,UFC Welterweight Title
+07/16/1999,Jeremy Horn,Daiju Takase,Red,Middleweight
+07/16/1999,Paul Jones,Flavio Luiz Moura,Red,Middleweight
+07/16/1999,Tsuyoshi Kohsaka,Tim Lajcik,Red,Heavyweight
+07/16/1999,Eugene Jackson,Royce Alger,Red,Middleweight
+07/16/1999,Andre Roberts,Ron Waterman,Red,Heavyweight
+07/16/1999,Travis Fulton,David Dodd,Red,Heavyweight
+05/07/1999,Bas Rutten,Kevin Randleman,Red,UFC Heavyweight Title
+05/07/1999,Pedro Rizzo,Tra Telligman,Red,Heavyweight
+05/07/1999,Pete Williams,Travis Fulton,Red,Heavyweight
+05/07/1999,Wanderlei Silva,Tony Petarra,Red,Middleweight
+05/07/1999,Marcelo Mello,David Roberts,Red,Lightweight
+05/07/1999,Laverne Clark,Fabiano Iha,Red,Lightweight
+05/07/1999,Ron Waterman,Chris Condo,Red,Heavyweight
+03/05/1999,Tito Ortiz,Guy Mezger,Red,Middleweight
+03/05/1999,Gary Goodridge,Andre Roberts,Red,Heavyweight
+03/05/1999,Jeremy Horn,Chuck Liddell,Red,Middleweight
+03/05/1999,Kevin Randleman,Maurice Smith,Red,Heavyweight
+03/05/1999,Evan Tanner,Valeri Ignatov,Red,Middleweight
+03/05/1999,Pete Williams,Jason Godsey,Red,Heavyweight
+03/05/1999,Sione Latu,Joey Roberts,Red,Heavyweight
+01/08/1999,Bas Rutten,Tsuyoshi Kohsaka,Red,Heavyweight
+01/08/1999,Pat Miletich,Jorge Patino,Red,UFC Welterweight Title
+01/08/1999,Pedro Rizzo,Mark Coleman,Red,Heavyweight
+01/08/1999,Tito Ortiz,Jerry Bohlander,Red,Middleweight
+01/08/1999,Mikey Burnett,Townsend Saunders,Red,Lightweight
+01/08/1999,Evan Tanner,Darrel Gholar,Red,Middleweight
+01/08/1999,Laverne Clark,Frank Caracci,Red,Lightweight
+10/16/1998,Frank Shamrock,John Lober,Red,UFC Light Heavyweight Title
+10/16/1998,Vitor Belfort,Wanderlei Silva,Red,Middleweight
+10/16/1998,Pedro Rizzo,David Abbott,Red,Heavyweight
+10/16/1998,Pat Miletich,Mikey Burnett,Red,UFC Welterweight Title
+10/16/1998,Tsuyoshi Kohsaka,Pete Williams,Red,Heavyweight
+10/16/1998,Ebenezer Fontes Braga,Jeremy Horn,Red,Middleweight
+10/16/1998,Tulio Palhares,Adriano Santos,Red,Middleweight
+10/16/1998,Cesar Marscucci,Paulo Santos,Red,Lightweight
+05/15/1998,Frank Shamrock,Jeremy Horn,Red,UFC Light Heavyweight Title
+05/15/1998,Pete Williams,Mark Coleman,Red,Heavyweight
+05/15/1998,Dan Henderson,Carlos Newton,Red,UFC 17 Middleweight Tournament Title
+05/15/1998,David Abbott,Hugo Duarte,Red,Heavyweight
+05/15/1998,Mike van Arsdale,Joe Pardo,Red,Heavyweight
+05/15/1998,Carlos Newton,Bob Gilstrap,Red,Middleweight
+05/15/1998,Dan Henderson,Allan Goes,Red,Middleweight
+05/15/1998,Andre Roberts,Harry Moskowitz,Red,Heavyweight
+05/15/1998,Chuck Liddell,Noe Hernandez,Red,Middleweight
+03/13/1998,Frank Shamrock,Igor Zinoviev,Red,UFC Light Heavyweight Title
+03/13/1998,Tsuyoshi Kohsaka,Kimo Leopoldo,Red,Heavyweight
+03/13/1998,Pat Miletich,Chris Brennan,Red,Lightweight
+03/13/1998,Jerry Bohlander,Kevin Jackson,Red,Middleweight
+03/13/1998,Pat Miletich,Townsend Saunders,Red,Lightweight
+03/13/1998,Mikey Burnett,Eugenio Tadeu,Red,Lightweight
+03/13/1998,Chris Brennan,Courtney Turner,Red,Lightweight
+03/13/1998,Laverne Clark,Josh Stuart,Red,Lightweight
+12/21/1997,Randy Couture,Maurice Smith,Red,UFC Heavyweight Title
+12/21/1997,Kazushi Sakuraba,Marcus Silveira,Red,Ultimate Japan Heavyweight Tournament Title
+12/21/1997,Vitor Belfort,Joe Charles,Red,Heavyweight
+12/21/1997,Frank Shamrock,Kevin Jackson,Red,UFC Light Heavyweight Title
+12/21/1997,David Abbott,Yoji Anjo,Red,Heavyweight
+12/21/1997,Tra Telligman,Brad Kohler,Red,Heavyweight
+10/17/1997,Maurice Smith,David Abbott,Red,UFC Heavyweight Title
+10/17/1997,Mark Kerr,Dwayne Cason,Red,UFC 15 Heavyweight Tournament Title
+10/17/1997,Randy Couture,Vitor Belfort,Red,Heavyweight
+10/17/1997,Dave Beneteau,Carlos Barreto,Red,Heavyweight
+10/17/1997,Mark Kerr,Greg Stott,Red,Heavyweight
+10/17/1997,Dwayne Cason,Houston Dorr,Red,Heavyweight
+10/17/1997,Alex Hunter,Harry Moskowitz,Red,Heavyweight
+07/27/1997,Maurice Smith,Mark Coleman,Red,UFC Heavyweight Title
+07/27/1997,Mark Kerr,Dan Bobish,Red,UFC 14 Heavyweight Tournament Title
+07/27/1997,Kevin Jackson,Tony Fryklund,Red,UFC 14 Middleweight Tournament Title
+07/27/1997,Dan Bobish,Brian Johnston,Red,Heavyweight
+07/27/1997,Mark Kerr,Moti Horenstein,Red,Heavyweight
+07/27/1997,Kevin Jackson,Todd Butler,Red,Lightweight
+07/27/1997,Joe Moreira,Yuri Vaulin,Red,Lightweight
+07/27/1997,Alex Hunter,Sam Fulton,Red,Heavyweight
+07/27/1997,Tony Fryklund,Donnie Chappell,Red,Lightweight
+05/30/1997,Vitor Belfort,David Abbott,Red,Heavyweight
+05/30/1997,Randy Couture,Steven Graham,Red,UFC 13 Heavyweight Tournament Title
+05/30/1997,Guy Mezger,Tito Ortiz,Red,UFC 13 Lightweight Tournament Title
+05/30/1997,Randy Couture,Tony Halme,Red,Heavyweight
+05/30/1997,Steven Graham,Dmitri Stepanov,Red,Heavyweight
+05/30/1997,Enson Inoue,Royce Alger,Red,Lightweight
+05/30/1997,Guy Mezger,Christophe Leninger,Red,Lightweight
+05/30/1997,Jack Nilson,Saeed Hosseini,Red,Lightweight
+05/30/1997,Tito Ortiz,Wes Albritton,Red,Lightweight
+02/07/1997,Mark Coleman,Dan Severn,Red,UFC Heavyweight Title
+02/07/1997,Vitor Belfort,Scott Ferrozzo,Red,Heavyweight
+02/07/1997,Jerry Bohlander,Nick Sanzo,Red,Lightweight
+02/07/1997,Vitor Belfort,Tra Telligman,Red,Heavyweight
+02/07/1997,Scott Ferrozzo,Jim Mullen,Red,Heavyweight
+02/07/1997,Yoshiki Takahashi,Wallid Ismail,Red,Lightweight
+02/07/1997,Jerry Bohlander,Rainy Martinez,Red,Lightweight
+02/07/1997,Justin Martin,Eric Martin,Red,Heavyweight
+02/07/1997,Nick Sanzo,Jackie Lee,Red,Lightweight
+12/07/1996,Don Frye,David Abbott,Red,Ultimate Ultimate '96 Tournament Title
+12/07/1996,David Abbott,Steve Nelmark,Red,Open Weight
+12/07/1996,Don Frye,Mark Hall,Red,Open Weight
+12/07/1996,Ken Shamrock,Brian Johnston,Red,Open Weight
+12/07/1996,Kimo Leopoldo,Paul Varelans,Red,Open Weight
+12/07/1996,David Abbott,Cal Worsham,Red,Open Weight
+12/07/1996,Don Frye,Gary Goodridge,Red,Open Weight
+12/07/1996,Tai Bowden,Jack Nilson,Red,Open Weight
+12/07/1996,Steve Nelmark,Marcus Bossett,Red,Open Weight
+12/07/1996,Mark Hall,Felix Lee Mitchell,Red,Open Weight
+09/20/1996,Scott Ferrozzo,David Abbott,Red,Open Weight
+09/20/1996,Mark Coleman,Brian Johnston,Red,Open Weight
+09/20/1996,Jerry Bohlander,Fabio Gurgel,Red,Open Weight
+09/20/1996,David Abbott,Sam Adkins,Red,Open Weight
+09/20/1996,Brian Johnston,Reza Nasri,Red,Open Weight
+09/20/1996,Mark Coleman,Julian Sanchez,Red,Open Weight
+09/20/1996,Roberto Traven,Dave Berry,Red,Open Weight
+09/20/1996,Scott Ferrozzo,Sam Fulton,Red,Open Weight
+07/12/1996,Mark Coleman,Don Frye,Red,UFC 10 Tournament Title
+07/12/1996,Mark Coleman,Gary Goodridge,Red,Open Weight
+07/12/1996,Don Frye,Brian Johnston,Red,Open Weight
+07/12/1996,Gary Goodridge,John Campetella,Red,Open Weight
+07/12/1996,Mark Coleman,Moti Horenstein,Red,Open Weight
+07/12/1996,Brian Johnston,Scott Fiedler,Red,Open Weight
+07/12/1996,Don Frye,Mark Hall,Red,Open Weight
+07/12/1996,Sam Adkins,Felix Lee Mitchell,Red,Open Weight
+07/12/1996,Geza Kalman,Dieusel Berto,Red,Open Weight
+05/17/1996,Dan Severn,Ken Shamrock,Red,UFC Superfight Championship
+05/17/1996,Don Frye,Amaury Bitetti,Red,Open Weight
+05/17/1996,Mark Hall,Koji Kitao,Red,Open Weight
+05/17/1996,Mark Schultz,Gary Goodridge,Red,Open Weight
+05/17/1996,Rafael Carino,Matt Andersen,Red,Open Weight
+05/17/1996,Cal Worsham,Zane Frazier,Red,Open Weight
+05/17/1996,Steve Nelmark,Tai Bowden,Red,Open Weight
+02/16/1996,Don Frye,Gary Goodridge,Red,UFC 8 Tournament Title
+02/16/1996,Ken Shamrock,Kimo Leopoldo,Red,UFC Superfight Championship
+02/16/1996,Gary Goodridge,Jerry Bohlander,Red,Open Weight
+02/16/1996,Don Frye,Sam Adkins,Red,Open Weight
+02/16/1996,Gary Goodridge,Paul Herrera,Red,Open Weight
+02/16/1996,Jerry Bohlander,Scott Ferrozzo,Red,Open Weight
+02/16/1996,Paul Varelans,Joe Moreira,Red,Open Weight
+02/16/1996,Don Frye,Thomas Ramirez,Red,Open Weight
+02/16/1996,Sam Adkins,Keith Mielke,Red,Open Weight
+12/16/1995,Dan Severn,Oleg Taktarov,Red,Ultimate Ultimate '95 Tournament Title
+12/16/1995,Oleg Taktarov,Marco Ruas,Red,Open Weight
+12/16/1995,Dan Severn,David Abbott,Red,Open Weight
+12/16/1995,Oleg Taktarov,Dave Beneteau,Red,Open Weight
+12/16/1995,Marco Ruas,Keith Hackney,Red,Open Weight
+12/16/1995,Dan Severn,Paul Varelans,Red,Open Weight
+12/16/1995,David Abbott,Steve Jennum,Red,Open Weight
+12/16/1995,Mark Hall,Trent Jenkins,Red,Open Weight
+12/16/1995,Joe Charles,Scott Bessac,Red,Open Weight
+09/08/1995,Marco Ruas,Paul Varelans,Red,UFC 7 Tournament Title
+09/08/1995,Marco Ruas,Remco Pardoel,Red,Open Weight
+09/08/1995,Paul Varelans,Mark Hall,Red,Open Weight
+09/08/1995,Marco Ruas,Larry Cureton,Red,Open Weight
+09/08/1995,Remco Pardoel,Ryan Parker,Red,Open Weight
+09/08/1995,Mark Hall,Harold Howard,Red,Open Weight
+09/08/1995,Paul Varelans,Gerry Harris,Red,Open Weight
+09/08/1995,Scott Bessac,David Hood,Red,Open Weight
+09/08/1995,Onassis Parungao,Francesco Maturi,Red,Open Weight
+09/08/1995,Joel Sutton,Geza Kalman,Red,Open Weight
+07/14/1995,Oleg Taktarov,David Abbott,Red,UFC 6 Tournament Title
+07/14/1995,Ken Shamrock,Dan Severn,Red,UFC Superfight Championship
+07/14/1995,Oleg Taktarov,Anthony Macias,Red,Open Weight
+07/14/1995,David Abbott,Paul Varelans,Red,Open Weight
+07/14/1995,Oleg Taktarov,Dave Beneteau,Red,Open Weight
+07/14/1995,Patrick Smith,Rudyard Moncayo,Red,Open Weight
+07/14/1995,Paul Varelans,Cal Worsham,Red,Open Weight
+07/14/1995,David Abbott,John Matua,Red,Open Weight
+07/14/1995,Anthony Macias,He-Man Gipson,Red,Open Weight
+07/14/1995,Joel Sutton,Jack McGlaughlin,Red,Open Weight
+04/07/1995,Dan Severn,Dave Beneteau,Red,UFC 5 Tournament Title
+04/07/1995,Dan Severn,Oleg Taktarov,Red,Open Weight
+04/07/1995,Dave Beneteau,Todd Medina,Red,Open Weight
+04/07/1995,Dan Severn,Joe Charles,Red,Open Weight
+04/07/1995,Oleg Taktarov,Ernie Verdicia,Red,Open Weight
+04/07/1995,Todd Medina,Larry Cureton,Red,Open Weight
+04/07/1995,Jon Hess,Andy Anderson,Red,Open Weight
+04/07/1995,Guy Mezger,John Dowdy,Red,Open Weight
+04/07/1995,Dave Beneteau,Asbel Cancio,Red,Open Weight
+12/16/1994,Royce Gracie,Dan Severn,Red,UFC 4 Tournament Title
+12/16/1994,Dan Severn,Marcus Bossett,Red,Open Weight
+12/16/1994,Royce Gracie,Keith Hackney,Red,Open Weight
+12/16/1994,Dan Severn,Anthony Macias,Red,Open Weight
+12/16/1994,Steve Jennum,Melton Bowen,Red,Open Weight
+12/16/1994,Keith Hackney,Joe Son,Red,Open Weight
+12/16/1994,Royce Gracie,Ron van Clief,Red,Open Weight
+12/16/1994,Guy Mezger,Jason Fairn,Red,Open Weight
+12/16/1994,Marcus Bossett,Eldo Xavier Dias,Red,Open Weight
+12/16/1994,Joe Charles,Kevin Rosier,Red,Open Weight
+09/09/1994,Steve Jennum,Harold Howard,Red,UFC 3 Tournament Title
+09/09/1994,Ken Shamrock,Felix Lee Mitchell,Red,Open Weight
+09/09/1994,Royce Gracie,Kimo Leopoldo,Red,Open Weight
+09/09/1994,Harold Howard,Roland Payne,Red,Open Weight
+09/09/1994,Ken Shamrock,Christophe Leninger,Red,Open Weight
+09/09/1994,Keith Hackney,Emmanuel Yarborough,Red,Open Weight
+03/11/1994,Royce Gracie,Patrick Smith,Red,UFC 2 Tournament Title
+03/11/1994,Royce Gracie,Remco Pardoel,Red,Open Weight
+03/11/1994,Patrick Smith,Johnny Rhodes,Red,Open Weight
+03/11/1994,Royce Gracie,Jason DeLucia,Red,Open Weight
+03/11/1994,Remco Pardoel,Orlando Wiet,Red,Open Weight
+03/11/1994,Johnny Rhodes,Fred Ettish,Red,Open Weight
+03/11/1994,Patrick Smith,Scott Morris,Red,Open Weight
+03/11/1994,Royce Gracie,Minoki Ichihara,Red,Open Weight
+03/11/1994,Jason DeLucia,Scott Baker,Red,Open Weight
+03/11/1994,Remco Pardoel,Alberta Cerra Leon,Red,Open Weight
+03/11/1994,Orlando Wiet,Robert Lucarelli,Red,Open Weight
+03/11/1994,Frank Hamaker,Thaddeus Luster,Red,Open Weight
+03/11/1994,Johnny Rhodes,David Levicki,Red,Open Weight
+03/11/1994,Patrick Smith,Ray Wizard,Red,Open Weight
+03/11/1994,Scott Morris,Sean Daugherty,Red,Open Weight

--- a/dataset/preprocessed/event_list_ordered.csv
+++ b/dataset/preprocessed/event_list_ordered.csv
@@ -1,0 +1,7440 @@
+date,r_fighter,b_fighter,winner,weight_class
+03/23/2024,Rose Namajunas,Amanda Ribas,Red,Women's Flyweight
+03/23/2024,Karl Williams,Justin Tafa,Red,Heavyweight
+03/23/2024,Edmen Shahbazyan,AJ Dobson,Red,Middleweight
+03/23/2024,Payton Talbott,Cameron Saaiman,Red,Bantamweight
+03/23/2024,Youssef Zalal,Billy Quarantillo,Red,Featherweight
+03/23/2024,Fernando Padilla,Luis Pajuelo,Red,Featherweight
+03/23/2024,Trey Ogden,Kurt Holobaugh,Red,Lightweight
+03/23/2024,Julian Erosa,Ricardo Ramos,Red,Featherweight
+03/23/2024,Miles Johns,Cody Gibson,Red,Bantamweight
+03/23/2024,Jarno Errens,Steven Nguyen,Red,Featherweight
+03/23/2024,Daria Zhelezniakova,Montserrat Rendon,Red,Women's Bantamweight
+03/23/2024,Andre Lima,Igor Severino,Red,Flyweight
+03/23/2024,Mick Parkin,Mohammed Usman,Red,Heavyweight
+03/16/2024,Marcin Tybura,Tai Tuivasa,Red,Heavyweight
+03/16/2024,Ovince Saint Preux,Kennedy Nzechukwu,Red,Light Heavyweight
+03/16/2024,Christian Rodriguez,Isaac Dulgarian,Red,Featherweight
+03/16/2024,Macy Chiasson,Pannie Kianzad,Red,Women's Bantamweight
+03/16/2024,Gerald Meerschaert,Bryan Barberena,Red,Middleweight
+03/16/2024,Mike Davis,Natan Levy,Red,Lightweight
+03/16/2024,Chelsea Chandler,Josiane Nunes,Red,Women's Bantamweight
+03/16/2024,Jafel Filho,Ode Osbourne,Red,Flyweight
+03/16/2024,Danny Silva,Josh Culibao,Red,Featherweight
+03/16/2024,Jaqueline Amorim,Cory McKenna,Red,Women's Strawweight
+03/16/2024,Thiago Moises,Mitch Ramirez,Red,Lightweight
+03/16/2024,Chad Anheliger,Charalampos Grigoriou,Red,Bantamweight
+03/09/2024,Sean O'Malley,Marlon Vera,Red,UFC Bantamweight Title
+03/09/2024,Dustin Poirier,Benoit Saint Denis,Red,Lightweight
+03/09/2024,Michael Page,Kevin Holland,Red,Welterweight
+03/09/2024,Jack Della Maddalena,Gilbert Burns,Red,Welterweight
+03/09/2024,Petr Yan,Song Yadong,Red,Bantamweight
+03/09/2024,Curtis Blaydes,Jailton Almeida,Red,Heavyweight
+03/09/2024,Maycee Barber,Katlyn Cerminara,Red,Women's Flyweight
+03/09/2024,Mateusz Gamrot,Rafael Dos Anjos,Red,Lightweight
+03/09/2024,Kyler Phillips,Pedro Munhoz,Red,Bantamweight
+03/09/2024,Philipe Lins,Ion Cutelaba,Red,Light Heavyweight
+03/09/2024,Michel Pereira,Michal Oleksiejczuk,Red,Middleweight
+03/09/2024,Robelis Despaigne,Josh Parisian,Red,Heavyweight
+03/09/2024,Asu Almabayev,CJ Vergara,Red,Flyweight
+03/09/2024,Joanne Wood,Maryna Moroz,Red,Women's Flyweight
+03/02/2024,Jairzinho Rozenstruik,Shamil Gaziev,Red,Heavyweight
+03/02/2024,Vitor Petrino,Tyson Pedro,Red,Light Heavyweight
+03/02/2024,Muhammad Mokaev,Alex Perez,Red,Flyweight
+03/02/2024,Umar Nurmagomedov,Bekzat Almakhan,Red,Bantamweight
+03/02/2024,Steve Erceg,Matt Schnell,Red,Flyweight
+03/02/2024,Eryk Anders,Jamie Pickett,Red,Middleweight
+03/02/2024,Vinicius Oliveira,Benardo Sopaj,Red,Bantamweight
+03/02/2024,Aiemann Zahabi,Javid Basharat,Red,Bantamweight
+03/02/2024,Christian Leroy Duncan,Claudio Ribeiro,Red,Middleweight
+03/02/2024,Ludovit Klein,AJ Cunningham,Red,Lightweight
+03/02/2024,Loik Radzhabov,Abdul-Kareem Al-Selwady,Red,Lightweight
+02/24/2024,Brandon Royval,Brandon Moreno,Red,Flyweight
+02/24/2024,Brian Ortega,Yair Rodriguez,Red,Featherweight
+02/24/2024,Daniel Zellhuber,Francisco Prado,Red,Lightweight
+02/24/2024,Yazmin Jauregui,Sam Hughes,Red,Women's Strawweight
+02/24/2024,Manuel Torres,Chris Duncan,Red,Lightweight
+02/24/2024,Raoni Barcelos,Cristian Quinonez,Red,Bantamweight
+02/24/2024,Jesus Aguilar,Mateus Mendonca,Red,Flyweight
+02/24/2024,Edgar Chairez,Daniel Lacerda,Red,Flyweight
+02/24/2024,Fares Ziam,Claudio Puelles,Red,Lightweight
+02/24/2024,Ronaldo Rodriguez,Denys Bondar,Red,Flyweight
+02/24/2024,Felipe dos Santos,Victor Altamirano,Red,Flyweight
+02/24/2024,Muhammad Naimov,Erik Silva,Red,Featherweight
+02/17/2024,Ilia Topuria,Alexander Volkanovski,Red,UFC Featherweight Title
+02/17/2024,Robert Whittaker,Paulo Costa,Red,Middleweight
+02/17/2024,Ian Machado Garry,Geoff Neal,Red,Welterweight
+02/17/2024,Merab Dvalishvili,Henry Cejudo,Red,Bantamweight
+02/17/2024,Anthony Hernandez,Roman Kopylov,Red,Middleweight
+02/17/2024,Amanda Lemos,Mackenzie Dern,Red,Women's Strawweight
+02/17/2024,Marcos Rogerio de Lima,Junior Tafa,Red,Heavyweight
+02/17/2024,Rinya Nakamura,Carlos Vera,Red,Bantamweight
+02/17/2024,Zhang Mingyang,Brendson Ribeiro,Red,Light Heavyweight
+02/17/2024,Danny Barlow,Josh Quinlan,Red,Welterweight
+02/17/2024,Oban Elliott,Val Woodburn,Red,Welterweight
+02/17/2024,Miranda Maverick,Andrea Lee,Red,Women's Flyweight
+02/10/2024,Jack Hermansson,Joe Pyfer,Red,Middleweight
+02/10/2024,Dan Ige,Andre Fili,Red,Featherweight
+02/10/2024,Ihor Potieria,Robert Bryczek,Red,Middleweight
+02/10/2024,Gregory Rodrigues,Brad Tavares,Red,Middleweight
+02/10/2024,Michael Johnson,Darrius Flowers,Red,Lightweight
+02/10/2024,Rodolfo Vieira,Armen Petrosyan,Red,Middleweight
+02/10/2024,Carlos Prates,Trevin Giles,Red,Welterweight
+02/10/2024,Bolaji Oki,Timmy Cuamba,Red,Lightweight
+02/10/2024,Loma Lookboonmee,Bruna Brasil,Red,Women's Strawweight
+02/10/2024,Marcin Prachnio,Devin Clark,Red,Light Heavyweight
+02/10/2024,Max Griffin,Jeremiah Wells,Red,Welterweight
+02/10/2024,Bogdan Guskov,Zac Pauga,Red,Light Heavyweight
+02/10/2024,Hyder Amil,Fernie Garcia,Red,Featherweight
+02/03/2024,Nassourdine Imavov,Roman Dolidze,Red,Middleweight
+02/03/2024,Renato Moicano,Drew Dober,Red,Lightweight
+02/03/2024,Randy Brown,Muslim Salikhov,Red,Welterweight
+02/03/2024,Natalia Silva,Viviane Araujo,Red,Women's Flyweight
+02/03/2024,Charles Radtke,Gilbert Urbina,Red,Welterweight
+02/03/2024,Molly McCann,Diana Belbita,Red,Women's Strawweight
+02/03/2024,Charles Johnson,Azat Maksum,Red,Flyweight
+02/03/2024,Themba Gorimbo,Pete Rodriguez,Red,Welterweight
+02/03/2024,JeongYeong Lee,Blake Bilder,Red,Featherweight
+02/03/2024,Luana Carolina,Julija Stoliarenko,Red,Women's Flyweight
+02/03/2024,MarQuel Mederos,Landon Quinones,Red,Lightweight
+02/03/2024,Jamal Pogues,Thomas Petersen,Red,Heavyweight
+01/20/2024,Dricus Du Plessis,Sean Strickland,Red,UFC Middleweight Title
+01/20/2024,Raquel Pennington,Mayra Bueno Silva,Red,UFC Women's Bantamweight Title
+01/20/2024,Neil Magny,Mike Malott,Red,Welterweight
+01/20/2024,Chris Curtis,Marc-Andre Barriault,Red,Middleweight
+01/20/2024,Movsar Evloev,Arnold Allen,Red,Featherweight
+01/20/2024,Garrett Armfield,Brad Katona,Red,Bantamweight
+01/20/2024,Sean Woodson,Charles Jourdain,Red,Featherweight
+01/20/2024,Ramon Taveras,Serhiy Sidey,Red,Bantamweight
+01/20/2024,Gillian Robertson,Polyana Viana,Red,Women's Strawweight
+01/20/2024,Sam Patterson,Yohan Lainesse,Red,Welterweight
+01/20/2024,Jasmine Jasudavicius,Priscila Cachoeira,Red,Women's Bantamweight
+01/20/2024,Jimmy Flick,Malcolm Gordon,Red,Flyweight
+01/13/2024,Magomed Ankalaev,Johnny Walker,Red,Light Heavyweight
+01/13/2024,Jim Miller,Gabriel Benitez,Red,Lightweight
+01/13/2024,Mario Bautista,Ricky Simon,Red,Bantamweight
+01/13/2024,Brunno Ferreira,Phil Hawes,Red,Middleweight
+01/13/2024,Waldo Cortes-Acosta,Andrei Arlovski,Red,Heavyweight
+01/13/2024,Preston Parsons,Matthew Semelsberger,Red,Welterweight
+01/13/2024,Marcus McGhee,Gaston Bolanos,Red,Bantamweight
+01/13/2024,Farid Basharat,Taylor Lapilus,Red,Bantamweight
+01/13/2024,Jean Silva,Westin Wilson,Red,Featherweight
+01/13/2024,Nikolas Motta,Tom Nolan,Red,Lightweight
+01/13/2024,Joshua Van,Felipe Bunes,Red,Flyweight
+12/16/2023,Leon Edwards,Colby Covington,Red,UFC Welterweight Title
+12/16/2023,Alexandre Pantoja,Brandon Royval,Red,UFC Flyweight Title
+12/16/2023,Shavkat Rakhmonov,Stephen Thompson,Red,Welterweight
+12/16/2023,Paddy Pimblett,Tony Ferguson,Red,Lightweight
+12/16/2023,Josh Emmett,Bryce Mitchell,Red,Featherweight
+12/16/2023,Alonzo Menifield,Dustin Jacoby,Red,Light Heavyweight
+12/16/2023,Irene Aldana,Karol Rosa,Red,Women's Bantamweight
+12/16/2023,Cody Garbrandt,Brian Kelleher,Red,Bantamweight
+12/16/2023,Ariane Lipski,Casey O'Neill,Red,Women's Flyweight
+12/16/2023,Tagir Ulanbekov,Cody Durden,Red,Flyweight
+12/16/2023,Andre Fili,Lucas Almeida,Red,Featherweight
+12/16/2023,Shamil Gaziev,Martin Buday,Red,Heavyweight
+12/09/2023,Song Yadong,Chris Gutierrez,Red,Bantamweight
+12/09/2023,Khalil Rountree Jr.,Anthony Smith,Red,Light Heavyweight
+12/09/2023,Nasrat Haqparast,Jamie Mullarkey,Red,Lightweight
+12/09/2023,Tim Elliott,Sumudaerji,Red,Bantamweight
+12/09/2023,Andre Muniz,JunYong Park,Red,Middleweight
+12/09/2023,Kevin Jousset,Song Kenan,Red,Welterweight
+12/09/2023,HyunSung Park,Shannon Ross,Red,Flyweight
+12/09/2023,Steve Garcia,Melquizael Costa,Red,Lightweight
+12/09/2023,Luana Santos,Stephanie Egger,Red,Women's Bantamweight
+12/09/2023,Tatsuro Taira,Carlos Hernandez,Red,Flyweight
+12/09/2023,Talita Alencar,Rayanne Amanda,Red,Women's Strawweight
+12/02/2023,Arman Tsarukyan,Beneil Dariush,Red,Lightweight
+12/02/2023,Jalin Turner,Bobby Green,Red,Lightweight
+12/02/2023,Deiveson Figueiredo,Rob Font,Red,Bantamweight
+12/02/2023,Sean Brady,Kelvin Gastelum,Red,Welterweight
+12/02/2023,Joaquim Silva,Clay Guida,Red,Lightweight
+12/02/2023,Dustin Stoltzfus,Punahele Soriano,Red,Middleweight
+12/02/2023,Miesha Tate,Julia Avila,Red,Women's Bantamweight
+12/02/2023,Cody Brundage,Zach Reese,Red,Middleweight
+12/02/2023,Drakkar Klose,Joe Solecki,Red,Lightweight
+12/02/2023,Rodolfo Bellato,Ihor Potieria,Red,Light Heavyweight
+12/02/2023,Jared Gooden,Wellington Turman,Red,Welterweight
+12/02/2023,Veronica Hardy,Jamey-Lyn Horth,Red,Women's Flyweight
+11/18/2023,Brendan Allen,Paul Craig,Red,Middleweight
+11/18/2023,Michael Morales,Jake Matthews,Red,Welterweight
+11/18/2023,Chase Hooper,Jordan Leavitt,Red,Lightweight
+11/18/2023,Payton Talbott,Nick Aguirre,Red,Bantamweight
+11/18/2023,Amanda Ribas,Luana Pinheiro,Red,Women's Strawweight
+11/18/2023,Myktybek Orolbai,Uros Medic,Red,Welterweight
+11/18/2023,Joanderson Brito,Jonathan Pearce,Red,Featherweight
+11/18/2023,Jose Johnson,Chad Anheliger,Red,Bantamweight
+11/18/2023,Christian Leroy Duncan,Denis Tiuliulin,Red,Middleweight
+11/18/2023,Mick Parkin,Caio Machado,Red,Heavyweight
+11/18/2023,Jeka Saragih,Lucas Alexander,Red,Featherweight
+11/18/2023,Ailin Perez,Lucie Pudilova,Red,Women's Bantamweight
+11/18/2023,Rafael Estevam,Charles Johnson,Red,Flyweight
+11/11/2023,Alex Pereira,Jiri Prochazka,Red,UFC Light Heavyweight Title
+11/11/2023,Tom Aspinall,Sergei Pavlovich,Red,UFC Interim Heavyweight Title
+11/11/2023,Jessica Andrade,Mackenzie Dern,Red,Women's Strawweight
+11/11/2023,Benoit Saint Denis,Matt Frevola,Red,Lightweight
+11/11/2023,Diego Lopes,Pat Sabatini,Red,Featherweight
+11/11/2023,Steve Erceg,Alessandro Costa,Red,Flyweight
+11/11/2023,Loopy Godinez,Tabatha Ricci,Red,Women's Strawweight
+11/11/2023,Mateusz Rebecki,Roosevelt Roberts,Red,Lightweight
+11/11/2023,Jared Gordon,Mark Madsen,Red,Lightweight
+11/11/2023,John Castaneda,Kyung Ho Kang,Red,Catch Weight
+11/11/2023,Joshua Van,Kevin Borjas,Red,Flyweight
+11/11/2023,Jamall Emmers,Dennis Buzukja,Red,Featherweight
+11/04/2023,Jailton Almeida,Derrick Lewis,Red,Heavyweight
+11/04/2023,Nicolas Dalby,Gabriel Bonfim,Red,Welterweight
+11/04/2023,Rodrigo Nascimento,Don'Tale Mayes,Red,Heavyweight
+11/04/2023,Caio Borralho,Abus Magomedov,Red,Middleweight
+11/04/2023,Elves Brener,Kaynan Kruschewsky,Red,Catch Weight
+11/04/2023,Vitor Petrino,Modestas Bukauskas,Red,Light Heavyweight
+11/04/2023,Angela Hill,Denise Gomes,Red,Women's Strawweight
+11/04/2023,Eduarda Moura,Montserrat Conejo Ruiz,Red,Women's Strawweight
+11/04/2023,Marc Diakiese,Kaue Fernandes,Red,Lightweight
+10/21/2023,Islam Makhachev,Alexander Volkanovski,Red,UFC Lightweight Title
+10/21/2023,Khamzat Chimaev,Kamaru Usman,Red,Middleweight
+10/21/2023,Ikram Aliskerov,Warlley Alves,Red,Middleweight
+10/21/2023,Said Nurmagomedov,Muin Gafurov,Red,Bantamweight
+10/21/2023,Muhammad Mokaev,Tim Elliott,Red,Flyweight
+10/21/2023,Trevor Peek,Mohammad Yahya,Red,Lightweight
+10/21/2023,Sedriques Dumas,Abu Azaitar,Red,Middleweight
+10/21/2023,Mike Breeden,Anshul Jubli,Red,Lightweight
+10/21/2023,Muhammad Naimov,Nathaniel Wood,Red,Featherweight
+10/21/2023,Viktoriia Dudakova,Jinh Yu Frey,Red,Women's Strawweight
+10/21/2023,Shara Magomedov,Bruno Silva,Red,Middleweight
+10/14/2023,Edson Barboza,Sodiq Yusuff,Red,Featherweight
+10/14/2023,Viviane Araujo,Jennifer Maia,Red,Women's Flyweight
+10/14/2023,Jonathan Martinez,Adrian Yanez,Red,Bantamweight
+10/14/2023,Michel Pereira,Andre Petroski,Red,Middleweight
+10/14/2023,Christian Rodriguez,Cameron Saaiman,Red,Bantamweight
+10/14/2023,Darren Elkins,TJ Brown,Red,Featherweight
+10/14/2023,Tainara Lisboa,Ravena Oliveira,Red,Women's Bantamweight
+10/14/2023,Terrance McKinney,Brendon Marotte,Red,Lightweight
+10/14/2023,Melissa Dixon,Irina Alekseeva,Red,Women's Bantamweight
+10/14/2023,Chris Gutierrez,Alatengheili,Red,Bantamweight
+10/14/2023,Emily Ducote,Ashley Yoder,Red,Women's Strawweight
+10/07/2023,Bobby Green,Grant Dawson,Red,Lightweight
+10/07/2023,Joe Pyfer,Abdul Razak Alhassan,Red,Middleweight
+10/07/2023,Joaquin Buckley,Alex Morono,Red,Welterweight
+10/07/2023,Drew Dober,Ricky Glenn,Red,Lightweight
+10/07/2023,Bill Algeo,Alexander Hernandez,Red,Featherweight
+10/07/2023,Karolina Kowalkiewicz,Diana Belbita,Red,Women's Strawweight
+10/07/2023,Nate Maness,Mateus Mendonca,Red,Flyweight
+10/07/2023,Vanessa Demopoulos,Kanako Murata,Red,Women's Strawweight
+10/07/2023,Aoriqileng,Johnny Munoz,Red,Bantamweight
+10/07/2023,JJ Aldrich,Montana De La Rosa,Red,Women's Flyweight
+09/23/2023,Mateusz Gamrot,Rafael Fiziev,Red,Lightweight
+09/23/2023,Bryce Mitchell,Dan Ige,Red,Featherweight
+09/23/2023,Marina Rodriguez,Michelle Waterson-Gomez,Red,Women's Strawweight
+09/23/2023,Bryan Battle,AJ Fletcher,Red,Welterweight
+09/23/2023,Charles Jourdain,Ricardo Ramos,Red,Featherweight
+09/23/2023,Tim Means,Andre Fialho,Red,Welterweight
+09/23/2023,Cody Brundage,Jacob Malkoun,Red,Middleweight
+09/23/2023,Mohammed Usman,Jake Collier,Red,Heavyweight
+09/23/2023,Mizuki,Hannah Goldy,Red,Women's Strawweight
+09/23/2023,Montserrat Rendon,Tamires Vidal,Red,Women's Bantamweight
+09/16/2023,Jack Della Maddalena,Kevin Holland,Red,Welterweight
+09/16/2023,Raul Rosas Jr.,Terrence Mitchell,Red,Bantamweight
+09/16/2023,Daniel Zellhuber,Christos Giagos,Red,Lightweight
+09/16/2023,Kyle Nelson,Fernando Padilla,Red,Featherweight
+09/16/2023,Loopy Godinez,Elise Reed,Red,Women's Strawweight
+09/16/2023,Roman Kopylov,Josh Fremd,Red,Middleweight
+09/16/2023,Tracy Cortez,Jasmine Jasudavicius,Red,Women's Flyweight
+09/16/2023,Charlie Campbell,Alex Reyes,Red,Lightweight
+09/16/2023,Josefine Knutsson,Marnic Mann,Red,Women's Strawweight
+09/09/2023,Sean Strickland,Israel Adesanya,Red,UFC Middleweight Title
+09/09/2023,Alexander Volkov,Tai Tuivasa,Red,Heavyweight
+09/09/2023,Manel Kape,Felipe dos Santos,Red,Flyweight
+09/09/2023,Justin Tafa,Austen Lane,Red,Heavyweight
+09/09/2023,Tyson Pedro,Anton Turkalj,Red,Light Heavyweight
+09/09/2023,Carlos Ulberg,Da Woon Jung,Red,Light Heavyweight
+09/09/2023,Chepe Mariscal,Jack Jenkins,Red,Featherweight
+09/09/2023,Jamie Mullarkey,John Makdessi,Red,Lightweight
+09/09/2023,Nasrat Haqparast,Landon Quinones,Red,Lightweight
+09/09/2023,Charles Radtke,Blood Diamond,Red,Welterweight
+09/09/2023,Gabriel Miranda,Shane Young,Red,Featherweight
+09/09/2023,Kevin Jousset,Kiefer Crosbie,Red,Welterweight
+09/02/2023,Ciryl Gane,Serghei Spivac,Red,Heavyweight
+09/02/2023,Manon Fiorot,Rose Namajunas,Red,Women's Flyweight
+09/02/2023,Benoit Saint Denis,Thiago Moises,Red,Lightweight
+09/02/2023,Volkan Oezdemir,Bogdan Guskov,Red,Light Heavyweight
+09/02/2023,William Gomis,Yanis Ghemmouri,Red,Featherweight
+09/02/2023,Morgan Charriere,Manolo Zecchini,Red,Featherweight
+09/02/2023,Taylor Lapilus,Caolan Loughran,Red,Bantamweight
+09/02/2023,Ange Loosa,Rhys McKee,Red,Welterweight
+09/02/2023,Nora Cornolle,Joselyne Edwards,Red,Women's Bantamweight
+09/02/2023,Farid Basharat,Kleydson Rodrigues,Red,Bantamweight
+09/02/2023,Jacqueline Cavalcanti,Zarah Fairn,Red,Catch Weight
+08/26/2023,Max Holloway,Chan Sung Jung,Red,Featherweight
+08/26/2023,Anthony Smith,Ryan Spann,Red,Light Heavyweight
+08/26/2023,Giga Chikadze,Alex Caceres,Red,Featherweight
+08/26/2023,Rinya Nakamura,Fernie Garcia,Red,Bantamweight
+08/26/2023,Erin Blanchfield,Taila Santos,Red,Women's Flyweight
+08/26/2023,Junior Tafa,Parker Porter,Red,Heavyweight
+08/26/2023,Waldo Cortes-Acosta,Lukasz Brzeski,Red,Heavyweight
+08/26/2023,Garrett Armfield,Toshiomi Kazama,Red,Bantamweight
+08/26/2023,Michal Oleksiejczuk,Chidi Njokuani,Red,Middleweight
+08/26/2023,Song Kenan,Rolando Bedoya,Red,Welterweight
+08/26/2023,Billy Goff,Yusaku Kinoshita,Red,Welterweight
+08/26/2023,JJ Aldrich,Liang Na,Red,Women's Flyweight
+08/26/2023,SeungWoo Choi,Jarno Errens,Red,Featherweight
+08/19/2023,Sean O'Malley,Aljamain Sterling,Red,UFC Bantamweight Title
+08/19/2023,Zhang Weili,Amanda Lemos,Red,UFC Women's Strawweight Title
+08/19/2023,Ian Machado Garry,Neil Magny,Red,Welterweight
+08/19/2023,Mario Bautista,Da'Mon Blackshear,Red,Bantamweight
+08/19/2023,Marlon Vera,Pedro Munhoz,Red,Bantamweight
+08/19/2023,Brad Tavares,Chris Weidman,Red,Middleweight
+08/19/2023,Gregory Rodrigues,Denis Tiuliulin,Red,Middleweight
+08/19/2023,Kurt Holobaugh,Austin Hubbard,Red,Lightweight
+08/19/2023,Brad Katona,Cody Gibson,Red,Bantamweight
+08/19/2023,Andre Petroski,Gerald Meerschaert,Red,Middleweight
+08/19/2023,Natalia Silva,Andrea Lee,Red,Women's Flyweight
+08/19/2023,Karine Silva,Maryna Moroz,Red,Women's Flyweight
+08/12/2023,Vicente Luque,Rafael Dos Anjos,Red,Welterweight
+08/12/2023,Cub Swanson,Hakeem Dawodu,Red,Featherweight
+08/12/2023,Khalil Rountree Jr.,Chris Daukaus,Red,Light Heavyweight
+08/12/2023,Iasmin Lucindo,Polyana Viana,Red,Women's Strawweight
+08/12/2023,AJ Dobson,Tafon Nchukwi,Red,Middleweight
+08/12/2023,Josh Fremd,Jamie Pickett,Red,Middleweight
+08/12/2023,Marcus McGhee,JP Buys,Red,Bantamweight
+08/12/2023,Terrance McKinney,Mike Breeden,Red,Lightweight
+08/12/2023,Isaac Dulgarian,Francis Marshall,Red,Featherweight
+08/12/2023,Martin Buday,Josh Parisian,Red,Heavyweight
+08/12/2023,Jaqueline Amorim,Montserrat Conejo Ruiz,Red,Women's Strawweight
+08/12/2023,Da'Mon Blackshear,Jose Johnson,Red,Bantamweight
+08/12/2023,Luana Santos,Juliana Miller,Red,Women's Flyweight
+08/05/2023,Cory Sandhagen,Rob Font,Red,Catch Weight
+08/05/2023,Tatiana Suarez,Jessica Andrade,Red,Women's Strawweight
+08/05/2023,Dustin Jacoby,Kennedy Nzechukwu,Red,Light Heavyweight
+08/05/2023,Diego Lopes,Gavin Tucker,Red,Featherweight
+08/05/2023,Tanner Boser,Aleksa Camur,Red,Light Heavyweight
+08/05/2023,Ludovit Klein,Ignacio Bahamondes,Red,Lightweight
+08/05/2023,Kyler Phillips,Raoni Barcelos,Red,Bantamweight
+08/05/2023,Carlston Harris,Jeremiah Wells,Red,Welterweight
+08/05/2023,Billy Quarantillo,Damon Jackson,Red,Featherweight
+08/05/2023,Cody Durden,Jake Hadley,Red,Flyweight
+08/05/2023,Sean Woodson,Dennis Buzukja,Red,Featherweight
+08/05/2023,Asu Almabayev,Ode Osbourne,Red,Flyweight
+07/29/2023,Justin Gaethje,Dustin Poirier,Red,Lightweight
+07/29/2023,Alex Pereira,Jan Blachowicz,Red,Light Heavyweight
+07/29/2023,Derrick Lewis,Marcos Rogerio de Lima,Red,Heavyweight
+07/29/2023,Bobby Green,Tony Ferguson,Red,Lightweight
+07/29/2023,Kevin Holland,Michael Chiesa,Red,Welterweight
+07/29/2023,Gabriel Bonfim,Trevin Giles,Red,Welterweight
+07/29/2023,CJ Vergara,Vinicius Salvador,Red,Flyweight
+07/29/2023,Roman Kopylov,Claudio Ribeiro,Red,Middleweight
+07/29/2023,Jake Matthews,Darrius Flowers,Red,Welterweight
+07/29/2023,Uros Medic,Matthew Semelsberger,Red,Welterweight
+07/29/2023,Miranda Maverick,Priscila Cachoeira,Red,Women's Flyweight
+07/22/2023,Tom Aspinall,Marcin Tybura,Red,Heavyweight
+07/22/2023,Julija Stoliarenko,Molly McCann,Red,Women's Flyweight
+07/22/2023,Nathaniel Wood,Andre Fili,Red,Featherweight
+07/22/2023,Paul Craig,Andre Muniz,Red,Middleweight
+07/22/2023,Fares Ziam,Jai Herbert,Red,Lightweight
+07/22/2023,Lerone Murphy,Josh Culibao,Red,Featherweight
+07/22/2023,Daniel Marcos,Davey Grant,Red,Bantamweight
+07/22/2023,Jonny Parsons,Danny Roberts,Red,Welterweight
+07/22/2023,Joel Alvarez,Marc Diakiese,Red,Lightweight
+07/22/2023,Mick Parkin,Jamal Pogues,Red,Heavyweight
+07/22/2023,Makhmud Muradov,Bryan Barberena,Red,Middleweight
+07/22/2023,Ketlen Vieira,Pannie Kianzad,Red,Women's Bantamweight
+07/22/2023,Chris Duncan,Yanal Ashmouz,Red,Lightweight
+07/22/2023,Bruna Brasil,Shauna Bannon,Red,Women's Strawweight
+07/22/2023,Jafel Filho,Daniel Barez,Red,Flyweight
+07/15/2023,Jack Della Maddalena,Bassil Hafez,Red,Welterweight
+07/15/2023,Francisco Prado,Ottman Azaitar,Red,Lightweight
+07/15/2023,JunYong Park,Albert Duraev,Red,Middleweight
+07/15/2023,Norma Dumont,Chelsea Chandler,Red,Women's Featherweight
+07/15/2023,Nazim Sadykhov,Terrance McKinney,Red,Lightweight
+07/15/2023,Melsik Baghdasaryan,Tucker Lutz,Red,Featherweight
+07/15/2023,Viktoriia Dudakova,Istela Nunes,Red,Women's Strawweight
+07/15/2023,Melquizael Costa,Austin Lingo,Red,Featherweight
+07/15/2023,Evan Elder,Genaro Valdez,Red,Lightweight
+07/15/2023,Azat Maksum,Tyson Nam,Red,Flyweight
+07/15/2023,Alexander Munoz,Carl Deaton,Red,Lightweight
+07/15/2023,Ailin Perez,Ashlee Evans-Smith,Red,Women's Bantamweight
+07/08/2023,Alexander Volkanovski,Yair Rodriguez,Red,UFC Featherweight Title
+07/08/2023,Alexandre Pantoja,Brandon Moreno,Red,UFC Flyweight Title
+07/08/2023,Dricus Du Plessis,Robert Whittaker,Red,Middleweight
+07/08/2023,Dan Hooker,Jalin Turner,Red,Lightweight
+07/08/2023,Bo Nickal,Val Woodburn,Red,Middleweight
+07/08/2023,Robbie Lawler,Niko Price,Red,Welterweight
+07/08/2023,Tatsuro Taira,Edgar Chairez,Red,Catch Weight
+07/08/2023,Denise Gomes,Yazmin Jauregui,Red,Women's Strawweight
+07/08/2023,Alonzo Menifield,Jimmy Crute,Red,Light Heavyweight
+07/08/2023,Vitor Petrino,Marcin Prachnio,Red,Light Heavyweight
+07/08/2023,Cameron Saaiman,Terrence Mitchell,Red,Bantamweight
+07/08/2023,Jesus Aguilar,Shannon Ross,Red,Flyweight
+07/08/2023,Esteban Ribovics,Kamuela Kirk,Red,Lightweight
+07/01/2023,Sean Strickland,Abus Magomedov,Red,Middleweight
+07/01/2023,Grant Dawson,Damir Ismagulov,Red,Lightweight
+07/01/2023,Michael Morales,Max Griffin,Red,Welterweight
+07/01/2023,Ariane Lipski,Melissa Gatto,Red,Women's Flyweight
+07/01/2023,Benoit Saint Denis,Ismael Bonfim,Red,Lightweight
+07/01/2023,Nursulton Ruziboev,Brunno Ferreira,Red,Middleweight
+07/01/2023,Rinat Fakhretdinov,Kevin Lee,Red,Welterweight
+07/01/2023,Joanderson Brito,Westin Wilson,Red,Featherweight
+07/01/2023,Karol Rosa,Yana Santos,Red,Women's Featherweight
+07/01/2023,Elves Brener,Guram Kutateladze,Red,Lightweight
+07/01/2023,Luana Carolina,Ivana Petrovic,Red,Women's Flyweight
+07/01/2023,Alexandr Romanov,Blagoy Ivanov,Red,Heavyweight
+06/24/2023,Ilia Topuria,Josh Emmett,Red,Featherweight
+06/24/2023,Maycee Barber,Amanda Ribas,Red,Women's Flyweight
+06/24/2023,David Onama,Gabriel Santos,Red,Featherweight
+06/24/2023,Brendan Allen,Bruno Silva,Red,Middleweight
+06/24/2023,Neil Magny,Phil Rowe,Red,Welterweight
+06/24/2023,Randy Brown,Wellington Turman,Red,Welterweight
+06/24/2023,Mateusz Rebecki,Loik Radzhabov,Red,Lightweight
+06/24/2023,Tabatha Ricci,Gillian Robertson,Red,Women's Strawweight
+06/24/2023,Joshua Van,Zhalgas Zhumagulov,Red,Flyweight
+06/24/2023,Chepe Mariscal,Trevor Peek,Red,Lightweight
+06/24/2023,Jack Jenkins,Jamall Emmers,Red,Featherweight
+06/24/2023,Sedriques Dumas,Cody Brundage,Red,Middleweight
+06/17/2023,Jared Cannonier,Marvin Vettori,Red,Middleweight
+06/17/2023,Arman Tsarukyan,Joaquim Silva,Red,Lightweight
+06/17/2023,Armen Petrosyan,Christian Leroy Duncan,Red,Middleweight
+06/17/2023,Pat Sabatini,Lucas Almeida,Red,Featherweight
+06/17/2023,Manuel Torres,Nikolas Motta,Red,Lightweight
+06/17/2023,Nicolas Dalby,Muslim Salikhov,Red,Welterweight
+06/17/2023,Alessandro Costa,Jimmy Flick,Red,Flyweight
+06/17/2023,Kyung Ho Kang,Cristian Quinonez,Red,Bantamweight
+06/17/2023,Carlos Hernandez,Denys Bondar,Red,Flyweight
+06/17/2023,Tereza Bleda,Gabriella Fernandes,Red,Women's Flyweight
+06/17/2023,Modestas Bukauskas,Zac Pauga,Red,Light Heavyweight
+06/10/2023,Amanda Nunes,Irene Aldana,Red,UFC Women's Bantamweight Title
+06/10/2023,Charles Oliveira,Beneil Dariush,Red,Lightweight
+06/10/2023,Mike Malott,Adam Fugitt,Red,Welterweight
+06/10/2023,Dan Ige,Nate Landwehr,Red,Featherweight
+06/10/2023,Marc-Andre Barriault,Eryk Anders,Red,Middleweight
+06/10/2023,Jasmine Jasudavicius,Miranda Maverick,Red,Women's Flyweight
+06/10/2023,Aiemann Zahabi,Aoriqileng,Red,Bantamweight
+06/10/2023,Kyle Nelson,Blake Bilder,Red,Featherweight
+06/10/2023,Steve Erceg,David Dvorak,Red,Flyweight
+06/10/2023,Diana Belbita,Maria Oliveira,Red,Women's Strawweight
+06/03/2023,Amir Albazi,Kai Kara-France,Red,Flyweight
+06/03/2023,Alex Caceres,Daniel Pineda,Red,Featherweight
+06/03/2023,Jim Miller,Jesse Butler,Red,Lightweight
+06/03/2023,Tim Elliott,Victor Altamirano,Red,Flyweight
+06/03/2023,Karine Silva,Ketlen Souza,Red,Women's Flyweight
+06/03/2023,Elizeu Zaleski dos Santos,Abubakar Nurmagomedov,Red,Welterweight
+06/03/2023,Daniel Santos,Johnny Munoz,Red,Bantamweight
+06/03/2023,Don'Tale Mayes,Andrei Arlovski,Red,Heavyweight
+06/03/2023,John Castaneda,Muin Gafurov,Red,Bantamweight
+06/03/2023,Muhammad Naimov,Jamie Mullarkey,Red,Lightweight
+06/03/2023,Elise Reed,Jinh Yu Frey,Red,Women's Strawweight
+06/03/2023,Da'Mon Blackshear,Luan Lacerda,Red,Bantamweight
+06/03/2023,Philipe Lins,Maxim Grishin,Red,Light Heavyweight
+05/20/2023,Mackenzie Dern,Angela Hill,Red,Women's Strawweight
+05/20/2023,Anthony Hernandez,Edmen Shahbazyan,Red,Middleweight
+05/20/2023,Loopy Godinez,Emily Ducote,Red,Catch Weight
+05/20/2023,Joaquin Buckley,Andre Fialho,Red,Welterweight
+05/20/2023,Diego Ferreira,Michael Johnson,Red,Lightweight
+05/20/2023,Viacheslav Borshchev,Maheshate,Red,Lightweight
+05/20/2023,Karolina Kowalkiewicz,Vanessa Demopoulos,Red,Women's Strawweight
+05/20/2023,Gilbert Urbina,Orion Cosce,Red,Welterweight
+05/20/2023,Rodrigo Nascimento,Ilir Latifi,Red,Heavyweight
+05/20/2023,Chase Hooper,Nick Fiore,Red,Lightweight
+05/20/2023,Natalia Silva,Victoria Leonardo,Red,Women's Flyweight
+05/20/2023,Themba Gorimbo,Takashi Sato,Red,Welterweight
+05/13/2023,Jailton Almeida,Jairzinho Rozenstruik,Red,Heavyweight
+05/13/2023,Johnny Walker,Anthony Smith,Red,Light Heavyweight
+05/13/2023,Ian Machado Garry,Daniel Rodriguez,Red,Welterweight
+05/13/2023,Carlos Ulberg,Ihor Potieria,Red,Light Heavyweight
+05/13/2023,Alex Morono,Tim Means,Red,Welterweight
+05/13/2023,Matt Brown,Court McGee,Red,Welterweight
+05/13/2023,Karl Williams,Chase Sherman,Red,Heavyweight
+05/13/2023,Douglas Silva de Andrade,Cody Stamann,Red,Catch Weight
+05/13/2023,Mandy Bohm,Ji Yeon Kim,Red,Women's Flyweight
+05/13/2023,Bryan Battle,Gabe Green,Red,Welterweight
+05/13/2023,Tainara Lisboa,Jessica-Rose Clark,Red,Women's Bantamweight
+05/06/2023,Aljamain Sterling,Henry Cejudo,Red,UFC Bantamweight Title
+05/06/2023,Belal Muhammad,Gilbert Burns,Red,Welterweight
+05/06/2023,Yan Xiaonan,Jessica Andrade,Red,Women's Strawweight
+05/06/2023,Movsar Evloev,Diego Lopes,Red,Featherweight
+05/06/2023,Charles Jourdain,Kron Gracie,Red,Featherweight
+05/06/2023,Matt Frevola,Drew Dober,Red,Lightweight
+05/06/2023,Kennedy Nzechukwu,Devin Clark,Red,Light Heavyweight
+05/06/2023,Khaos Williams,Rolando Bedoya,Red,Welterweight
+05/06/2023,Virna Jandiroba,Marina Rodriguez,Red,Women's Strawweight
+05/06/2023,Parker Porter,Braxton Smith,Red,Heavyweight
+05/06/2023,Ikram Aliskerov,Phil Hawes,Red,Middleweight
+05/06/2023,Claudio Ribeiro,Joseph Holmes,Red,Middleweight
+04/29/2023,Song Yadong,Ricky Simon,Red,Bantamweight
+04/29/2023,Caio Borralho,Michal Oleksiejczuk,Red,Middleweight
+04/29/2023,Rodolfo Vieira,Cody Brundage,Red,Middleweight
+04/29/2023,Fernando Padilla,Julian Erosa,Red,Featherweight
+04/29/2023,Marcos Rogerio de Lima,Waldo Cortes-Acosta,Red,Heavyweight
+04/29/2023,Trey Waters,Josh Quinlan,Red,Welterweight
+04/29/2023,Martin Buday,Jake Collier,Red,Heavyweight
+04/29/2023,Cody Durden,Charles Johnson,Red,Flyweight
+04/29/2023,Irina Alekseeva,Stephanie Egger,Red,Women's Bantamweight
+04/29/2023,Marcus McGhee,Journey Newson,Red,Catch Weight
+04/29/2023,Jamey-Lyn Horth,Hailey Cowan,Red,Women's Bantamweight
+04/22/2023,Sergei Pavlovich,Curtis Blaydes,Red,Heavyweight
+04/22/2023,Bruno Silva,Brad Tavares,Red,Middleweight
+04/22/2023,Iasmin Lucindo,Brogan Walker,Red,Women's Flyweight
+04/22/2023,Jeremiah Wells,Matthew Semelsberger,Red,Welterweight
+04/22/2023,Christos Giagos,Ricky Glenn,Red,Lightweight
+04/22/2023,Montel Jackson,Rani Yahya,Red,Bantamweight
+04/22/2023,Norma Dumont,Karol Rosa,Red,Women's Featherweight
+04/22/2023,Mohammed Usman,Junior Tafa,Red,Heavyweight
+04/22/2023,William Gomis,Francis Marshall,Red,Featherweight
+04/22/2023,Brady Hiestand,Batgerel Danaa,Red,Bantamweight
+04/15/2023,Max Holloway,Arnold Allen,Red,Featherweight
+04/15/2023,Edson Barboza,Billy Quarantillo,Red,Featherweight
+04/15/2023,Azamat Murzakanov,Dustin Jacoby,Red,Light Heavyweight
+04/15/2023,Ion Cutelaba,Tanner Boser,Red,Light Heavyweight
+04/15/2023,Pedro Munhoz,Chris Gutierrez,Red,Bantamweight
+04/15/2023,Rafa Garcia,Clay Guida,Red,Lightweight
+04/15/2023,Bill Algeo,TJ Brown,Red,Featherweight
+04/15/2023,Brandon Royval,Matheus Nicolau,Red,Flyweight
+04/15/2023,Zak Cummings,Ed Herman,Red,Light Heavyweight
+04/15/2023,Gillian Robertson,Piera Rodriguez,Red,Women's Strawweight
+04/15/2023,Daniel Zellhuber,Lando Vannata,Red,Lightweight
+04/15/2023,Denise Gomes,Bruna Brasil,Red,Women's Strawweight
+04/15/2023,Gaston Bolanos,Aaron Phillips,Red,Bantamweight
+04/15/2023,Joselyne Edwards,Lucie Pudilova,Red,Women's Bantamweight
+04/08/2023,Israel Adesanya,Alex Pereira,Red,UFC Middleweight Title
+04/08/2023,Gilbert Burns,Jorge Masvidal,Red,Welterweight
+04/08/2023,Rob Font,Adrian Yanez,Red,Bantamweight
+04/08/2023,Kevin Holland,Santiago Ponzinibbio,Red,Welterweight
+04/08/2023,Christian Rodriguez,Raul Rosas Jr.,Red,Bantamweight
+04/08/2023,Kelvin Gastelum,Chris Curtis,Red,Middleweight
+04/08/2023,Luana Pinheiro,Michelle Waterson-Gomez,Red,Women's Strawweight
+04/08/2023,Joe Pyfer,Gerald Meerschaert,Red,Middleweight
+04/08/2023,Loopy Godinez,Cynthia Calvillo,Red,Women's Strawweight
+04/08/2023,Ignacio Bahamondes,Trey Ogden,Red,Catch Weight
+04/08/2023,Steve Garcia,Shayilan Nuerdanbieke,Red,Featherweight
+04/08/2023,Sam Hughes,Jaqueline Amorim,Red,Women's Strawweight
+03/25/2023,Cory Sandhagen,Marlon Vera,Red,Bantamweight
+03/25/2023,Holly Holm,Yana Santos,Red,Women's Bantamweight
+03/25/2023,Nate Landwehr,Austin Lingo,Red,Featherweight
+03/25/2023,Maycee Barber,Andrea Lee,Red,Women's Flyweight
+03/25/2023,Albert Duraev,Chidi Njokuani,Red,Middleweight
+03/25/2023,Daniel Pineda,Tucker Lutz,Red,Featherweight
+03/25/2023,Lucas Alexander,Steven Peterson,Red,Featherweight
+03/25/2023,Trevin Giles,Preston Parsons,Red,Welterweight
+03/25/2023,CJ Vergara,Daniel Lacerda,Red,Flyweight
+03/25/2023,Victor Altamirano,Vinicius Salvador,Red,Flyweight
+03/18/2023,Leon Edwards,Kamaru Usman,Red,UFC Welterweight Title
+03/18/2023,Justin Gaethje,Rafael Fiziev,Red,Lightweight
+03/18/2023,Gunnar Nelson,Bryan Barberena,Red,Welterweight
+03/18/2023,Jennifer Maia,Casey O'Neill,Red,Women's Flyweight
+03/18/2023,Marvin Vettori,Roman Dolidze,Red,Middleweight
+03/18/2023,Jack Shore,Makwan Amirkhani,Red,Featherweight
+03/18/2023,Chris Duncan,Omar Morales,Red,Lightweight
+03/18/2023,Yanal Ashmouz,Sam Patterson,Red,Lightweight
+03/18/2023,Muhammad Mokaev,Jafel Filho,Red,Flyweight
+03/18/2023,Lerone Murphy,Gabriel Santos,Red,Featherweight
+03/18/2023,Christian Leroy Duncan,Dusko Todorovic,Red,Middleweight
+03/18/2023,Jake Hadley,Malcolm Gordon,Red,Flyweight
+03/18/2023,Joanne Wood,Luana Carolina,Red,Women's Flyweight
+03/18/2023,Veronica Hardy,Juliana Miller,Red,Women's Flyweight
+03/11/2023,Merab Dvalishvili,Petr Yan,Red,Bantamweight
+03/11/2023,Alexander Volkov,Alexandr Romanov,Red,Heavyweight
+03/11/2023,Nikita Krylov,Ryan Spann,Red,Catch Weight
+03/11/2023,Jonathan Martinez,Said Nurmagomedov,Red,Bantamweight
+03/11/2023,Mario Bautista,Guido Cannetti,Red,Bantamweight
+03/11/2023,Vitor Petrino,Anton Turkalj,Red,Light Heavyweight
+03/11/2023,Karl Williams,Lukasz Brzeski,Red,Heavyweight
+03/11/2023,Davey Grant,Raphael Assuncao,Red,Bantamweight
+03/11/2023,Josh Fremd,Sedriques Dumas,Red,Middleweight
+03/11/2023,Victor Henry,Tony Gravely,Red,Bantamweight
+03/11/2023,Ariane Lipski,JJ Aldrich,Red,Women's Flyweight
+03/11/2023,Bruno Silva,Tyson Nam,Red,Flyweight
+03/11/2023,Carlston Harris,Jared Gooden,Red,Welterweight
+03/04/2023,Jon Jones,Ciryl Gane,Red,UFC Heavyweight Title
+03/04/2023,Alexa Grasso,Valentina Shevchenko,Red,UFC Women's Flyweight Title
+03/04/2023,Shavkat Rakhmonov,Geoff Neal,Red,Welterweight
+03/04/2023,Mateusz Gamrot,Jalin Turner,Red,Lightweight
+03/04/2023,Bo Nickal,Jamie Pickett,Red,Middleweight
+03/04/2023,Cody Garbrandt,Trevin Jones,Red,Bantamweight
+03/04/2023,Dricus Du Plessis,Derek Brunson,Red,Middleweight
+03/04/2023,Amanda Ribas,Viviane Araujo,Red,Women's Flyweight
+03/04/2023,Marc-Andre Barriault,Julian Marquez,Red,Middleweight
+03/04/2023,Ian Machado Garry,Song Kenan,Red,Welterweight
+03/04/2023,Cameron Saaiman,Mana Martinez,Red,Bantamweight
+03/04/2023,Tabatha Ricci,Jessica Penne,Red,Women's Strawweight
+03/04/2023,Farid Basharat,Da'Mon Blackshear,Red,Bantamweight
+03/04/2023,Loik Radzhabov,Esteban Ribovics,Red,Lightweight
+02/25/2023,Brendan Allen,Andre Muniz,Red,Middleweight
+02/25/2023,Augusto Sakai,Don'Tale Mayes,Red,Heavyweight
+02/25/2023,Tatiana Suarez,Montana De La Rosa,Red,Women's Flyweight
+02/25/2023,Mike Malott,Yohan Lainesse,Red,Welterweight
+02/25/2023,Trevor Peek,Erick Gonzalez,Red,Lightweight
+02/25/2023,Jasmine Jasudavicius,Gabriella Fernandes,Red,Women's Flyweight
+02/25/2023,Jordan Leavitt,Victor Martinez,Red,Lightweight
+02/25/2023,Ode Osbourne,Charles Johnson,Red,Catch Weight
+02/25/2023,Joe Solecki,Carl Deaton,Red,Lightweight
+02/25/2023,Nurullo Aliev,Rafael Alves,Red,Lightweight
+02/18/2023,Erin Blanchfield,Jessica Andrade,Red,Women's Flyweight
+02/18/2023,Zac Pauga,Jordan Wright,Red,Light Heavyweight
+02/18/2023,Jamal Pogues,Josh Parisian,Red,Heavyweight
+02/18/2023,Marcin Prachnio,William Knight,Red,Light Heavyweight
+02/18/2023,Alexander Hernandez,Jim Miller,Red,Lightweight
+02/18/2023,Nazim Sadykhov,Evan Elder,Red,Lightweight
+02/18/2023,Mayra Bueno Silva,Lina Lansberg,Red,Women's Bantamweight
+02/18/2023,Jamall Emmers,Khusein Askhabov,Red,Featherweight
+02/18/2023,Philipe Lins,Ovince Saint Preux,Red,Light Heavyweight
+02/18/2023,AJ Fletcher,Themba Gorimbo,Red,Welterweight
+02/18/2023,Clayton Carpenter,Juancamilo Ronderos,Red,Flyweight
+02/11/2023,Islam Makhachev,Alexander Volkanovski,Red,UFC Lightweight Title
+02/11/2023,Yair Rodriguez,Josh Emmett,Red,UFC Interim Featherweight Title
+02/11/2023,Jack Della Maddalena,Randy Brown,Red,Welterweight
+02/11/2023,Justin Tafa,Parker Porter,Red,Heavyweight
+02/11/2023,Modestas Bukauskas,Tyson Pedro,Red,Light Heavyweight
+02/11/2023,Josh Culibao,Melsik Baghdasaryan,Red,Featherweight
+02/11/2023,Kleydson Rodrigues,Shannon Ross,Red,Flyweight
+02/11/2023,Jamie Mullarkey,Francisco Prado,Red,Lightweight
+02/11/2023,Jack Jenkins,Don Shainis,Red,Featherweight
+02/11/2023,Loma Lookboonmee,Elise Reed,Red,Women's Strawweight
+02/11/2023,Blake Bilder,Shane Young,Red,Featherweight
+02/11/2023,Elves Brener,Zubaira Tukhugov,Red,Lightweight
+02/04/2023,Serghei Spivac,Derrick Lewis,Red,Heavyweight
+02/04/2023,Devin Clark,Da Woon Jung,Red,Light Heavyweight
+02/04/2023,Marcin Tybura,Blagoy Ivanov,Red,Heavyweight
+02/04/2023,Adam Fugitt,Yusaku Kinoshita,Red,Welterweight
+02/04/2023,Anshul Jubli,Jeka Saragih,Red,Lightweight
+02/04/2023,JeongYeong Lee,Yizha,Red,Featherweight
+02/04/2023,Rinya Nakamura,Toshiomi Kazama,Red,Bantamweight
+02/04/2023,HyunSung Park,SeungGuk Choi,Red,Flyweight
+02/04/2023,JunYong Park,Denis Tiuliulin,Red,Middleweight
+02/04/2023,Tatsuro Taira,Jesus Aguilar,Red,Flyweight
+01/21/2023,Jamahal Hill,Glover Teixeira,Red,UFC Light Heavyweight Title
+01/21/2023,Brandon Moreno,Deiveson Figueiredo,Red,UFC Flyweight Title
+01/21/2023,Gilbert Burns,Neil Magny,Red,Welterweight
+01/21/2023,Jessica Andrade,Lauren Murphy,Red,Women's Flyweight
+01/21/2023,Johnny Walker,Paul Craig,Red,Light Heavyweight
+01/21/2023,Ihor Potieria,Mauricio Rua,Red,Light Heavyweight
+01/21/2023,Brunno Ferreira,Gregory Rodrigues,Red,Middleweight
+01/21/2023,Thiago Moises,Melquizael Costa,Red,Lightweight
+01/21/2023,Gabriel Bonfim,Mounir Lazzez,Red,Welterweight
+01/21/2023,Jailton Almeida,Shamil Abdurakhimov,Red,Heavyweight
+01/21/2023,Cody Stamann,Luan Lacerda,Red,Bantamweight
+01/21/2023,Ismael Bonfim,Terrance McKinney,Red,Lightweight
+01/21/2023,Nicolas Dalby,Warlley Alves,Red,Welterweight
+01/21/2023,Josiane Nunes,Zarah Fairn,Red,Women's Featherweight
+01/21/2023,Daniel Marcos,Saimon Oliveira,Red,Bantamweight
+01/14/2023,Sean Strickland,Nassourdine Imavov,Red,Light Heavyweight
+01/14/2023,Dan Ige,Damon Jackson,Red,Featherweight
+01/14/2023,Roman Kopylov,Punahele Soriano,Red,Middleweight
+01/14/2023,Raquel Pennington,Ketlen Vieira,Red,Women's Bantamweight
+01/14/2023,Umar Nurmagomedov,Raoni Barcelos,Red,Bantamweight
+01/14/2023,Javid Basharat,Mateus Mendonca,Red,Bantamweight
+01/14/2023,Abdul Razak Alhassan,Claudio Ribeiro,Red,Middleweight
+01/14/2023,Mateusz Rebecki,Nick Fiore,Red,Lightweight
+01/14/2023,Allan Nascimento,Carlos Hernandez,Red,Flyweight
+01/14/2023,Dan Argueta,Nick Aguirre,Red,Featherweight
+01/14/2023,Charles Johnson,Jimmy Flick,Red,Flyweight
+12/17/2022,Jared Cannonier,Sean Strickland,Red,Middleweight
+12/17/2022,Arman Tsarukyan,Damir Ismagulov,Red,Lightweight
+12/17/2022,Amir Albazi,Alessandro Costa,Red,Flyweight
+12/17/2022,Alex Caceres,Julian Erosa,Red,Featherweight
+12/17/2022,Drew Dober,Bobby Green,Red,Lightweight
+12/17/2022,Michal Oleksiejczuk,Cody Brundage,Red,Middleweight
+12/17/2022,Cory McKenna,Cheyanne Vlismas,Red,Women's Strawweight
+12/17/2022,Matthew Semelsberger,Jake Matthews,Red,Welterweight
+12/17/2022,Said Nurmagomedov,Saidyokub Kakhramonov,Red,Bantamweight
+12/17/2022,Rafa Garcia,Maheshate,Red,Lightweight
+12/17/2022,Rinat Fakhretdinov,Bryan Battle,Red,Welterweight
+12/17/2022,Manel Kape,David Dvorak,Red,Flyweight
+12/17/2022,Sergey Morozov,Journey Newson,Red,Bantamweight
+12/10/2022,Paddy Pimblett,Jared Gordon,Red,Lightweight
+12/10/2022,Santiago Ponzinibbio,Alex Morono,Red,Catch Weight
+12/10/2022,Dricus Du Plessis,Darren Till,Red,Middleweight
+12/10/2022,Ilia Topuria,Bryce Mitchell,Red,Featherweight
+12/10/2022,Raul Rosas Jr.,Jay Perrin,Red,Bantamweight
+12/10/2022,Jairzinho Rozenstruik,Chris Daukaus,Red,Heavyweight
+12/10/2022,Edmen Shahbazyan,Dalcha Lungiambula,Red,Middleweight
+12/10/2022,Chris Curtis,Joaquin Buckley,Red,Middleweight
+12/10/2022,Billy Quarantillo,Alexander Hernandez,Red,Featherweight
+12/10/2022,TJ Brown,Erik Silva,Red,Featherweight
+12/10/2022,Cameron Saaiman,Steven Koslow,Red,Bantamweight
+12/03/2022,Stephen Thompson,Kevin Holland,Red,Welterweight
+12/03/2022,Rafael Dos Anjos,Bryan Barberena,Red,Welterweight
+12/03/2022,Matheus Nicolau,Matt Schnell,Red,Flyweight
+12/03/2022,Sergei Pavlovich,Tai Tuivasa,Red,Heavyweight
+12/03/2022,Roman Dolidze,Jack Hermansson,Red,Middleweight
+12/03/2022,Eryk Anders,Kyle Daukaus,Red,Middleweight
+12/03/2022,Phil Rowe,Niko Price,Red,Welterweight
+12/03/2022,Angela Hill,Emily Ducote,Red,Women's Strawweight
+12/03/2022,Clay Guida,Scott Holtzman,Red,Lightweight
+12/03/2022,Michael Johnson,Marc Diakiese,Red,Lightweight
+12/03/2022,Jonathan Pearce,Darren Elkins,Red,Featherweight
+12/03/2022,Natan Levy,Genaro Valdez,Red,Lightweight
+12/03/2022,Francis Marshall,Marcelo Rojo,Red,Featherweight
+12/03/2022,Yazmin Jauregui,Istela Nunes,Red,Women's Strawweight
+11/19/2022,Kennedy Nzechukwu,Ion Cutelaba,Red,Light Heavyweight
+11/19/2022,Waldo Cortes-Acosta,Chase Sherman,Red,Heavyweight
+11/19/2022,Muslim Salikhov,Andre Fialho,Red,Welterweight
+11/19/2022,Jack Della Maddalena,Danny Roberts,Red,Welterweight
+11/19/2022,Charles Johnson,Zhalgas Zhumagulov,Red,Flyweight
+11/19/2022,Jennifer Maia,Maryna Moroz,Red,Women's Flyweight
+11/19/2022,Miles Johns,Vince Morales,Red,Bantamweight
+11/19/2022,Ricky Turcios,Kevin Natividad,Red,Bantamweight
+11/19/2022,Vanessa Demopoulos,Maria Oliveira,Red,Women's Strawweight
+11/19/2022,Brady Hiestand,Fernie Garcia,Red,Bantamweight
+11/19/2022,Natalia Silva,Tereza Bleda,Red,Women's Flyweight
+11/12/2022,Alex Pereira,Israel Adesanya,Red,UFC Middleweight Title
+11/12/2022,Zhang Weili,Carla Esparza,Red,UFC Women's Strawweight Title
+11/12/2022,Dustin Poirier,Michael Chandler,Red,Lightweight
+11/12/2022,Chris Gutierrez,Frankie Edgar,Red,Bantamweight
+11/12/2022,Dan Hooker,Claudio Puelles,Red,Lightweight
+11/12/2022,Renato Moicano,Brad Riddell,Red,Lightweight
+11/12/2022,Ryan Spann,Dominick Reyes,Red,Light Heavyweight
+11/12/2022,Erin Blanchfield,Molly McCann,Red,Women's Flyweight
+11/12/2022,Andre Petroski,Wellington Turman,Red,Middleweight
+11/12/2022,Matt Frevola,Ottman Azaitar,Red,Lightweight
+11/12/2022,Karolina Kowalkiewicz,Silvana Gomez Juarez,Red,Women's Strawweight
+11/12/2022,Michael Trizano,SeungWoo Choi,Red,Featherweight
+11/12/2022,Montel Jackson,Julio Arce,Red,Bantamweight
+11/12/2022,Carlos Ulberg,Nicolae Negumereanu,Red,Light Heavyweight
+11/05/2022,Amanda Lemos,Marina Rodriguez,Red,Women's Strawweight
+11/05/2022,Neil Magny,Daniel Rodriguez,Red,Welterweight
+11/05/2022,Shayilan Nuerdanbieke,Darrick Minner,Red,Featherweight
+11/05/2022,Tagir Ulanbekov,Nate Maness,Red,Flyweight
+11/05/2022,Grant Dawson,Mark Madsen,Red,Lightweight
+11/05/2022,Miranda Maverick,Shanna Young,Red,Women's Flyweight
+11/05/2022,Mario Bautista,Benito Lopez,Red,Bantamweight
+11/05/2022,Polyana Viana,Jinh Yu Frey,Red,Women's Strawweight
+11/05/2022,Johnny Munoz,Liudvik Sholinian,Red,Bantamweight
+11/05/2022,Jake Hadley,Carlos Candelario,Red,Flyweight
+11/05/2022,Tamires Vidal,Ramona Pascual,Red,Women's Bantamweight
+10/29/2022,Arnold Allen,Calvin Kattar,Red,Featherweight
+10/29/2022,Max Griffin,Tim Means,Red,Welterweight
+10/29/2022,Waldo Cortes-Acosta,Jared Vanderaa,Red,Heavyweight
+10/29/2022,Tresean Gore,Josh Fremd,Red,Middleweight
+10/29/2022,Khalil Rountree Jr.,Dustin Jacoby,Red,Light Heavyweight
+10/29/2022,Roman Dolidze,Phil Hawes,Red,Middleweight
+10/29/2022,Marcos Rogerio de Lima,Andrei Arlovski,Red,Heavyweight
+10/29/2022,JunYong Park,Joseph Holmes,Red,Middleweight
+10/29/2022,Steve Garcia,Chase Hooper,Red,Featherweight
+10/29/2022,Cody Durden,Carlos Mota,Red,Flyweight
+10/29/2022,Christian Rodriguez,Joshua Weems,Red,Bantamweight
+10/22/2022,Islam Makhachev,Charles Oliveira,Red,UFC Lightweight Title
+10/22/2022,Aljamain Sterling,TJ Dillashaw,Red,UFC Bantamweight Title
+10/22/2022,Sean O'Malley,Petr Yan,Red,Bantamweight
+10/22/2022,Beneil Dariush,Mateusz Gamrot,Red,Lightweight
+10/22/2022,Manon Fiorot,Katlyn Cerminara,Red,Women's Flyweight
+10/22/2022,Belal Muhammad,Sean Brady,Red,Welterweight
+10/22/2022,Caio Borralho,Makhmud Muradov,Red,Middleweight
+10/22/2022,Nikita Krylov,Volkan Oezdemir,Red,Light Heavyweight
+10/22/2022,Abubakar Nurmagomedov,Gadzhi Omargadzhiev,Red,Welterweight
+10/22/2022,Armen Petrosyan,AJ Dobson,Red,Middleweight
+10/22/2022,Muhammad Mokaev,Malcolm Gordon,Red,Flyweight
+10/22/2022,Karol Rosa,Lina Lansberg,Red,Women's Bantamweight
+10/15/2022,Alexa Grasso,Viviane Araujo,Red,Women's Flyweight
+10/15/2022,Jonathan Martinez,Cub Swanson,Red,Bantamweight
+10/15/2022,Dusko Todorovic,Jordan Wright,Red,Middleweight
+10/15/2022,Raphael Assuncao,Victor Henry,Red,Bantamweight
+10/15/2022,Alonzo Menifield,Misha Cirkunov,Red,Light Heavyweight
+10/15/2022,Mana Martinez,Brandon Davis,Red,Bantamweight
+10/15/2022,Jacob Malkoun,Nick Maximov,Red,Middleweight
+10/15/2022,Joanderson Brito,Lucas Alexander,Red,Featherweight
+10/15/2022,Piera Rodriguez,Sam Hughes,Red,Women's Strawweight
+10/15/2022,Tatsuro Taira,CJ Vergara,Red,Flyweight
+10/15/2022,Pete Rodriguez,Mike Jackson,Red,Welterweight
+10/01/2022,Yan Xiaonan,Mackenzie Dern,Red,Women's Strawweight
+10/01/2022,Randy Brown,Francisco Trinaldo,Red,Welterweight
+10/01/2022,Raoni Barcelos,Trevin Jones,Red,Bantamweight
+10/01/2022,Sodiq Yusuff,Don Shainis,Red,Featherweight
+10/01/2022,Mike Davis,Viacheslav Borshchev,Red,Lightweight
+10/01/2022,Daniel Santos,John Castaneda,Red,Catch Weight
+10/01/2022,Ilir Latifi,Aleksei Oleinik,Red,Heavyweight
+10/01/2022,Joaquim Silva,Jesse Ronson,Red,Lightweight
+10/01/2022,Brendan Allen,Krzysztof Jotko,Red,Middleweight
+10/01/2022,Chelsea Chandler,Julija Stoliarenko,Red,Catch Weight
+10/01/2022,Guido Cannetti,Randy Costa,Red,Bantamweight
+09/17/2022,Cory Sandhagen,Song Yadong,Red,Bantamweight
+09/17/2022,Gregory Rodrigues,Chidi Njokuani,Red,Middleweight
+09/17/2022,Andre Fili,Bill Algeo,Red,Featherweight
+09/17/2022,Joe Pyfer,Alen Amedovski,Red,Middleweight
+09/17/2022,Rodrigo Nascimento,Tanner Boser,Red,Heavyweight
+09/17/2022,Anthony Hernandez,Marc-Andre Barriault,Red,Middleweight
+09/17/2022,Damon Jackson,Pat Sabatini,Red,Featherweight
+09/17/2022,Trevin Giles,Louis Cosce,Red,Welterweight
+09/17/2022,Loma Lookboonmee,Denise Gomes,Red,Women's Strawweight
+09/17/2022,Trey Ogden,Daniel Zellhuber,Red,Lightweight
+09/17/2022,Gillian Robertson,Mariya Agapova,Red,Women's Flyweight
+09/17/2022,Javid Basharat,Tony Gravely,Red,Bantamweight
+09/17/2022,Nikolas Motta,Cameron VanCamp,Red,Lightweight
+09/10/2022,Nate Diaz,Tony Ferguson,Red,Welterweight
+09/10/2022,Khamzat Chimaev,Kevin Holland,Red,Catch Weight
+09/10/2022,Daniel Rodriguez,Li Jingliang,Red,Catch Weight
+09/10/2022,Irene Aldana,Macy Chiasson,Red,Catch Weight
+09/10/2022,Johnny Walker,Ion Cutelaba,Red,Light Heavyweight
+09/10/2022,Julian Erosa,Hakeem Dawodu,Red,Featherweight
+09/10/2022,Jailton Almeida,Anton Turkalj,Red,Catch Weight
+09/10/2022,Denis Tiuliulin,Jamie Pickett,Red,Middleweight
+09/10/2022,Chris Barnett,Jake Collier,Red,Heavyweight
+09/10/2022,Norma Dumont,Danyelle Wolf,Red,Women's Featherweight
+09/10/2022,Alatengheili,Chad Anheliger,Red,Bantamweight
+09/10/2022,Elise Reed,Melissa Martinez,Red,Women's Strawweight
+09/10/2022,Yohan Lainesse,Darian Weeks,Red,Welterweight
+09/03/2022,Ciryl Gane,Tai Tuivasa,Red,Heavyweight
+09/03/2022,Robert Whittaker,Marvin Vettori,Red,Middleweight
+09/03/2022,Nassourdine Imavov,Joaquin Buckley,Red,Middleweight
+09/03/2022,Roman Kopylov,Alessio Di Chirico,Red,Middleweight
+09/03/2022,William Gomis,Jarno Errens,Red,Featherweight
+09/03/2022,Nathaniel Wood,Charles Jourdain,Red,Featherweight
+09/03/2022,Abus Magomedov,Dustin Stoltzfus,Red,Middleweight
+09/03/2022,Nasrat Haqparast,John Makdessi,Red,Lightweight
+09/03/2022,Fares Ziam,Michal Figlak,Red,Lightweight
+09/03/2022,Benoit Saint Denis,Gabriel Miranda,Red,Lightweight
+09/03/2022,Cristian Quinonez,Khalid Taha,Red,Bantamweight
+09/03/2022,Stephanie Egger,Ailin Perez,Red,Women's Featherweight
+08/20/2022,Leon Edwards,Kamaru Usman,Red,UFC Welterweight Title
+08/20/2022,Paulo Costa,Luke Rockhold,Red,Middleweight
+08/20/2022,Merab Dvalishvili,Jose Aldo,Red,Bantamweight
+08/20/2022,Lucie Pudilova,Wu Yanan,Red,Women's Bantamweight
+08/20/2022,Tyson Pedro,Harry Hunsucker,Red,Light Heavyweight
+08/20/2022,Marcin Tybura,Alexandr Romanov,Red,Heavyweight
+08/20/2022,Jared Gordon,Leonardo Santos,Red,Lightweight
+08/20/2022,Ange Loosa,AJ Fletcher,Red,Welterweight
+08/20/2022,Amir Albazi,Francisco Figueiredo,Red,Flyweight
+08/20/2022,Aoriqileng,Jay Perrin,Red,Bantamweight
+08/20/2022,Victor Altamirano,Daniel Lacerda,Red,Flyweight
+08/13/2022,Marlon Vera,Dominick Cruz,Red,Bantamweight
+08/13/2022,Nate Landwehr,David Onama,Red,Featherweight
+08/13/2022,Yazmin Jauregui,Iasmin Lucindo,Red,Women's Strawweight
+08/13/2022,Azamat Murzakanov,Devin Clark,Red,Light Heavyweight
+08/13/2022,Priscila Cachoeira,Ariane Lipski,Red,Women's Bantamweight
+08/13/2022,Gerald Meerschaert,Bruno Silva,Red,Middleweight
+08/13/2022,Angela Hill,Loopy Godinez,Red,Catch Weight
+08/13/2022,Martin Buday,Lukasz Brzeski,Red,Heavyweight
+08/13/2022,Nina Nunes,Cynthia Calvillo,Red,Women's Flyweight
+08/13/2022,Gabriel Benitez,Charlie Ontiveros,Red,Lightweight
+08/13/2022,Tyson Nam,Ode Osbourne,Red,Flyweight
+08/13/2022,Josh Quinlan,Jason Witt,Red,Catch Weight
+08/06/2022,Jamahal Hill,Thiago Santos,Red,Light Heavyweight
+08/06/2022,Geoff Neal,Vicente Luque,Red,Welterweight
+08/06/2022,Mohammed Usman,Zac Pauga,Red,Heavyweight
+08/06/2022,Juliana Miller,Brogan Walker,Red,Women's Flyweight
+08/06/2022,Serghei Spivac,Augusto Sakai,Red,Heavyweight
+08/06/2022,Terrance McKinney,Erick Gonzalez,Red,Lightweight
+08/06/2022,Michal Oleksiejczuk,Sam Alvey,Red,Middleweight
+08/06/2022,Bryan Battle,Takashi Sato,Red,Welterweight
+08/06/2022,Cory McKenna,Miranda Granger,Red,Women's Strawweight
+08/06/2022,Mayra Bueno Silva,Stephanie Egger,Red,Women's Bantamweight
+07/30/2022,Amanda Nunes,Julianna Pena,Red,UFC Women's Bantamweight Title
+07/30/2022,Brandon Moreno,Kai Kara-France,Red,UFC Interim Flyweight Title
+07/30/2022,Sergei Pavlovich,Derrick Lewis,Red,Heavyweight
+07/30/2022,Alexandre Pantoja,Alex Perez,Red,Flyweight
+07/30/2022,Magomed Ankalaev,Anthony Smith,Red,Light Heavyweight
+07/30/2022,Alex Morono,Matthew Semelsberger,Red,Welterweight
+07/30/2022,Drew Dober,Rafael Alves,Red,Lightweight
+07/30/2022,Drakkar Klose,Rafa Garcia,Red,Lightweight
+07/30/2022,Michael Morales,Adam Fugitt,Red,Welterweight
+07/30/2022,Joselyne Edwards,Ji Yeon Kim,Red,Women's Bantamweight
+07/30/2022,Nicolae Negumereanu,Ihor Potieria,Red,Light Heavyweight
+07/30/2022,Orion Cosce,Blood Diamond,Red,Welterweight
+07/23/2022,Curtis Blaydes,Tom Aspinall,Red,Heavyweight
+07/23/2022,Jack Hermansson,Chris Curtis,Red,Middleweight
+07/23/2022,Paddy Pimblett,Jordan Leavitt,Red,Lightweight
+07/23/2022,Nikita Krylov,Alexander Gustafsson,Red,Light Heavyweight
+07/23/2022,Molly McCann,Hannah Goldy,Red,Women's Flyweight
+07/23/2022,Volkan Oezdemir,Paul Craig,Red,Light Heavyweight
+07/23/2022,Ludovit Klein,Mason Jones,Red,Lightweight
+07/23/2022,Marc Diakiese,Damir Hadzovic,Red,Lightweight
+07/23/2022,Nathaniel Wood,Charles Rosa,Red,Featherweight
+07/23/2022,Jonathan Pearce,Makwan Amirkhani,Red,Featherweight
+07/23/2022,Muhammad Mokaev,Charles Johnson,Red,Flyweight
+07/23/2022,Jai Herbert,Kyle Nelson,Red,Lightweight
+07/23/2022,Victoria Leonardo,Mandy Bohm,Red,Women's Flyweight
+07/23/2022,Nicolas Dalby,Claudio Silva,Red,Welterweight
+07/16/2022,Yair Rodriguez,Brian Ortega,Red,Featherweight
+07/16/2022,Amanda Lemos,Michelle Waterson-Gomez,Red,Women's Strawweight
+07/16/2022,Li Jingliang,Muslim Salikhov,Red,Welterweight
+07/16/2022,Matt Schnell,Sumudaerji,Red,Flyweight
+07/16/2022,Shane Burgos,Charles Jourdain,Red,Featherweight
+07/16/2022,Lauren Murphy,Miesha Tate,Red,Women's Flyweight
+07/16/2022,Punahele Soriano,Dalcha Lungiambula,Red,Middleweight
+07/16/2022,Ricky Simon,Jack Shore,Red,Bantamweight
+07/16/2022,Bill Algeo,Herbert Burns,Red,Featherweight
+07/16/2022,Dustin Jacoby,Da Woon Jung,Red,Light Heavyweight
+07/16/2022,Dustin Stoltzfus,Dwight Grant,Red,Middleweight
+07/16/2022,Emily Ducote,Jessica Penne,Red,Women's Strawweight
+07/09/2022,Rafael Fiziev,Rafael Dos Anjos,Red,Lightweight
+07/09/2022,Caio Borralho,Armen Petrosyan,Red,Middleweight
+07/09/2022,Said Nurmagomedov,Douglas Silva de Andrade,Red,Bantamweight
+07/09/2022,Chase Sherman,Jared Vanderaa,Red,Heavyweight
+07/09/2022,Aiemann Zahabi,Ricky Turcios,Red,Bantamweight
+07/09/2022,Jamie Mullarkey,Michael Johnson,Red,Lightweight
+07/09/2022,Cody Brundage,Tresean Gore,Red,Middleweight
+07/09/2022,Antonina Shevchenko,Cortney Casey,Red,Women's Flyweight
+07/09/2022,David Onama,Garrett Armfield,Red,Featherweight
+07/09/2022,Kennedy Nzechukwu,Karl Roberson,Red,Light Heavyweight
+07/09/2022,Saidyokub Kakhramonov,Ronnie Lawrence,Red,Bantamweight
+07/02/2022,Israel Adesanya,Jared Cannonier,Red,UFC Middleweight Title
+07/02/2022,Alexander Volkanovski,Max Holloway,Red,UFC Featherweight Title
+07/02/2022,Alex Pereira,Sean Strickland,Red,Middleweight
+07/02/2022,Bryan Barberena,Robbie Lawler,Red,Welterweight
+07/02/2022,Jalin Turner,Brad Riddell,Red,Lightweight
+07/02/2022,Jim Miller,Donald Cerrone,Red,Welterweight
+07/02/2022,Ian Machado Garry,Gabe Green,Red,Welterweight
+07/02/2022,Dricus Du Plessis,Brad Tavares,Red,Middleweight
+07/02/2022,Andre Muniz,Uriah Hall,Red,Middleweight
+07/02/2022,Maycee Barber,Jessica Eye,Red,Women's Flyweight
+07/02/2022,Julija Stoliarenko,Jessica-Rose Clark,Red,Women's Bantamweight
+06/25/2022,Mateusz Gamrot,Arman Tsarukyan,Red,Lightweight
+06/25/2022,Shavkat Rakhmonov,Neil Magny,Red,Welterweight
+06/25/2022,Josh Parisian,Alan Baudot,Red,Heavyweight
+06/25/2022,Thiago Moises,Christos Giagos,Red,Lightweight
+06/25/2022,Umar Nurmagomedov,Nate Maness,Red,Bantamweight
+06/25/2022,Chris Curtis,Rodolfo Vieira,Red,Middleweight
+06/25/2022,Carlos Ulberg,Tafon Nchukwi,Red,Light Heavyweight
+06/25/2022,Shayilan Nuerdanbieke,TJ Brown,Red,Featherweight
+06/25/2022,Sergey Morozov,Raulian Paiva,Red,Bantamweight
+06/25/2022,Cody Durden,JP Buys,Red,Flyweight
+06/25/2022,Mario Bautista,Brian Kelleher,Red,Bantamweight
+06/25/2022,Vanessa Demopoulos,Jinh Yu Frey,Red,Women's Strawweight
+06/18/2022,Josh Emmett,Calvin Kattar,Red,Featherweight
+06/18/2022,Kevin Holland,Tim Means,Red,Welterweight
+06/18/2022,Joaquin Buckley,Albert Duraev,Red,Middleweight
+06/18/2022,Damir Ismagulov,Guram Kutateladze,Red,Lightweight
+06/18/2022,Gregory Rodrigues,Julian Marquez,Red,Middleweight
+06/18/2022,Adrian Yanez,Tony Kelley,Red,Bantamweight
+06/18/2022,Natalia Silva,Jasmine Jasudavicius,Red,Women's Flyweight
+06/18/2022,Jeremiah Wells,Court McGee,Red,Welterweight
+06/18/2022,Ricardo Ramos,Danny Chavez,Red,Featherweight
+06/18/2022,Maria Oliveira,Gloria de Paula,Red,Women's Strawweight
+06/18/2022,Cody Stamann,Eddie Wineland,Red,Bantamweight
+06/18/2022,Phil Hawes,Deron Winn,Red,Middleweight
+06/18/2022,Roman Dolidze,Kyle Daukaus,Red,Middleweight
+06/11/2022,Jiri Prochazka,Glover Teixeira,Red,UFC Light Heavyweight Title
+06/11/2022,Valentina Shevchenko,Taila Santos,Red,UFC Women's Flyweight Title
+06/11/2022,Zhang Weili,Joanna Jedrzejczyk,Red,Women's Strawweight
+06/11/2022,Jake Matthews,Andre Fialho,Red,Welterweight
+06/11/2022,Jack Della Maddalena,Ramazan Emeev,Red,Welterweight
+06/11/2022,Josh Culibao,SeungWoo Choi,Red,Featherweight
+06/11/2022,Maheshate,Steve Garcia,Red,Lightweight
+06/11/2022,Brendan Allen,Jacob Malkoun,Red,Middleweight
+06/11/2022,Kyung Ho Kang,Batgerel Danaa,Red,Bantamweight
+06/11/2022,Silvana Gomez Juarez,Liang Na,Red,Women's Strawweight
+06/11/2022,Joselyne Edwards,Ramona Pascual,Red,Women's Featherweight
+06/04/2022,Alexander Volkov,Jairzinho Rozenstruik,Red,Heavyweight
+06/04/2022,Movsar Evloev,Dan Ige,Red,Featherweight
+06/04/2022,Lucas Almeida,Michael Trizano,Red,Featherweight
+06/04/2022,Karine Silva,Poliana Botelho,Red,Women's Flyweight
+06/04/2022,Ode Osbourne,Zarrukh Adashev,Red,Flyweight
+06/04/2022,Alonzo Menifield,Askar Mozharov,Red,Light Heavyweight
+06/04/2022,Karolina Kowalkiewicz,Felice Herrig,Red,Women's Strawweight
+06/04/2022,Joe Solecki,Alex Da Silva,Red,Lightweight
+06/04/2022,Damon Jackson,Dan Argueta,Red,Featherweight
+06/04/2022,Benoit Saint Denis,Niklas Stolze,Red,Lightweight
+06/04/2022,Tony Gravely,Johnny Munoz,Red,Bantamweight
+06/04/2022,Jeff Molina,Zhalgas Zhumagulov,Red,Flyweight
+06/04/2022,Rinat Fakhretdinov,Andreas Michailidis,Red,Welterweight
+06/04/2022,Erin Blanchfield,JJ Aldrich,Red,Women's Flyweight
+05/21/2022,Ketlen Vieira,Holly Holm,Red,Women's Bantamweight
+05/21/2022,Michel Pereira,Santiago Ponzinibbio,Red,Welterweight
+05/21/2022,Chidi Njokuani,Dusko Todorovic,Red,Middleweight
+05/21/2022,Tabatha Ricci,Polyana Viana,Red,Women's Strawweight
+05/21/2022,JunYong Park,Eryk Anders,Red,Middleweight
+05/21/2022,Joseph Holmes,Alen Amedovski,Red,Middleweight
+05/21/2022,Jailton Almeida,Parker Porter,Red,Heavyweight
+05/21/2022,Uros Medic,Omar Morales,Red,Lightweight
+05/21/2022,Jonathan Martinez,Vince Morales,Red,Bantamweight
+05/21/2022,Chase Hooper,Felipe Colares,Red,Featherweight
+05/21/2022,Sam Hughes,Elise Reed,Red,Women's Strawweight
+05/14/2022,Jan Blachowicz,Aleksandar Rakic,Red,Light Heavyweight
+05/14/2022,Ryan Spann,Ion Cutelaba,Red,Light Heavyweight
+05/14/2022,Davey Grant,Louis Smolka,Red,Bantamweight
+05/14/2022,Katlyn Cerminara,Amanda Ribas,Red,Women's Flyweight
+05/14/2022,Manuel Torres,Frank Camacho,Red,Lightweight
+05/14/2022,Allan Nascimento,Jake Hadley,Red,Flyweight
+05/14/2022,Viviane Araujo,Andrea Lee,Red,Women's Flyweight
+05/14/2022,Michael Johnson,Alan Patrick,Red,Lightweight
+05/14/2022,Virna Jandiroba,Angela Hill,Red,Women's Strawweight
+05/14/2022,Tatsuro Taira,Carlos Candelario,Red,Flyweight
+05/14/2022,Andre Petroski,Nick Maximov,Red,Middleweight
+05/07/2022,Charles Oliveira,Justin Gaethje,Red,Lightweight
+05/07/2022,Carla Esparza,Rose Namajunas,Red,UFC Women's Strawweight Title
+05/07/2022,Michael Chandler,Tony Ferguson,Red,Lightweight
+05/07/2022,Ovince Saint Preux,Mauricio Rua,Red,Light Heavyweight
+05/07/2022,Randy Brown,Khaos Williams,Red,Welterweight
+05/07/2022,Francisco Trinaldo,Danny Roberts,Red,Welterweight
+05/07/2022,Macy Chiasson,Norma Dumont,Red,Women's Featherweight
+05/07/2022,Brandon Royval,Matt Schnell,Red,Flyweight
+05/07/2022,Blagoy Ivanov,Marcos Rogerio de Lima,Red,Heavyweight
+05/07/2022,Andre Fialho,Cameron VanCamp,Red,Welterweight
+05/07/2022,Tracy Cortez,Melissa Gatto,Red,Women's Flyweight
+05/07/2022,CJ Vergara,Kleydson Rodrigues,Red,Flyweight
+05/07/2022,Loopy Godinez,Ariane Carnelossi,Red,Women's Strawweight
+05/07/2022,Journey Newson,Fernie Garcia,Red,Bantamweight
+04/30/2022,Marlon Vera,Rob Font,Red,Bantamweight
+04/30/2022,Andrei Arlovski,Jake Collier,Red,Heavyweight
+04/30/2022,Joanderson Brito,Andre Fili,Red,Featherweight
+04/30/2022,Grant Dawson,Jared Gordon,Red,Lightweight
+04/30/2022,Darren Elkins,Tristan Connelly,Red,Featherweight
+04/30/2022,Krzysztof Jotko,Gerald Meerschaert,Red,Middleweight
+04/30/2022,Alexandr Romanov,Chase Sherman,Red,Heavyweight
+04/30/2022,Francisco Figueiredo,Daniel Lacerda,Red,Flyweight
+04/30/2022,Gabe Green,Yohan Lainesse,Red,Welterweight
+04/30/2022,Natan Levy,Mike Breeden,Red,Lightweight
+04/30/2022,Shanna Young,Gina Mazany,Red,Women's Flyweight
+04/23/2022,Jessica Andrade,Amanda Lemos,Red,Women's Strawweight
+04/23/2022,Claudio Puelles,Clay Guida,Red,Lightweight
+04/23/2022,Maycee Barber,Montana De La Rosa,Red,Women's Flyweight
+04/23/2022,Charles Jourdain,Lando Vannata,Red,Featherweight
+04/23/2022,Marc-Andre Barriault,Jordan Wright,Red,Catch Weight
+04/23/2022,Sergey Khandozhko,Dwight Grant,Red,Welterweight
+04/23/2022,Tyson Pedro,Ike Villanueva,Red,Light Heavyweight
+04/23/2022,Aoriqileng,Cameron Else,Red,Bantamweight
+04/23/2022,Preston Parsons,Evan Elder,Red,Welterweight
+04/23/2022,Philipe Lins,Marcin Prachnio,Red,Light Heavyweight
+04/23/2022,Mike Jackson,Dean Barry,Red,Welterweight
+04/16/2022,Belal Muhammad,Vicente Luque,Red,Welterweight
+04/16/2022,Caio Borralho,Gadzhi Omargadzhiev,Red,Middleweight
+04/16/2022,Andre Fialho,Miguel Baeza,Red,Welterweight
+04/16/2022,Mayra Bueno Silva,Wu Yanan,Red,Women's Bantamweight
+04/16/2022,Pat Sabatini,TJ Laramie,Red,Featherweight
+04/16/2022,Mounir Lazzez,Ange Loosa,Red,Welterweight
+04/16/2022,Devin Clark,William Knight,Red,Heavyweight
+04/16/2022,Pannie Kianzad,Lina Lansberg,Red,Women's Bantamweight
+04/16/2022,Drakkar Klose,Brandon Jenkins,Red,Lightweight
+04/16/2022,Rafa Garcia,Jesse Ronson,Red,Lightweight
+04/16/2022,Martin Buday,Chris Barnett,Red,Heavyweight
+04/16/2022,Jordan Leavitt,Trey Ogden,Red,Lightweight
+04/16/2022,Sam Hughes,Istela Nunes,Red,Women's Strawweight
+04/16/2022,Alatengheili,Kevin Croom,Red,Bantamweight
+04/09/2022,Alexander Volkanovski,Chan Sung Jung,Red,UFC Featherweight Title
+04/09/2022,Aljamain Sterling,Petr Yan,Red,UFC Bantamweight Title
+04/09/2022,Khamzat Chimaev,Gilbert Burns,Red,Welterweight
+04/09/2022,Mackenzie Dern,Tecia Torres,Red,Women's Strawweight
+04/09/2022,Mark Madsen,Vinc Pichel,Red,Lightweight
+04/09/2022,Ian Machado Garry,Darian Weeks,Red,Welterweight
+04/09/2022,Anthony Hernandez,Josh Fremd,Red,Middleweight
+04/09/2022,Raquel Pennington,Aspen Ladd,Red,Women's Bantamweight
+04/09/2022,Mike Malott,Mickey Gall,Red,Welterweight
+04/09/2022,Aleksei Oleinik,Jared Vanderaa,Red,Heavyweight
+04/09/2022,Piera Rodriguez,Kay Hansen,Red,Women's Strawweight
+04/09/2022,Julio Arce,Daniel Santos,Red,Bantamweight
+03/26/2022,Curtis Blaydes,Chris Daukaus,Red,Heavyweight
+03/26/2022,Alexa Grasso,Joanne Wood,Red,Women's Flyweight
+03/26/2022,Bryan Barberena,Matt Brown,Red,Welterweight
+03/26/2022,Kai Kara-France,Askar Askarov,Red,Flyweight
+03/26/2022,Neil Magny,Max Griffin,Red,Welterweight
+03/26/2022,Marc Diakiese,Viacheslav Borshchev,Red,Lightweight
+03/26/2022,Sara McMann,Karol Rosa,Red,Women's Bantamweight
+03/26/2022,Chris Gutierrez,Batgerel Danaa,Red,Bantamweight
+03/26/2022,Aliaskhab Khizriev,Denis Tiuliulin,Red,Middleweight
+03/26/2022,Manon Fiorot,Jennifer Maia,Red,Women's Flyweight
+03/26/2022,Matheus Nicolau,David Dvorak,Red,Flyweight
+03/26/2022,Luis Saldana,Bruno Souza,Red,Featherweight
+03/19/2022,Tom Aspinall,Alexander Volkov,Red,Heavyweight
+03/19/2022,Arnold Allen,Dan Hooker,Red,Featherweight
+03/19/2022,Paddy Pimblett,Kazula Vargas,Red,Lightweight
+03/19/2022,Gunnar Nelson,Takashi Sato,Red,Welterweight
+03/19/2022,Molly McCann,Luana Carolina,Red,Women's Flyweight
+03/19/2022,Ilia Topuria,Jai Herbert,Red,Lightweight
+03/19/2022,Makwan Amirkhani,Mike Grundy,Red,Featherweight
+03/19/2022,Sergei Pavlovich,Shamil Abdurakhimov,Red,Heavyweight
+03/19/2022,Paul Craig,Nikita Krylov,Red,Light Heavyweight
+03/19/2022,Jack Shore,Timur Valiev,Red,Bantamweight
+03/19/2022,Elise Reed,Cory McKenna,Red,Women's Strawweight
+03/19/2022,Muhammad Mokaev,Cody Durden,Red,Flyweight
+03/12/2022,Magomed Ankalaev,Thiago Santos,Red,Light Heavyweight
+03/12/2022,Song Yadong,Marlon Moraes,Red,Bantamweight
+03/12/2022,Sodiq Yusuff,Alex Caceres,Red,Featherweight
+03/12/2022,Khalil Rountree Jr.,Karl Roberson,Red,Light Heavyweight
+03/12/2022,Drew Dober,Terrance McKinney,Red,Lightweight
+03/12/2022,Alex Pereira,Bruno Silva,Red,Middleweight
+03/12/2022,Matthew Semelsberger,AJ Fletcher,Red,Welterweight
+03/12/2022,JJ Aldrich,Gillian Robertson,Red,Women's Flyweight
+03/12/2022,Javid Basharat,Trevin Jones,Red,Bantamweight
+03/12/2022,Damon Jackson,Kamuela Kirk,Red,Featherweight
+03/12/2022,Miranda Maverick,Sabina Mazo,Red,Women's Flyweight
+03/12/2022,Cody Brundage,Dalcha Lungiambula,Red,Middleweight
+03/12/2022,Guido Cannetti,Kris Moutinho,Red,Bantamweight
+03/12/2022,Azamat Murzakanov,Tafon Nchukwi,Red,Light Heavyweight
+03/05/2022,Colby Covington,Jorge Masvidal,Red,Welterweight
+03/05/2022,Rafael Dos Anjos,Renato Moicano,Red,Catch Weight
+03/05/2022,Bryce Mitchell,Edson Barboza,Red,Featherweight
+03/05/2022,Kevin Holland,Alex Oliveira,Red,Welterweight
+03/05/2022,Serghei Spivac,Greg Hardy,Red,Heavyweight
+03/05/2022,Jalin Turner,Jamie Mullarkey,Red,Lightweight
+03/05/2022,Marina Rodriguez,Yan Xiaonan,Red,Women's Strawweight
+03/05/2022,Nicolae Negumereanu,Kennedy Nzechukwu,Red,Light Heavyweight
+03/05/2022,Maryna Moroz,Mariya Agapova,Red,Women's Flyweight
+03/05/2022,Umar Nurmagomedov,Brian Kelleher,Red,Featherweight
+03/05/2022,Tim Elliott,Tagir Ulanbekov,Red,Flyweight
+03/05/2022,Ludovit Klein,Devonte Smith,Red,Lightweight
+03/05/2022,Dustin Jacoby,Michal Oleksiejczuk,Red,Light Heavyweight
+02/26/2022,Islam Makhachev,Bobby Green,Red,Catch Weight
+02/26/2022,Wellington Turman,Misha Cirkunov,Red,Middleweight
+02/26/2022,Priscila Cachoeira,Ji Yeon Kim,Red,Women's Flyweight
+02/26/2022,Arman Tsarukyan,Joel Alvarez,Red,Lightweight
+02/26/2022,Armen Petrosyan,Gregory Rodrigues,Red,Middleweight
+02/26/2022,Ignacio Bahamondes,Rongzhu,Red,Lightweight
+02/26/2022,Josiane Nunes,Ramona Pascual,Red,Women's Featherweight
+02/26/2022,Terrance McKinney,Fares Ziam,Red,Lightweight
+02/26/2022,Jonathan Martinez,Alejandro Perez,Red,Featherweight
+02/26/2022,Ramiz Brahimaj,Micheal Gillmore,Red,Welterweight
+02/26/2022,Carlos Hernandez,Victor Altamirano,Red,Flyweight
+02/19/2022,Jamahal Hill,Johnny Walker,Red,Light Heavyweight
+02/19/2022,Kyle Daukaus,Jamie Pickett,Red,Catch Weight
+02/19/2022,Parker Porter,Alan Baudot,Red,Heavyweight
+02/19/2022,Jim Miller,Nikolas Motta,Red,Lightweight
+02/19/2022,Joaquin Buckley,Abdul Razak Alhassan,Red,Middleweight
+02/19/2022,David Onama,Gabriel Benitez,Red,Featherweight
+02/19/2022,Stephanie Egger,Jessica-Rose Clark,Red,Women's Bantamweight
+02/19/2022,Chas Skelly,Mark Striegl,Red,Featherweight
+02/19/2022,Gloria de Paula,Diana Belbita,Red,Women's Strawweight
+02/19/2022,Chad Anheliger,Jesse Strader,Red,Bantamweight
+02/19/2022,Jonathan Pearce,Christian Rodriguez,Red,Featherweight
+02/19/2022,Mario Bautista,Jay Perrin,Red,Bantamweight
+02/12/2022,Israel Adesanya,Robert Whittaker,Red,UFC Middleweight Title
+02/12/2022,Tai Tuivasa,Derrick Lewis,Red,Heavyweight
+02/12/2022,Jared Cannonier,Derek Brunson,Red,Middleweight
+02/12/2022,Renato Moicano,Alexander Hernandez,Red,Lightweight
+02/12/2022,Bobby Green,Nasrat Haqparast,Red,Lightweight
+02/12/2022,Andrei Arlovski,Jared Vanderaa,Red,Heavyweight
+02/12/2022,Casey O'Neill,Roxanne Modafferi,Red,Women's Flyweight
+02/12/2022,Kyler Phillips,Marcelo Rojo,Red,Bantamweight
+02/12/2022,Carlos Ulberg,Fabio Cherant,Red,Light Heavyweight
+02/12/2022,Ronnie Lawrence,Mana Martinez,Red,Bantamweight
+02/12/2022,Jacob Malkoun,AJ Dobson,Red,Middleweight
+02/12/2022,Douglas Silva de Andrade,Sergey Morozov,Red,Bantamweight
+02/12/2022,Jeremiah Wells,Blood Diamond,Red,Welterweight
+02/12/2022,Maxim Grishin,William Knight,Red,Heavyweight
+02/05/2022,Sean Strickland,Jack Hermansson,Red,Middleweight
+02/05/2022,Nick Maximov,Punahele Soriano,Red,Middleweight
+02/05/2022,Shavkat Rakhmonov,Carlston Harris,Red,Welterweight
+02/05/2022,Brendan Allen,Sam Alvey,Red,Light Heavyweight
+02/05/2022,Bryan Battle,Tresean Gore,Red,Middleweight
+02/05/2022,Julian Erosa,Steven Peterson,Red,Featherweight
+02/05/2022,John Castaneda,Miles Johns,Red,Bantamweight
+02/05/2022,Hakeem Dawodu,Michael Trizano,Red,Featherweight
+02/05/2022,Chidi Njokuani,Marc-Andre Barriault,Red,Middleweight
+02/05/2022,Alexis Davis,Julija Stoliarenko,Red,Women's Bantamweight
+02/05/2022,Jailton Almeida,Danilo Marques,Red,Light Heavyweight
+02/05/2022,Phil Rowe,Jason Witt,Red,Welterweight
+02/05/2022,Malcolm Gordon,Denys Bondar,Red,Flyweight
+01/22/2022,Francis Ngannou,Ciryl Gane,Red,UFC Heavyweight Title
+01/22/2022,Deiveson Figueiredo,Brandon Moreno,Red,UFC Flyweight Title
+01/22/2022,Michel Pereira,Andre Fialho,Red,Welterweight
+01/22/2022,Said Nurmagomedov,Cody Stamann,Red,Bantamweight
+01/22/2022,Michael Morales,Trevin Giles,Red,Welterweight
+01/22/2022,Victor Henry,Raoni Barcelos,Red,Bantamweight
+01/22/2022,Jack Della Maddalena,Pete Rodriguez,Red,Welterweight
+01/22/2022,Tony Gravely,Saimon Oliveira,Red,Bantamweight
+01/22/2022,Matt Frevola,Genaro Valdez,Red,Lightweight
+01/22/2022,Vanessa Demopoulos,Silvana Gomez Juarez,Red,Women's Strawweight
+01/22/2022,Jasmine Jasudavicius,Kay Hansen,Red,Women's Flyweight
+01/15/2022,Calvin Kattar,Giga Chikadze,Red,Featherweight
+01/15/2022,Jake Collier,Chase Sherman,Red,Heavyweight
+01/15/2022,Brandon Royval,Rogerio Bontorin,Red,Flyweight
+01/15/2022,Katlyn Cerminara,Jennifer Maia,Red,Women's Flyweight
+01/15/2022,Viacheslav Borshchev,Dakota Bush,Red,Lightweight
+01/15/2022,Bill Algeo,Joanderson Brito,Red,Featherweight
+01/15/2022,Jamie Pickett,Joseph Holmes,Red,Middleweight
+01/15/2022,Court McGee,Ramiz Brahimaj,Red,Welterweight
+01/15/2022,Brian Kelleher,Kevin Croom,Red,Featherweight
+01/15/2022,TJ Brown,Charles Rosa,Red,Lightweight
+12/18/2021,Derrick Lewis,Chris Daukaus,Red,Heavyweight
+12/18/2021,Belal Muhammad,Stephen Thompson,Red,Welterweight
+12/18/2021,Amanda Lemos,Angela Hill,Red,Women's Strawweight
+12/18/2021,Ricky Simon,Raphael Assuncao,Red,Bantamweight
+12/18/2021,Mateusz Gamrot,Diego Ferreira,Red,Lightweight
+12/18/2021,Cub Swanson,Darren Elkins,Red,Featherweight
+12/18/2021,Gerald Meerschaert,Dustin Stoltzfus,Red,Middleweight
+12/18/2021,Justin Tafa,Harry Hunsucker,Red,Heavyweight
+12/18/2021,Melissa Gatto,Sijara Eubanks,Red,Women's Flyweight
+12/18/2021,Charles Jourdain,Andre Ewell,Red,Featherweight
+12/18/2021,Raquel Pennington,Macy Chiasson,Red,Women's Featherweight
+12/18/2021,Don'Tale Mayes,Josh Parisian,Red,Heavyweight
+12/18/2021,Jordan Leavitt,Matt Sayles,Red,Lightweight
+12/11/2021,Charles Oliveira,Dustin Poirier,Red,UFC Lightweight Title
+12/11/2021,Julianna Pena,Amanda Nunes,Red,UFC Women's Bantamweight Title
+12/11/2021,Geoff Neal,Santiago Ponzinibbio,Red,Welterweight
+12/11/2021,Kai Kara-France,Cody Garbrandt,Red,Flyweight
+12/11/2021,Sean O'Malley,Raulian Paiva,Red,Bantamweight
+12/11/2021,Josh Emmett,Dan Ige,Red,Featherweight
+12/11/2021,Dominick Cruz,Pedro Munhoz,Red,Bantamweight
+12/11/2021,Tai Tuivasa,Augusto Sakai,Red,Heavyweight
+12/11/2021,Bruno Silva,Jordan Wright,Red,Middleweight
+12/11/2021,Andre Muniz,Eryk Anders,Red,Middleweight
+12/11/2021,Erin Blanchfield,Miranda Maverick,Red,Women's Flyweight
+12/11/2021,Ryan Hall,Darrick Minner,Red,Featherweight
+12/11/2021,Tony Kelley,Randy Costa,Red,Bantamweight
+12/11/2021,Gillian Robertson,Priscila Cachoeira,Red,Women's Flyweight
+12/04/2021,Jose Aldo,Rob Font,Red,Bantamweight
+12/04/2021,Rafael Fiziev,Brad Riddell,Red,Lightweight
+12/04/2021,Jamahal Hill,Jimmy Crute,Red,Light Heavyweight
+12/04/2021,Clay Guida,Leonardo Santos,Red,Lightweight
+12/04/2021,Chris Curtis,Brendan Allen,Red,Middleweight
+12/04/2021,Alex Morono,Mickey Gall,Red,Welterweight
+12/04/2021,Dusko Todorovic,Maki Pitolo,Red,Middleweight
+12/04/2021,Manel Kape,Zhalgas Zhumagulov,Red,Flyweight
+12/04/2021,Bryan Barberena,Darian Weeks,Red,Welterweight
+12/04/2021,Cheyanne Vlismas,Mallory Martin,Red,Women's Strawweight
+12/04/2021,William Knight,Alonzo Menifield,Red,Light Heavyweight
+12/04/2021,Claudio Puelles,Chris Gruetzemacher,Red,Lightweight
+12/04/2021,Vince Morales,Louis Smolka,Red,Bantamweight
+11/20/2021,Ketlen Vieira,Miesha Tate,Red,Women's Bantamweight
+11/20/2021,Sean Brady,Michael Chiesa,Red,Welterweight
+11/20/2021,Taila Santos,Joanne Wood,Red,Women's Flyweight
+11/20/2021,Rani Yahya,Kyung Ho Kang,Red,Bantamweight
+11/20/2021,Adrian Yanez,Davey Grant,Red,Bantamweight
+11/20/2021,Pat Sabatini,Tucker Lutz,Red,Featherweight
+11/20/2021,Rafa Garcia,Natan Levy,Red,Lightweight
+11/20/2021,Loopy Godinez,Loma Lookboonmee,Red,Women's Strawweight
+11/20/2021,Cody Durden,Aoriqileng,Red,Flyweight
+11/20/2021,Shayilan Nuerdanbieke,Sean Soriano,Red,Featherweight
+11/20/2021,Luana Pinheiro,Sam Hughes,Red,Women's Strawweight
+11/13/2021,Max Holloway,Yair Rodriguez,Red,Featherweight
+11/13/2021,Marcos Rogerio de Lima,Ben Rothwell,Red,Heavyweight
+11/13/2021,Felicia Spencer,Leah Letson,Red,Women's Featherweight
+11/13/2021,Khaos Williams,Miguel Baeza,Red,Welterweight
+11/13/2021,Song Yadong,Julio Arce,Red,Bantamweight
+11/13/2021,Joel Alvarez,Thiago Moises,Red,Lightweight
+11/13/2021,Andrea Lee,Cynthia Calvillo,Red,Women's Flyweight
+11/13/2021,Sean Woodson,Collin Anglin,Red,Featherweight
+11/13/2021,Cortney Casey,Liana Jojua,Red,Women's Flyweight
+11/13/2021,Rafael Alves,Marc Diakiese,Red,Lightweight
+11/13/2021,Da Woon Jung,Kennedy Nzechukwu,Red,Light Heavyweight
+11/06/2021,Kamaru Usman,Colby Covington,Red,UFC Welterweight Title
+11/06/2021,Rose Namajunas,Zhang Weili,Red,UFC Women's Strawweight Title
+11/06/2021,Marlon Vera,Frankie Edgar,Red,Bantamweight
+11/06/2021,Shane Burgos,Billy Quarantillo,Red,Featherweight
+11/06/2021,Justin Gaethje,Michael Chandler,Red,Lightweight
+11/06/2021,Alex Pereira,Andreas Michailidis,Red,Middleweight
+11/06/2021,Bobby Green,Al Iaquinta,Red,Lightweight
+11/06/2021,Chris Curtis,Phil Hawes,Red,Middleweight
+11/06/2021,Nassourdine Imavov,Edmen Shahbazyan,Red,Middleweight
+11/06/2021,Ian Machado Garry,Jordan Williams,Red,Welterweight
+11/06/2021,Chris Barnett,Gian Villante,Red,Heavyweight
+11/06/2021,Dustin Jacoby,John Allan,Red,Light Heavyweight
+11/06/2021,Melsik Baghdasaryan,Bruno Souza,Red,Featherweight
+11/06/2021,Ode Osbourne,CJ Vergara,Red,Flyweight
+10/30/2021,Glover Teixeira,Jan Blachowicz,Red,UFC Light Heavyweight Title
+10/30/2021,Petr Yan,Cory Sandhagen,Red,UFC Interim Bantamweight Title
+10/30/2021,Islam Makhachev,Dan Hooker,Red,Lightweight
+10/30/2021,Alexander Volkov,Marcin Tybura,Red,Heavyweight
+10/30/2021,Khamzat Chimaev,Li Jingliang,Red,Welterweight
+10/30/2021,Magomed Ankalaev,Volkan Oezdemir,Red,Light Heavyweight
+10/30/2021,Amanda Ribas,Virna Jandiroba,Red,Women's Strawweight
+10/30/2021,Zubaira Tukhugov,Ricardo Ramos,Red,Featherweight
+10/30/2021,Albert Duraev,Roman Kopylov,Red,Middleweight
+10/30/2021,Elizeu Zaleski dos Santos,Benoit Saint Denis,Red,Welterweight
+10/30/2021,Michal Oleksiejczuk,Shamil Gamzatov,Red,Light Heavyweight
+10/30/2021,Lerone Murphy,Makwan Amirkhani,Red,Featherweight
+10/30/2021,Andre Petroski,Hu Yaozong,Red,Middleweight
+10/30/2021,Tagir Ulanbekov,Allan Nascimento,Red,Flyweight
+10/23/2021,Marvin Vettori,Paulo Costa,Red,Light Heavyweight
+10/23/2021,Jessica-Rose Clark,Joselyne Edwards,Red,Women's Bantamweight
+10/23/2021,Alex Caceres,SeungWoo Choi,Red,Featherweight
+10/23/2021,Francisco Trinaldo,Dwight Grant,Red,Welterweight
+10/23/2021,Nicolae Negumereanu,Ike Villanueva,Red,Light Heavyweight
+10/23/2021,Gregory Rodrigues,JunYong Park,Red,Middleweight
+10/23/2021,Mason Jones,David Onama,Red,Lightweight
+10/23/2021,Tabatha Ricci,Maria Oliveira,Red,Women's Strawweight
+10/23/2021,Jamie Pickett,Laureano Staropoli,Red,Middleweight
+10/23/2021,Jai Herbert,Khama Worthy,Red,Lightweight
+10/23/2021,Jeff Molina,Daniel Lacerda,Red,Flyweight
+10/23/2021,Randa Markos,Livinha Souza,Red,Women's Strawweight
+10/23/2021,Jonathan Martinez,Zviad Lazishvili,Red,Bantamweight
+10/16/2021,Norma Dumont,Aspen Ladd,Red,Women's Featherweight
+10/16/2021,Andrei Arlovski,Carlos Felipe,Red,Heavyweight
+10/16/2021,Jim Miller,Erick Gonzalez,Red,Lightweight
+10/16/2021,Manon Fiorot,Mayra Bueno Silva,Red,Women's Flyweight
+10/16/2021,Nate Landwehr,Ludovit Klein,Red,Featherweight
+10/16/2021,Bruno Silva,Andrew Sanchez,Red,Middleweight
+10/16/2021,Danny Roberts,Ramazan Emeev,Red,Welterweight
+10/16/2021,Luana Carolina,Loopy Godinez,Red,Women's Flyweight
+10/16/2021,Batgerel Danaa,Brandon Davis,Red,Bantamweight
+10/16/2021,Ariane Carnelossi,Istela Nunes,Red,Women's Strawweight
+10/09/2021,Marina Rodriguez,Mackenzie Dern,Red,Women's Strawweight
+10/09/2021,Randy Brown,Jared Gooden,Red,Welterweight
+10/09/2021,Matheus Nicolau,Tim Elliott,Red,Flyweight
+10/09/2021,Mariya Agapova,Sabina Mazo,Red,Women's Flyweight
+10/09/2021,Chris Gutierrez,Felipe Colares,Red,Bantamweight
+10/09/2021,Alexandr Romanov,Jared Vanderaa,Red,Heavyweight
+10/09/2021,Damon Jackson,Charles Rosa,Red,Featherweight
+10/09/2021,Loopy Godinez,Silvana Gomez Juarez,Red,Women's Strawweight
+10/09/2021,Steve Garcia,Charlie Ontiveros,Red,Lightweight
+10/02/2021,Thiago Santos,Johnny Walker,Red,Light Heavyweight
+10/02/2021,Niko Price,Alex Oliveira,Red,Welterweight
+10/02/2021,Krzysztof Jotko,Misha Cirkunov,Red,Middleweight
+10/02/2021,Alexander Hernandez,Mike Breeden,Red,Lightweight
+10/02/2021,Jared Gordon,Joe Solecki,Red,Lightweight
+10/02/2021,Casey O'Neill,Antonina Shevchenko,Red,Women's Flyweight
+10/02/2021,Karol Rosa,Bethe Correia,Red,Women's Bantamweight
+10/02/2021,Jamie Mullarkey,Devonte Smith,Red,Lightweight
+10/02/2021,Douglas Silva de Andrade,Gaetano Pirrello,Red,Bantamweight
+10/02/2021,Stephanie Egger,Shanna Young,Red,Women's Bantamweight
+10/02/2021,Alejandro Perez,Johnny Eduardo,Red,Bantamweight
+09/25/2021,Alexander Volkanovski,Brian Ortega,Red,UFC Featherweight Title
+09/25/2021,Valentina Shevchenko,Lauren Murphy,Red,UFC Women's Flyweight Title
+09/25/2021,Robbie Lawler,Nick Diaz,Red,Middleweight
+09/25/2021,Curtis Blaydes,Jairzinho Rozenstruik,Red,Heavyweight
+09/25/2021,Jessica Andrade,Cynthia Calvillo,Red,Women's Flyweight
+09/25/2021,Merab Dvalishvili,Marlon Moraes,Red,Bantamweight
+09/25/2021,Dan Hooker,Nasrat Haqparast,Red,Lightweight
+09/25/2021,Chris Daukaus,Shamil Abdurakhimov,Red,Heavyweight
+09/25/2021,Taila Santos,Roxanne Modafferi,Red,Women's Flyweight
+09/25/2021,Jalin Turner,Uros Medic,Red,Lightweight
+09/25/2021,Nick Maximov,Cody Brundage,Red,Middleweight
+09/25/2021,Matthew Semelsberger,Martin Sano,Red,Welterweight
+09/25/2021,Jonathan Pearce,Omar Morales,Red,Featherweight
+09/18/2021,Anthony Smith,Ryan Spann,Red,Light Heavyweight
+09/18/2021,Ion Cutelaba,Devin Clark,Red,Light Heavyweight
+09/18/2021,Ariane Lipski,Mandy Bohm,Red,Women's Flyweight
+09/18/2021,Arman Tsarukyan,Christos Giagos,Red,Lightweight
+09/18/2021,Nate Maness,Tony Gravely,Red,Bantamweight
+09/18/2021,Joaquin Buckley,Antonio Arroyo,Red,Middleweight
+09/18/2021,Tafon Nchukwi,Mike Rodriguez,Red,Light Heavyweight
+09/18/2021,Raquel Pennington,Pannie Kianzad,Red,Women's Bantamweight
+09/18/2021,Rongzhu,Brandon Jenkins,Red,Lightweight
+09/18/2021,Montel Jackson,JP Buys,Red,Bantamweight
+09/18/2021,Erin Blanchfield,Sarah Alpar,Red,Women's Flyweight
+09/18/2021,Carlston Harris,Impa Kasanganay,Red,Welterweight
+09/18/2021,Hannah Goldy,Emily Whitmire,Red,Women's Flyweight
+09/04/2021,Derek Brunson,Darren Till,Red,Middleweight
+09/04/2021,Tom Aspinall,Serghei Spivac,Red,Heavyweight
+09/04/2021,Alex Morono,David Zawada,Red,Welterweight
+09/04/2021,Khalil Rountree Jr.,Modestas Bukauskas,Red,Light Heavyweight
+09/04/2021,Paddy Pimblett,Luigi Vendramini,Red,Lightweight
+09/04/2021,Molly McCann,Ji Yeon Kim,Red,Women's Flyweight
+09/04/2021,Jack Shore,Liudvik Sholinian,Red,Bantamweight
+09/04/2021,Julian Erosa,Charles Jourdain,Red,Catch Weight
+09/04/2021,Marc-Andre Barriault,Dalcha Lungiambula,Red,Middleweight
+08/28/2021,Giga Chikadze,Edson Barboza,Red,Featherweight
+08/28/2021,Bryan Battle,Gilbert Urbina,Red,Middleweight
+08/28/2021,Ricky Turcios,Brady Hiestand,Red,Bantamweight
+08/28/2021,Daniel Rodriguez,Kevin Lee,Red,Welterweight
+08/28/2021,Andre Petroski,Micheal Gillmore,Red,Middleweight
+08/28/2021,Gerald Meerschaert,Makhmud Muradov,Red,Middleweight
+08/28/2021,Abdul Razak Alhassan,Alessio Di Chirico,Red,Middleweight
+08/28/2021,Wellington Turman,Sam Alvey,Red,Middleweight
+08/28/2021,Dustin Jacoby,Darren Stewart,Red,Light Heavyweight
+08/28/2021,JJ Aldrich,Vanessa Demopoulos,Red,Women's Flyweight
+08/28/2021,Pat Sabatini,Jamall Emmers,Red,Featherweight
+08/28/2021,Mana Martinez,Guido Cannetti,Red,Bantamweight
+08/21/2021,Jared Cannonier,Kelvin Gastelum,Red,Middleweight
+08/21/2021,Mark Madsen,Clay Guida,Red,Lightweight
+08/21/2021,Parker Porter,Chase Sherman,Red,Heavyweight
+08/21/2021,Saidyokub Kakhramonov,Trevin Jones,Red,Bantamweight
+08/21/2021,Vinc Pichel,Austin Hubbard,Red,Lightweight
+08/21/2021,Alexandre Pantoja,Brandon Royval,Red,Flyweight
+08/21/2021,Austin Lingo,Luis Saldana,Red,Featherweight
+08/21/2021,Brian Kelleher,Domingo Pilarte,Red,Bantamweight
+08/21/2021,Josiane Nunes,Bea Malecki,Red,Women's Bantamweight
+08/21/2021,William Knight,Fabio Cherant,Red,Light Heavyweight
+08/21/2021,Ignacio Bahamondes,Roosevelt Roberts,Red,Lightweight
+08/21/2021,Ramiz Brahimaj,Sasha Palatnikov,Red,Welterweight
+08/07/2021,Ciryl Gane,Derrick Lewis,Red,UFC Interim Heavyweight Title
+08/07/2021,Jose Aldo,Pedro Munhoz,Red,Bantamweight
+08/07/2021,Vicente Luque,Michael Chiesa,Red,Welterweight
+08/07/2021,Tecia Torres,Angela Hill,Red,Women's Strawweight
+08/07/2021,Song Yadong,Casey Kenney,Red,Bantamweight
+08/07/2021,Rafael Fiziev,Bobby Green,Red,Lightweight
+08/07/2021,Vince Morales,Drako Rodriguez,Red,Bantamweight
+08/07/2021,Alonzo Menifield,Ed Herman,Red,Light Heavyweight
+08/07/2021,Jessica Penne,Karolina Kowalkiewicz,Red,Women's Strawweight
+08/07/2021,Manel Kape,Ode Osbourne,Red,Flyweight
+08/07/2021,Miles Johns,Anderson Dos Santos,Red,Bantamweight
+08/07/2021,Melissa Gatto,Victoria Leonardo,Red,Women's Flyweight
+08/07/2021,Johnny Munoz,Jamey Simmons,Red,Bantamweight
+07/31/2021,Sean Strickland,Uriah Hall,Red,Middleweight
+07/31/2021,Cheyanne Vlismas,Gloria de Paula,Red,Women's Strawweight
+07/31/2021,Jared Gooden,Niklas Stolze,Red,Welterweight
+07/31/2021,Melsik Baghdasaryan,Collin Anglin,Red,Featherweight
+07/31/2021,Jason Witt,Bryan Barberena,Red,Welterweight
+07/31/2021,Chris Gruetzemacher,Rafa Garcia,Red,Lightweight
+07/31/2021,Jinh Yu Frey,Ashley Yoder,Red,Women's Strawweight
+07/31/2021,Zarrukh Adashev,Ryan Benoit,Red,Flyweight
+07/31/2021,Phil Rowe,Orion Cosce,Red,Welterweight
+07/24/2021,TJ Dillashaw,Cory Sandhagen,Red,Bantamweight
+07/24/2021,Raulian Paiva,Kyler Phillips,Red,Bantamweight
+07/24/2021,Darren Elkins,Darrick Minner,Red,Featherweight
+07/24/2021,Maycee Barber,Miranda Maverick,Red,Women's Flyweight
+07/24/2021,Adrian Yanez,Randy Costa,Red,Bantamweight
+07/24/2021,Brendan Allen,Punahele Soriano,Red,Middleweight
+07/24/2021,Nassourdine Imavov,Ian Heinisch,Red,Middleweight
+07/24/2021,Mickey Gall,Jordan Williams,Red,Welterweight
+07/24/2021,Julio Arce,Andre Ewell,Red,Bantamweight
+07/24/2021,Sijara Eubanks,Elise Reed,Red,Women's Flyweight
+07/24/2021,Diana Belbita,Hannah Goldy,Red,Women's Strawweight
+07/17/2021,Islam Makhachev,Thiago Moises,Red,Lightweight
+07/17/2021,Miesha Tate,Marion Reneau,Red,Women's Bantamweight
+07/17/2021,Mateusz Gamrot,Jeremy Stephens,Red,Lightweight
+07/17/2021,Rodolfo Vieira,Dustin Stoltzfus,Red,Middleweight
+07/17/2021,Billy Quarantillo,Gabriel Benitez,Red,Featherweight
+07/17/2021,Daniel Rodriguez,Preston Parsons,Red,Welterweight
+07/17/2021,Amanda Lemos,Montserrat Conejo Ruiz,Red,Women's Strawweight
+07/17/2021,Sergey Morozov,Khalid Taha,Red,Bantamweight
+07/17/2021,Malcolm Gordon,Francisco Figueiredo,Red,Flyweight
+07/10/2021,Dustin Poirier,Conor McGregor,Red,Lightweight
+07/10/2021,Gilbert Burns,Stephen Thompson,Red,Welterweight
+07/10/2021,Tai Tuivasa,Greg Hardy,Red,Heavyweight
+07/10/2021,Irene Aldana,Yana Santos,Red,Women's Bantamweight
+07/10/2021,Sean O'Malley,Kris Moutinho,Red,Bantamweight
+07/10/2021,Max Griffin,Carlos Condit,Red,Welterweight
+07/10/2021,Michel Pereira,Niko Price,Red,Welterweight
+07/10/2021,Ilia Topuria,Ryan Hall,Red,Featherweight
+07/10/2021,Dricus Du Plessis,Trevin Giles,Red,Middleweight
+07/10/2021,Jennifer Maia,Jessica Eye,Red,Women's Flyweight
+07/10/2021,Brad Tavares,Omari Akhmedov,Red,Middleweight
+07/10/2021,Zhalgas Zhumagulov,Jerome Rivera,Red,Flyweight
+06/26/2021,Ciryl Gane,Alexander Volkov,Red,Heavyweight
+06/26/2021,Tanner Boser,Ovince Saint Preux,Red,Heavyweight
+06/26/2021,Timur Valiev,Raoni Barcelos,Red,Bantamweight
+06/26/2021,Tim Means,Nicolas Dalby,Red,Welterweight
+06/26/2021,Renato Moicano,Jai Herbert,Red,Lightweight
+06/26/2021,Kennedy Nzechukwu,Danilo Marques,Red,Light Heavyweight
+06/26/2021,Shavkat Rakhmonov,Michel Prazeres,Red,Welterweight
+06/26/2021,Jeremiah Wells,Warlley Alves,Red,Welterweight
+06/26/2021,Marcin Prachnio,Ike Villanueva,Red,Light Heavyweight
+06/26/2021,Julia Avila,Julija Stoliarenko,Red,Women's Bantamweight
+06/26/2021,Charles Rosa,Justin Jaynes,Red,Featherweight
+06/26/2021,Damir Hadzovic,Yancy Medeiros,Red,Lightweight
+06/19/2021,Chan Sung Jung,Dan Ige,Red,Featherweight
+06/19/2021,Serghei Spivac,Aleksei Oleinik,Red,Heavyweight
+06/19/2021,Marlon Vera,Davey Grant,Red,Bantamweight
+06/19/2021,SeungWoo Choi,Julian Erosa,Red,Featherweight
+06/19/2021,Bruno Silva,Wellington Turman,Red,Middleweight
+06/19/2021,Matt Brown,Dhiego Lima,Red,Welterweight
+06/19/2021,Nicolae Negumereanu,Aleksa Camur,Red,Light Heavyweight
+06/19/2021,Virna Jandiroba,Kanako Murata,Red,Women's Strawweight
+06/19/2021,Khaos Williams,Matthew Semelsberger,Red,Welterweight
+06/19/2021,Josh Parisian,Roque Martinez,Red,Heavyweight
+06/19/2021,Ricky Glenn,Joaquim Silva,Red,Lightweight
+06/19/2021,Casey O'Neill,Lara Procopio,Red,Women's Flyweight
+06/12/2021,Israel Adesanya,Marvin Vettori,Red,UFC Middleweight Title
+06/12/2021,Brandon Moreno,Deiveson Figueiredo,Red,UFC Flyweight Title
+06/12/2021,Leon Edwards,Nate Diaz,Red,Welterweight
+06/12/2021,Belal Muhammad,Demian Maia,Red,Welterweight
+06/12/2021,Paul Craig,Jamahal Hill,Red,Light Heavyweight
+06/12/2021,Brad Riddell,Drew Dober,Red,Lightweight
+06/12/2021,Eryk Anders,Darren Stewart,Red,Light Heavyweight
+06/12/2021,Lauren Murphy,Joanne Wood,Red,Women's Flyweight
+06/12/2021,Movsar Evloev,Hakeem Dawodu,Red,Featherweight
+06/12/2021,Pannie Kianzad,Alexis Davis,Red,Women's Bantamweight
+06/12/2021,Terrance McKinney,Matt Frevola,Red,Lightweight
+06/12/2021,Steven Peterson,Chase Hooper,Red,Featherweight
+06/12/2021,Fares Ziam,Luigi Vendramini,Red,Lightweight
+06/12/2021,Carlos Felipe,Jake Collier,Red,Heavyweight
+06/05/2021,Jairzinho Rozenstruik,Augusto Sakai,Red,Heavyweight
+06/05/2021,Marcin Tybura,Walt Harris,Red,Heavyweight
+06/05/2021,Roman Dolidze,Laureano Staropoli,Red,Middleweight
+06/05/2021,Santiago Ponzinibbio,Miguel Baeza,Red,Welterweight
+06/05/2021,Gregory Rodrigues,Dusko Todorovic,Red,Middleweight
+06/05/2021,Montana De La Rosa,Ariane Lipski,Red,Women's Flyweight
+06/05/2021,Ilir Latifi,Tanner Boser,Red,Heavyweight
+06/05/2021,Muslim Salikhov,Francisco Trinaldo,Red,Welterweight
+06/05/2021,Kamuela Kirk,Makwan Amirkhani,Red,Featherweight
+06/05/2021,Manon Fiorot,Tabatha Ricci,Red,Women's Flyweight
+06/05/2021,Sean Woodson,Youssef Zalal,Red,Featherweight
+06/05/2021,Claudio Puelles,Jordan Leavitt,Red,Lightweight
+05/22/2021,Rob Font,Cody Garbrandt,Red,Bantamweight
+05/22/2021,Carla Esparza,Yan Xiaonan,Red,Women's Strawweight
+05/22/2021,Jared Vanderaa,Justin Tafa,Red,Heavyweight
+05/22/2021,Norma Dumont,Felicia Spencer,Red,Women's Featherweight
+05/22/2021,Ricardo Ramos,Bill Algeo,Red,Featherweight
+05/22/2021,Jack Hermansson,Edmen Shahbazyan,Red,Middleweight
+05/22/2021,Ben Rothwell,Chris Barnett,Red,Heavyweight
+05/22/2021,Court McGee,Claudio Silva,Red,Welterweight
+05/22/2021,Bruno Silva,Victor Rodriguez,Red,Flyweight
+05/22/2021,Josh Culibao,Shayilan Nuerdanbieke,Red,Featherweight
+05/22/2021,David Dvorak,Juancamilo Ronderos,Red,Flyweight
+05/22/2021,Damir Ismagulov,Rafael Alves,Red,Lightweight
+05/15/2021,Charles Oliveira,Michael Chandler,Red,UFC Lightweight Title
+05/15/2021,Beneil Dariush,Tony Ferguson,Red,Lightweight
+05/15/2021,Katlyn Cerminara,Viviane Araujo,Red,Women's Flyweight
+05/15/2021,Edson Barboza,Shane Burgos,Red,Featherweight
+05/15/2021,Andre Muniz,Jacare Souza,Red,Middleweight
+05/15/2021,Lando Vannata,Mike Grundy,Red,Featherweight
+05/15/2021,Jordan Wright,Jamie Pickett,Red,Middleweight
+05/15/2021,Andrea Lee,Antonina Shevchenko,Red,Women's Flyweight
+05/15/2021,Priscila Cachoeira,Gina Mazany,Red,Women's Flyweight
+05/15/2021,Tucker Lutz,Kevin Aguilar,Red,Featherweight
+05/15/2021,Christos Giagos,Sean Soriano,Red,Lightweight
+05/08/2021,Marina Rodriguez,Michelle Waterson-Gomez,Red,Women's Flyweight
+05/08/2021,Alex Morono,Donald Cerrone,Red,Welterweight
+05/08/2021,Neil Magny,Geoff Neal,Red,Welterweight
+05/08/2021,Marcos Rogerio de Lima,Maurice Greene,Red,Heavyweight
+05/08/2021,Gregor Gillespie,Diego Ferreira,Red,Lightweight
+05/08/2021,Phil Hawes,Kyle Daukaus,Red,Middleweight
+05/08/2021,Michael Trizano,Ludovit Klein,Red,Featherweight
+05/08/2021,JunYong Park,Tafon Nchukwi,Red,Middleweight
+05/08/2021,Carlston Harris,Christian Aguilera,Red,Welterweight
+05/01/2021,Jiri Prochazka,Dominick Reyes,Red,Light Heavyweight
+05/01/2021,Giga Chikadze,Cub Swanson,Red,Featherweight
+05/01/2021,Sean Strickland,Krzysztof Jotko,Red,Middleweight
+05/01/2021,Merab Dvalishvili,Cody Stamann,Red,Bantamweight
+05/01/2021,Luana Pinheiro,Randa Markos,Red,Women's Strawweight
+05/01/2021,TJ Brown,Kai Kamaka,Red,Featherweight
+05/01/2021,Luana Carolina,Poliana Botelho,Red,Women's Flyweight
+05/01/2021,Loma Lookboonmee,Sam Hughes,Red,Women's Strawweight
+05/01/2021,Andreas Michailidis,KB Bhullar,Red,Middleweight
+05/01/2021,Felipe Colares,Luke Sanders,Red,Featherweight
+04/24/2021,Kamaru Usman,Jorge Masvidal,Red,UFC Welterweight Title
+04/24/2021,Rose Namajunas,Zhang Weili,Red,UFC Women's Strawweight Title
+04/24/2021,Valentina Shevchenko,Jessica Andrade,Red,UFC Women's Flyweight Title
+04/24/2021,Uriah Hall,Chris Weidman,Red,Middleweight
+04/24/2021,Anthony Smith,Jimmy Crute,Red,Light Heavyweight
+04/24/2021,Randy Brown,Alex Oliveira,Red,Welterweight
+04/24/2021,Dwight Grant,Stefan Sekulic,Red,Welterweight
+04/24/2021,Brendan Allen,Karl Roberson,Red,Middleweight
+04/24/2021,Pat Sabatini,Tristan Connelly,Red,Featherweight
+04/24/2021,Batgerel Danaa,Kevin Natividad,Red,Bantamweight
+04/24/2021,Kazula Vargas,Rongzhu,Red,Lightweight
+04/24/2021,Jeff Molina,Aoriqileng,Red,Flyweight
+04/24/2021,Ariane Carnelossi,Liang Na,Red,Women's Strawweight
+04/17/2021,Robert Whittaker,Kelvin Gastelum,Red,Middleweight
+04/17/2021,Andrei Arlovski,Chase Sherman,Red,Heavyweight
+04/17/2021,Jacob Malkoun,Abdul Razak Alhassan,Red,Middleweight
+04/17/2021,Tracy Cortez,Justine Kish,Red,Women's Flyweight
+04/17/2021,Luis Pena,Alexander Munoz,Red,Lightweight
+04/17/2021,Alexandr Romanov,Juan Espino,Red,Heavyweight
+04/17/2021,Jessica Penne,Loopy Godinez,Red,Women's Strawweight
+04/17/2021,Gerald Meerschaert,Bartosz Fabinski,Red,Middleweight
+04/17/2021,Austin Hubbard,Dakota Bush,Red,Lightweight
+04/17/2021,Tony Gravely,Anthony Birchak,Red,Bantamweight
+04/10/2021,Marvin Vettori,Kevin Holland,Red,Middleweight
+04/10/2021,Arnold Allen,Sodiq Yusuff,Red,Featherweight
+04/10/2021,Julian Marquez,Sam Alvey,Red,Middleweight
+04/10/2021,Mackenzie Dern,Nina Nunes,Red,Women's Strawweight
+04/10/2021,Daniel Rodriguez,Mike Perry,Red,Welterweight
+04/10/2021,Joe Solecki,Jim Miller,Red,Lightweight
+04/10/2021,Mateusz Gamrot,Scott Holtzman,Red,Lightweight
+04/10/2021,John Makdessi,Ignacio Bahamondes,Red,Lightweight
+04/10/2021,Jarjis Danho,Yorgan De Castro,Red,Heavyweight
+04/10/2021,Jack Shore,Hunter Azure,Red,Bantamweight
+04/10/2021,Luis Saldana,Jordan Griffin,Red,Featherweight
+04/10/2021,Da Woon Jung,William Knight,Red,Light Heavyweight
+04/10/2021,Impa Kasanganay,Sasha Palatnikov,Red,Welterweight
+03/27/2021,Francis Ngannou,Stipe Miocic,Red,UFC Heavyweight Title
+03/27/2021,Vicente Luque,Tyron Woodley,Red,Welterweight
+03/27/2021,Sean O'Malley,Thomas Almeida,Red,Bantamweight
+03/27/2021,Miranda Maverick,Gillian Robertson,Red,Women's Flyweight
+03/27/2021,Jamie Mullarkey,Khama Worthy,Red,Lightweight
+03/27/2021,Alonzo Menifield,Fabio Cherant,Red,Light Heavyweight
+03/27/2021,Abubakar Nurmagomedov,Jared Gooden,Red,Welterweight
+03/27/2021,Michal Oleksiejczuk,Modestas Bukauskas,Red,Light Heavyweight
+03/27/2021,Omar Morales,Shane Young,Red,Featherweight
+03/27/2021,Marc-Andre Barriault,Abu Azaitar,Red,Middleweight
+03/20/2021,Derek Brunson,Kevin Holland,Red,Middleweight
+03/20/2021,Max Griffin,Song Kenan,Red,Welterweight
+03/20/2021,Montserrat Conejo Ruiz,Cheyanne Vlismas,Red,Women's Strawweight
+03/20/2021,Adrian Yanez,Gustavo Lopez,Red,Bantamweight
+03/20/2021,Tai Tuivasa,Harry Hunsucker,Red,Heavyweight
+03/20/2021,Macy Chiasson,Marion Reneau,Red,Women's Bantamweight
+03/20/2021,Grant Dawson,Leonardo Santos,Red,Lightweight
+03/20/2021,Trevin Giles,Roman Dolidze,Red,Middleweight
+03/20/2021,Montel Jackson,Jesse Strader,Red,Bantamweight
+03/20/2021,Bruno Silva,JP Buys,Red,Flyweight
+03/13/2021,Ryan Spann,Misha Cirkunov,Red,Light Heavyweight
+03/13/2021,Dan Ige,Gavin Tucker,Red,Featherweight
+03/13/2021,Davey Grant,Jonathan Martinez,Red,Bantamweight
+03/13/2021,Matheus Nicolau,Manel Kape,Red,Flyweight
+03/13/2021,Angela Hill,Ashley Yoder,Red,Women's Strawweight
+03/13/2021,Charles Jourdain,Marcelo Rojo,Red,Featherweight
+03/13/2021,Rani Yahya,Ray Rodriguez,Red,Bantamweight
+03/13/2021,Nasrat Haqparast,Rafa Garcia,Red,Lightweight
+03/13/2021,JJ Aldrich,Cortney Casey,Red,Women's Flyweight
+03/13/2021,Jinh Yu Frey,Gloria de Paula,Red,Women's Strawweight
+03/13/2021,Matthew Semelsberger,Jason Witt,Red,Welterweight
+03/06/2021,Jan Blachowicz,Israel Adesanya,Red,UFC Light Heavyweight Title
+03/06/2021,Amanda Nunes,Megan Anderson,Red,UFC Women's Featherweight Title
+03/06/2021,Aljamain Sterling,Petr Yan,Red,UFC Bantamweight Title
+03/06/2021,Islam Makhachev,Drew Dober,Red,Lightweight
+03/06/2021,Aleksandar Rakic,Thiago Santos,Red,Light Heavyweight
+03/06/2021,Dominick Cruz,Casey Kenney,Red,Bantamweight
+03/06/2021,Kyler Phillips,Song Yadong,Red,Bantamweight
+03/06/2021,Askar Askarov,Joseph Benavidez,Red,Flyweight
+03/06/2021,Kai Kara-France,Rogerio Bontorin,Red,Flyweight
+03/06/2021,Tim Elliott,Jordan Espinosa,Red,Flyweight
+03/06/2021,Kennedy Nzechukwu,Carlos Ulberg,Red,Light Heavyweight
+03/06/2021,Sean Brady,Jake Matthews,Red,Welterweight
+03/06/2021,Amanda Lemos,Livinha Souza,Red,Women's Strawweight
+03/06/2021,Uros Medic,Aalon Cruz,Red,Lightweight
+03/06/2021,Trevin Jones,Mario Bautista,Red,Bantamweight
+02/27/2021,Ciryl Gane,Jairzinho Rozenstruik,Red,Heavyweight
+02/27/2021,Magomed Ankalaev,Nikita Krylov,Red,Light Heavyweight
+02/27/2021,Pedro Munhoz,Jimmie Rivera,Red,Bantamweight
+02/27/2021,Alex Caceres,Kevin Croom,Red,Featherweight
+02/27/2021,Thiago Moises,Alexander Hernandez,Red,Lightweight
+02/27/2021,Alexis Davis,Sabina Mazo,Red,Women's Bantamweight
+02/27/2021,Ronnie Lawrence,Vince Cachero,Red,Bantamweight
+02/27/2021,Dustin Jacoby,Maxim Grishin,Red,Light Heavyweight
+02/20/2021,Derrick Lewis,Curtis Blaydes,Red,Heavyweight
+02/20/2021,Yana Santos,Ketlen Vieira,Red,Women's Bantamweight
+02/20/2021,Darrick Minner,Charles Rosa,Red,Featherweight
+02/20/2021,Chris Daukaus,Aleksei Oleinik,Red,Heavyweight
+02/20/2021,Phil Hawes,Nassourdine Imavov,Red,Middleweight
+02/20/2021,Tom Aspinall,Andrei Arlovski,Red,Heavyweight
+02/20/2021,Jared Gordon,Danny Chavez,Red,Featherweight
+02/20/2021,John Castaneda,Eddie Wineland,Red,Bantamweight
+02/20/2021,Julian Erosa,Nate Landwehr,Red,Featherweight
+02/20/2021,Casey O'Neill,Shana Dobson,Red,Women's Flyweight
+02/20/2021,Aiemann Zahabi,Drako Rodriguez,Red,Bantamweight
+02/20/2021,Serghei Spivac,Jared Vanderaa,Red,Heavyweight
+02/13/2021,Kamaru Usman,Gilbert Burns,Red,UFC Welterweight Title
+02/13/2021,Alexa Grasso,Maycee Barber,Red,Women's Flyweight
+02/13/2021,Kelvin Gastelum,Ian Heinisch,Red,Middleweight
+02/13/2021,Ricky Simon,Brian Kelleher,Red,Featherweight
+02/13/2021,Julian Marquez,Maki Pitolo,Red,Middleweight
+02/13/2021,Anthony Hernandez,Rodolfo Vieira,Red,Middleweight
+02/13/2021,Belal Muhammad,Dhiego Lima,Red,Welterweight
+02/13/2021,Polyana Viana,Mallory Martin,Red,Women's Strawweight
+02/13/2021,Chris Gutierrez,Andre Ewell,Red,Catch Weight
+02/13/2021,Gabe Green,Phil Rowe,Red,Welterweight
+02/06/2021,Alexander Volkov,Alistair Overeem,Red,Heavyweight
+02/06/2021,Cory Sandhagen,Frankie Edgar,Red,Bantamweight
+02/06/2021,Clay Guida,Michael Johnson,Red,Lightweight
+02/06/2021,Alexandre Pantoja,Manel Kape,Red,Flyweight
+02/06/2021,Beneil Dariush,Diego Ferreira,Red,Lightweight
+02/06/2021,Danilo Marques,Mike Rodriguez,Red,Light Heavyweight
+02/06/2021,Devonte Smith,Justin Jaynes,Red,Catch Weight
+02/06/2021,Karol Rosa,Joselyne Edwards,Red,Women's Bantamweight
+02/06/2021,Lara Procopio,Molly McCann,Red,Women's Flyweight
+02/06/2021,SeungWoo Choi,Youssef Zalal,Red,Featherweight
+02/06/2021,Timur Valiev,Martin Day,Red,Featherweight
+02/06/2021,Ode Osbourne,Jerome Rivera,Red,Featherweight
+01/23/2021,Dustin Poirier,Conor McGregor,Red,Lightweight
+01/23/2021,Michael Chandler,Dan Hooker,Red,Lightweight
+01/23/2021,Joanne Wood,Jessica Eye,Red,Women's Flyweight
+01/23/2021,Makhmud Muradov,Andrew Sanchez,Red,Middleweight
+01/23/2021,Marina Rodriguez,Amanda Ribas,Red,Women's Strawweight
+01/23/2021,Arman Tsarukyan,Matt Frevola,Red,Lightweight
+01/23/2021,Brad Tavares,Antonio Carlos Junior,Red,Middleweight
+01/23/2021,Julianna Pena,Sara McMann,Red,Women's Bantamweight
+01/23/2021,Marcin Prachnio,Khalil Rountree Jr.,Red,Light Heavyweight
+01/23/2021,Movsar Evloev,Nik Lentz,Red,Catch Weight
+01/23/2021,Amir Albazi,Zhalgas Zhumagulov,Red,Flyweight
+01/20/2021,Michael Chiesa,Neil Magny,Red,Welterweight
+01/20/2021,Warlley Alves,Mounir Lazzez,Red,Welterweight
+01/20/2021,Ike Villanueva,Vinicius Moreira,Red,Light Heavyweight
+01/20/2021,Viviane Araujo,Roxanne Modafferi,Red,Women's Flyweight
+01/20/2021,Matt Schnell,Tyson Nam,Red,Flyweight
+01/20/2021,Lerone Murphy,Douglas Silva de Andrade,Red,Featherweight
+01/20/2021,Omari Akhmedov,Tom Breese,Red,Middleweight
+01/20/2021,Ricky Simon,Gaetano Pirrello,Red,Bantamweight
+01/20/2021,Sumudaerji,Zarrukh Adashev,Red,Flyweight
+01/20/2021,Dalcha Lungiambula,Markus Perez,Red,Middleweight
+01/20/2021,Francisco Figueiredo,Jerome Rivera,Red,Flyweight
+01/20/2021,Mike Davis,Mason Jones,Red,Lightweight
+01/20/2021,Umar Nurmagomedov,Sergey Morozov,Red,Bantamweight
+01/20/2021,Manon Fiorot,Victoria Leonardo,Red,Women's Flyweight
+01/16/2021,Max Holloway,Calvin Kattar,Red,Featherweight
+01/16/2021,Carlos Condit,Matt Brown,Red,Welterweight
+01/16/2021,Li Jingliang,Santiago Ponzinibbio,Red,Welterweight
+01/16/2021,Alessio Di Chirico,Joaquin Buckley,Red,Middleweight
+01/16/2021,Punahele Soriano,Dusko Todorovic,Red,Middleweight
+01/16/2021,Joselyne Edwards,Wu Yanan,Red,Women's Bantamweight
+01/16/2021,Carlos Felipe,Justin Tafa,Red,Heavyweight
+01/16/2021,Ramazan Emeev,David Zawada,Red,Welterweight
+01/16/2021,Vanessa Melo,Sarah Moras,Red,Women's Bantamweight
+01/16/2021,Austin Lingo,Jacob Kilburn,Red,Featherweight
+12/19/2020,Stephen Thompson,Geoff Neal,Red,Welterweight
+12/19/2020,Jose Aldo,Marlon Vera,Red,Bantamweight
+12/19/2020,Michel Pereira,Khaos Williams,Red,Welterweight
+12/19/2020,Rob Font,Marlon Moraes,Red,Bantamweight
+12/19/2020,Marcin Tybura,Greg Hardy,Red,Heavyweight
+12/19/2020,Anthony Pettis,Alex Morono,Red,Welterweight
+12/19/2020,Pannie Kianzad,Sijara Eubanks,Red,Women's Bantamweight
+12/19/2020,Deron Winn,Antonio Arroyo,Red,Catch Weight
+12/19/2020,Taila Santos,Gillian Robertson,Red,Women's Flyweight
+12/19/2020,Tafon Nchukwi,Jamie Pickett,Red,Middleweight
+12/19/2020,Jimmy Flick,Cody Durden,Red,Flyweight
+12/19/2020,Christos Giagos,Carlton Minus,Red,Catch Weight
+12/12/2020,Charles Oliveira,Tony Ferguson,Red,Lightweight
+12/12/2020,Mackenzie Dern,Virna Jandiroba,Red,Women's Strawweight
+12/12/2020,Kevin Holland,Jacare Souza,Red,Middleweight
+12/12/2020,Ciryl Gane,Junior Dos Santos,Red,Heavyweight
+12/12/2020,Cub Swanson,Daniel Pineda,Red,Featherweight
+12/12/2020,Rafael Fiziev,Renato Moicano,Red,Lightweight
+12/12/2020,Gavin Tucker,Billy Quarantillo,Red,Featherweight
+12/12/2020,Tecia Torres,Sam Hughes,Red,Women's Strawweight
+12/12/2020,Chase Hooper,Peter Barrett,Red,Featherweight
+12/05/2020,Marvin Vettori,Jack Hermansson,Red,Middleweight
+12/05/2020,Jamahal Hill,Ovince Saint Preux,Red,Light Heavyweight
+12/05/2020,Gabriel Benitez,Justin Jaynes,Red,Lightweight
+12/05/2020,Roman Dolidze,John Allan,Red,Light Heavyweight
+12/05/2020,Jordan Leavitt,Matt Wiman,Red,Lightweight
+12/05/2020,Louis Smolka,Jose Quinonez,Red,Bantamweight
+12/05/2020,Ilia Topuria,Damon Jackson,Red,Featherweight
+12/05/2020,Jake Collier,Gian Villante,Red,Heavyweight
+11/28/2020,Anthony Smith,Devin Clark,Red,Light Heavyweight
+11/28/2020,Miguel Baeza,Takashi Sato,Red,Welterweight
+11/28/2020,Parker Porter,Josh Parisian,Red,Heavyweight
+11/28/2020,Bill Algeo,Spike Carlyle,Red,Featherweight
+11/28/2020,Norma Dumont,Ashlee Evans-Smith,Red,Women's Bantamweight
+11/28/2020,Jonathan Pearce,Kai Kamaka,Red,Featherweight
+11/28/2020,Anderson Dos Santos,Martin Day,Red,Bantamweight
+11/28/2020,Gina Mazany,Rachael Ostovich,Red,Women's Flyweight
+11/28/2020,Sumudaerji,Malcolm Gordon,Red,Flyweight
+11/28/2020,Nate Maness,Luke Sanders,Red,Catch Weight
+11/21/2020,Deiveson Figueiredo,Alex Perez,Red,UFC Flyweight Title
+11/21/2020,Valentina Shevchenko,Jennifer Maia,Red,UFC Women's Flyweight Title
+11/21/2020,Tim Means,Mike Perry,Red,Welterweight
+11/21/2020,Katlyn Cerminara,Cynthia Calvillo,Red,Women's Flyweight
+11/21/2020,Paul Craig,Mauricio Rua,Red,Light Heavyweight
+11/21/2020,Brandon Moreno,Brandon Royval,Red,Flyweight
+11/21/2020,Joaquin Buckley,Jordan Wright,Red,Middleweight
+11/21/2020,Antonina Shevchenko,Ariane Lipski,Red,Women's Flyweight
+11/21/2020,Nicolas Dalby,Daniel Rodriguez,Red,Welterweight
+11/21/2020,Alan Jouban,Jared Gooden,Red,Welterweight
+11/21/2020,Kyle Daukaus,Dustin Stoltzfus,Red,Middleweight
+11/21/2020,Sasha Palatnikov,Louis Cosce,Red,Welterweight
+11/14/2020,Rafael Dos Anjos,Paul Felder,Red,Lightweight
+11/14/2020,Khaos Williams,Abdul Razak Alhassan,Red,Welterweight
+11/14/2020,Ashley Yoder,Miranda Granger,Red,Women's Strawweight
+11/14/2020,Sean Strickland,Brendan Allen,Red,Catch Weight
+11/14/2020,Cory McKenna,Kay Hansen,Red,Women's Strawweight
+11/14/2020,Kanako Murata,Randa Markos,Red,Women's Strawweight
+11/14/2020,Tony Gravely,Geraldo de Freitas,Red,Bantamweight
+11/14/2020,Alex Morono,Rhys McKee,Red,Welterweight
+11/14/2020,Don'Tale Mayes,Roque Martinez,Red,Heavyweight
+11/07/2020,Glover Teixeira,Thiago Santos,Red,Light Heavyweight
+11/07/2020,Andrei Arlovski,Tanner Boser,Red,Heavyweight
+11/07/2020,Raoni Barcelos,Khalid Taha,Red,Bantamweight
+11/07/2020,Giga Chikadze,Jamey Simmons,Red,Featherweight
+11/07/2020,Yan Xiaonan,Claudia Gadelha,Red,Women's Strawweight
+11/07/2020,Trevin Giles,Bevon Lewis,Red,Middleweight
+11/07/2020,Alexandr Romanov,Marcos Rogerio de Lima,Red,Heavyweight
+11/07/2020,Darren Elkins,Eduardo Garagorri,Red,Featherweight
+11/07/2020,Max Griffin,Ramiz Brahimaj,Red,Welterweight
+11/07/2020,Gustavo Lopez,Anthony Birchak,Red,Bantamweight
+10/31/2020,Uriah Hall,Anderson Silva,Red,Middleweight
+10/31/2020,Bryce Mitchell,Andre Fili,Red,Featherweight
+10/31/2020,Greg Hardy,Maurice Greene,Red,Heavyweight
+10/31/2020,Kevin Holland,Charlie Ontiveros,Red,Middleweight
+10/31/2020,Thiago Moises,Bobby Green,Red,Lightweight
+10/31/2020,Alexander Hernandez,Chris Gruetzemacher,Red,Lightweight
+10/31/2020,Adrian Yanez,Victor Rodriguez,Red,Bantamweight
+10/31/2020,Sean Strickland,Jack Marshman,Red,Middleweight
+10/31/2020,Jason Witt,Cole Williams,Red,Welterweight
+10/31/2020,Dustin Jacoby,Justin Ledet,Red,Light Heavyweight
+10/31/2020,Miles Johns,Kevin Natividad,Red,Bantamweight
+10/24/2020,Khabib Nurmagomedov,Justin Gaethje,Red,UFC Lightweight Title
+10/24/2020,Robert Whittaker,Jared Cannonier,Red,Middleweight
+10/24/2020,Alexander Volkov,Walt Harris,Red,Heavyweight
+10/24/2020,Phil Hawes,Jacob Malkoun,Red,Middleweight
+10/24/2020,Lauren Murphy,Liliya Shakirova,Red,Women's Flyweight
+10/24/2020,Magomed Ankalaev,Ion Cutelaba,Red,Light Heavyweight
+10/24/2020,Tai Tuivasa,Stefan Struve,Red,Heavyweight
+10/24/2020,Casey Kenney,Nathaniel Wood,Red,Catch Weight
+10/24/2020,Shavkat Rakhmonov,Alex Oliveira,Red,Welterweight
+10/24/2020,Miranda Maverick,Liana Jojua,Red,Women's Flyweight
+10/24/2020,Joel Alvarez,Alexander Yakovlev,Red,Lightweight
+10/17/2020,Brian Ortega,Chan Sung Jung,Red,Featherweight
+10/17/2020,Jessica Andrade,Katlyn Cerminara,Red,Women's Flyweight
+10/17/2020,Jimmy Crute,Modestas Bukauskas,Red,Light Heavyweight
+10/17/2020,James Krause,Claudio Silva,Red,Welterweight
+10/17/2020,Jonathan Martinez,Thomas Almeida,Red,Featherweight
+10/17/2020,Guram Kutateladze,Mateusz Gamrot,Red,Lightweight
+10/17/2020,Gillian Robertson,Poliana Botelho,Red,Women's Flyweight
+10/17/2020,JunYong Park,John Phillips,Red,Middleweight
+10/17/2020,Fares Ziam,Jamie Mullarkey,Red,Lightweight
+10/17/2020,Maxim Grishin,Gadzhimurad Antigulov,Red,Light Heavyweight
+10/17/2020,Said Nurmagomedov,Mark Striegl,Red,Bantamweight
+10/10/2020,Cory Sandhagen,Marlon Moraes,Red,Bantamweight
+10/10/2020,Edson Barboza,Makwan Amirkhani,Red,Featherweight
+10/10/2020,Marcin Tybura,Ben Rothwell,Red,Heavyweight
+10/10/2020,Dricus Du Plessis,Markus Perez,Red,Middleweight
+10/10/2020,Tom Aspinall,Alan Baudot,Red,Heavyweight
+10/10/2020,Ilia Topuria,Youssef Zalal,Red,Featherweight
+10/10/2020,Tom Breese,KB Bhullar,Red,Middleweight
+10/10/2020,Chris Daukaus,Rodrigo Nascimento,Red,Heavyweight
+10/10/2020,Joaquin Buckley,Impa Kasanganay,Red,Middleweight
+10/10/2020,Tony Kelley,Ali AlQaisi,Red,Bantamweight
+10/10/2020,Giga Chikadze,Omar Morales,Red,Featherweight
+10/10/2020,Tracy Cortez,Stephanie Egger,Red,Women's Bantamweight
+10/10/2020,Tagir Ulanbekov,Bruno Silva,Red,Flyweight
+10/03/2020,Holly Holm,Irene Aldana,Red,Women's Bantamweight
+10/03/2020,Carlos Felipe,Yorgan De Castro,Red,Heavyweight
+10/03/2020,Germaine de Randamie,Julianna Pena,Red,Women's Bantamweight
+10/03/2020,Kyler Phillips,Cameron Else,Red,Bantamweight
+10/03/2020,Dusko Todorovic,Dequan Townsend,Red,Middleweight
+10/03/2020,Carlos Condit,Court McGee,Red,Welterweight
+10/03/2020,Nassourdine Imavov,Jordan Williams,Red,Middleweight
+10/03/2020,Loma Lookboonmee,Jinh Yu Frey,Red,Women's Strawweight
+10/03/2020,Casey Kenney,Alatengheili,Red,Bantamweight
+10/03/2020,Luigi Vendramini,Jessin Ayari,Red,Lightweight
+09/26/2020,Israel Adesanya,Paulo Costa,Red,UFC Middleweight Title
+09/26/2020,Jan Blachowicz,Dominick Reyes,Red,UFC Light Heavyweight Title
+09/26/2020,Brandon Royval,Kai Kara-France,Red,Flyweight
+09/26/2020,Ketlen Vieira,Sijara Eubanks,Red,Women's Bantamweight
+09/26/2020,Hakeem Dawodu,Zubaira Tukhugov,Red,Featherweight
+09/26/2020,Brad Riddell,Alex Da Silva,Red,Lightweight
+09/26/2020,Jake Matthews,Diego Sanchez,Red,Welterweight
+09/26/2020,Ludovit Klein,Shane Young,Red,Featherweight
+09/26/2020,William Knight,Aleksa Camur,Red,Light Heavyweight
+09/26/2020,Juan Espino,Jeff Hughes,Red,Heavyweight
+09/26/2020,Danilo Marques,Khadis Ibragimov,Red,Light Heavyweight
+09/19/2020,Colby Covington,Tyron Woodley,Red,Welterweight
+09/19/2020,Khamzat Chimaev,Gerald Meerschaert,Red,Middleweight
+09/19/2020,Johnny Walker,Ryan Spann,Red,Light Heavyweight
+09/19/2020,Mackenzie Dern,Randa Markos,Red,Women's Strawweight
+09/19/2020,Kevin Holland,Darren Stewart,Red,Middleweight
+09/19/2020,David Dvorak,Jordan Espinosa,Red,Flyweight
+09/19/2020,Damon Jackson,Mirsad Bektic,Red,Featherweight
+09/19/2020,Mayra Bueno Silva,Mara Romero Borella,Red,Women's Flyweight
+09/19/2020,Jessica-Rose Clark,Sarah Alpar,Red,Women's Bantamweight
+09/19/2020,Darrick Minner,TJ Laramie,Red,Featherweight
+09/19/2020,Randy Costa,Journey Newson,Red,Bantamweight
+09/19/2020,Andre Ewell,Irwin Rivera,Red,Bantamweight
+09/19/2020,Tyson Nam,Jerome Rivera,Red,Bantamweight
+09/12/2020,Michelle Waterson-Gomez,Angela Hill,Red,Women's Strawweight
+09/12/2020,Ottman Azaitar,Khama Worthy,Red,Lightweight
+09/12/2020,Roxanne Modafferi,Andrea Lee,Red,Women's Flyweight
+09/12/2020,Ed Herman,Mike Rodriguez,Red,Light Heavyweight
+09/12/2020,Bobby Green,Alan Patrick,Red,Lightweight
+09/12/2020,Billy Quarantillo,Kyle Nelson,Red,Featherweight
+09/12/2020,Sijara Eubanks,Julia Avila,Red,Women's Bantamweight
+09/12/2020,Alexandr Romanov,Roque Martinez,Red,Heavyweight
+09/12/2020,Jalin Turner,Brok Weaver,Red,Catch Weight
+09/12/2020,Bryan Barberena,Anthony Ivy,Red,Welterweight
+09/12/2020,Sabina Mazo,Justine Kish,Red,Women's Flyweight
+09/05/2020,Alistair Overeem,Augusto Sakai,Red,Heavyweight
+09/05/2020,Ovince Saint Preux,Alonzo Menifield,Red,Light Heavyweight
+09/05/2020,Michel Pereira,Zelim Imadaev,Red,Welterweight
+09/05/2020,Andre Muniz,Bartosz Fabinski,Red,Middleweight
+09/05/2020,Brian Kelleher,Ray Rodriguez,Red,Featherweight
+09/05/2020,Viviane Araujo,Montana De La Rosa,Red,Women's Flyweight
+09/05/2020,Hunter Azure,Cole Smith,Red,Bantamweight
+08/29/2020,Aleksandar Rakic,Anthony Smith,Red,Light Heavyweight
+08/29/2020,Neil Magny,Robbie Lawler,Red,Welterweight
+08/29/2020,Alexa Grasso,Ji Yeon Kim,Red,Women's Flyweight
+08/29/2020,Ricardo Lamas,Bill Algeo,Red,Featherweight
+08/29/2020,Impa Kasanganay,Maki Pitolo,Red,Middleweight
+08/29/2020,Zak Cummings,Alessio Di Chirico,Red,Middleweight
+08/29/2020,Alex Caceres,Austin Springer,Red,Featherweight
+08/29/2020,Sean Brady,Christian Aguilera,Red,Welterweight
+08/29/2020,Polyana Viana,Emily Whitmire,Red,Women's Strawweight
+08/29/2020,Mallory Martin,Hannah Cifers,Red,Women's Strawweight
+08/22/2020,Frankie Edgar,Pedro Munhoz,Red,Bantamweight
+08/22/2020,Mike Rodriguez,Marcin Prachnio,Red,Light Heavyweight
+08/22/2020,Joe Solecki,Austin Hubbard,Red,Lightweight
+08/22/2020,Shana Dobson,Mariya Agapova,Red,Women's Flyweight
+08/22/2020,Daniel Rodriguez,Dwight Grant,Red,Welterweight
+08/22/2020,Amanda Lemos,Mizuki,Red,Women's Strawweight
+08/22/2020,Jordan Wright,Ike Villanueva,Red,Light Heavyweight
+08/22/2020,Matthew Semelsberger,Carlton Minus,Red,Welterweight
+08/15/2020,Stipe Miocic,Daniel Cormier,Red,UFC Heavyweight Title
+08/15/2020,Marlon Vera,Sean O'Malley,Red,Bantamweight
+08/15/2020,Jairzinho Rozenstruik,Junior Dos Santos,Red,Heavyweight
+08/15/2020,Daniel Pineda,Herbert Burns,Red,Featherweight
+08/15/2020,Merab Dvalishvili,John Dodson,Red,Bantamweight
+08/15/2020,Vinc Pichel,Jim Miller,Red,Lightweight
+08/15/2020,Virna Jandiroba,Felice Herrig,Red,Women's Strawweight
+08/15/2020,Danny Chavez,TJ Brown,Red,Featherweight
+08/15/2020,Livinha Souza,Ashley Yoder,Red,Women's Strawweight
+08/15/2020,Chris Daukaus,Parker Porter,Red,Heavyweight
+08/15/2020,Kai Kamaka,Tony Kelley,Red,Featherweight
+08/08/2020,Derrick Lewis,Aleksei Oleinik,Red,Heavyweight
+08/08/2020,Chris Weidman,Omari Akhmedov,Red,Middleweight
+08/08/2020,Darren Stewart,Maki Pitolo,Red,Middleweight
+08/08/2020,Yana Santos,Julija Stoliarenko,Red,Women's Bantamweight
+08/08/2020,Beneil Dariush,Scott Holtzman,Red,Lightweight
+08/08/2020,Tim Means,Laureano Staropoli,Red,Welterweight
+08/08/2020,Kevin Holland,Joaquin Buckley,Red,Middleweight
+08/08/2020,Nasrat Haqparast,Alexander Munoz,Red,Lightweight
+08/08/2020,Andrew Sanchez,Wellington Turman,Red,Middleweight
+08/08/2020,Gavin Tucker,Justin Jaynes,Red,Featherweight
+08/08/2020,Youssef Zalal,Peter Barrett,Red,Featherweight
+08/08/2020,Irwin Rivera,Ali AlQaisi,Red,Bantamweight
+08/01/2020,Derek Brunson,Edmen Shahbazyan,Red,Middleweight
+08/01/2020,Jennifer Maia,Joanne Wood,Red,Women's Flyweight
+08/01/2020,Vicente Luque,Randy Brown,Red,Welterweight
+08/01/2020,Bobby Green,Lando Vannata,Red,Lightweight
+08/01/2020,Jonathan Martinez,Frankie Saenz,Red,Bantamweight
+08/01/2020,Nate Maness,Johnny Munoz,Red,Featherweight
+08/01/2020,Jamall Emmers,Vince Cachero,Red,Featherweight
+07/25/2020,Robert Whittaker,Darren Till,Red,Middleweight
+07/25/2020,Mauricio Rua,Rogerio Nogueira,Red,Light Heavyweight
+07/25/2020,Fabricio Werdum,Alexander Gustafsson,Red,Heavyweight
+07/25/2020,Carla Esparza,Marina Rodriguez,Red,Women's Strawweight
+07/25/2020,Paul Craig,Gadzhimurad Antigulov,Red,Light Heavyweight
+07/25/2020,Alex Oliveira,Peter Sobotta,Red,Welterweight
+07/25/2020,Khamzat Chimaev,Rhys McKee,Red,Welterweight
+07/25/2020,Francisco Trinaldo,Jai Herbert,Red,Lightweight
+07/25/2020,Tom Aspinall,Jake Collier,Red,Heavyweight
+07/25/2020,Movsar Evloev,Mike Grundy,Red,Featherweight
+07/25/2020,Tanner Boser,Raphael Pessoa,Red,Heavyweight
+07/25/2020,Pannie Kianzad,Bethe Correia,Red,Women's Bantamweight
+07/25/2020,Ramazan Emeev,Niklas Stolze,Red,Welterweight
+07/25/2020,Nathaniel Wood,John Castaneda,Red,Bantamweight
+07/18/2020,Deiveson Figueiredo,Joseph Benavidez,Red,UFC Flyweight Title
+07/18/2020,Jack Hermansson,Kelvin Gastelum,Red,Middleweight
+07/18/2020,Rafael Fiziev,Marc Diakiese,Red,Lightweight
+07/18/2020,Ariane Lipski,Luana Carolina,Red,Women's Flyweight
+07/18/2020,Askar Askarov,Alexandre Pantoja,Red,Flyweight
+07/18/2020,Roman Dolidze,Khadis Ibragimov,Red,Light Heavyweight
+07/18/2020,Grant Dawson,Nad Narimani,Red,Catch Weight
+07/18/2020,Joel Alvarez,Joe Duffy,Red,Lightweight
+07/18/2020,Brett Johns,Montel Jackson,Red,Bantamweight
+07/18/2020,Amir Albazi,Malcolm Gordon,Red,Bantamweight
+07/18/2020,Arman Tsarukyan,Davi Ramos,Red,Lightweight
+07/18/2020,Serghei Spivac,Carlos Felipe,Red,Heavyweight
+07/15/2020,Calvin Kattar,Dan Ige,Red,Featherweight
+07/15/2020,Tim Elliott,Ryan Benoit,Red,Flyweight
+07/15/2020,Jimmie Rivera,Cody Stamann,Red,Featherweight
+07/15/2020,Taila Santos,Molly McCann,Red,Women's Flyweight
+07/15/2020,Mounir Lazzez,Abdul Razak Alhassan,Red,Welterweight
+07/15/2020,Khamzat Chimaev,John Phillips,Red,Middleweight
+07/15/2020,Lerone Murphy,Ricardo Ramos,Red,Featherweight
+07/15/2020,Modestas Bukauskas,Andreas Michailidis,Red,Light Heavyweight
+07/15/2020,Jared Gordon,Chris Fishgold,Red,Featherweight
+07/15/2020,Liana Jojua,Diana Belbita,Red,Women's Flyweight
+07/15/2020,Jack Shore,Aaron Phillips,Red,Bantamweight
+07/11/2020,Kamaru Usman,Jorge Masvidal,Red,UFC Welterweight Title
+07/11/2020,Alexander Volkanovski,Max Holloway,Red,UFC Featherweight Title
+07/11/2020,Petr Yan,Jose Aldo,Red,UFC Bantamweight Title
+07/11/2020,Rose Namajunas,Jessica Andrade,Red,Women's Strawweight
+07/11/2020,Amanda Ribas,Paige VanZant,Red,Women's Flyweight
+07/11/2020,Jiri Prochazka,Volkan Oezdemir,Red,Light Heavyweight
+07/11/2020,Muslim Salikhov,Elizeu Zaleski dos Santos,Red,Welterweight
+07/11/2020,Makwan Amirkhani,Danny Henry,Red,Featherweight
+07/11/2020,Leonardo Santos,Roman Bogatov,Red,Lightweight
+07/11/2020,Marcin Tybura,Maxim Grishin,Red,Heavyweight
+07/11/2020,Raulian Paiva,Zhalgas Zhumagulov,Red,Flyweight
+07/11/2020,Karol Rosa,Vanessa Melo,Red,Women's Bantamweight
+07/11/2020,Davey Grant,Martin Day,Red,Bantamweight
+06/27/2020,Dustin Poirier,Dan Hooker,Red,Lightweight
+06/27/2020,Mike Perry,Mickey Gall,Red,Welterweight
+06/27/2020,Maurice Greene,Gian Villante,Red,Heavyweight
+06/27/2020,Brendan Allen,Kyle Daukaus,Red,Middleweight
+06/27/2020,Takashi Sato,Jason Witt,Red,Welterweight
+06/27/2020,Julian Erosa,Sean Woodson,Red,Catch Weight
+06/27/2020,Khama Worthy,Luis Pena,Red,Lightweight
+06/27/2020,Tanner Boser,Philipe Lins,Red,Heavyweight
+06/27/2020,Kay Hansen,Jinh Yu Frey,Red,Women's Strawweight
+06/27/2020,Youssef Zalal,Jordan Griffin,Red,Featherweight
+06/20/2020,Curtis Blaydes,Alexander Volkov,Red,Heavyweight
+06/20/2020,Josh Emmett,Shane Burgos,Red,Featherweight
+06/20/2020,Raquel Pennington,Marion Reneau,Red,Women's Bantamweight
+06/20/2020,Belal Muhammad,Lyman Good,Red,Welterweight
+06/20/2020,Jim Miller,Roosevelt Roberts,Red,Catch Weight
+06/20/2020,Bobby Green,Clay Guida,Red,Lightweight
+06/20/2020,Tecia Torres,Brianna Fortino,Red,Women's Strawweight
+06/20/2020,Gillian Robertson,Cortney Casey,Red,Women's Flyweight
+06/20/2020,Justin Jaynes,Frank Camacho,Red,Lightweight
+06/20/2020,Lauren Murphy,Roxanne Modafferi,Red,Women's Flyweight
+06/20/2020,Austin Hubbard,Max Rohskopf,Red,Lightweight
+06/13/2020,Cynthia Calvillo,Jessica Eye,Red,Women's Flyweight
+06/13/2020,Marvin Vettori,Karl Roberson,Red,Middleweight
+06/13/2020,Charles Rosa,Kevin Aguilar,Red,Lightweight
+06/13/2020,Andre Fili,Charles Jourdain,Red,Featherweight
+06/13/2020,Jordan Espinosa,Mark De La Rosa,Red,Bantamweight
+06/13/2020,Mariya Agapova,Hannah Cifers,Red,Women's Flyweight
+06/13/2020,Merab Dvalishvili,Gustavo Lopez,Red,Catch Weight
+06/13/2020,Julia Avila,Gina Mazany,Red,Women's Bantamweight
+06/13/2020,Tyson Nam,Zarrukh Adashev,Red,Bantamweight
+06/13/2020,Christian Aguilera,Anthony Ivy,Red,Welterweight
+06/06/2020,Amanda Nunes,Felicia Spencer,Red,UFC Women's Featherweight Title
+06/06/2020,Cody Garbrandt,Raphael Assuncao,Red,Bantamweight
+06/06/2020,Aljamain Sterling,Cory Sandhagen,Red,Bantamweight
+06/06/2020,Neil Magny,Anthony Rocco Martin,Red,Welterweight
+06/06/2020,Sean O'Malley,Eddie Wineland,Red,Bantamweight
+06/06/2020,Alex Caceres,Chase Hooper,Red,Featherweight
+06/06/2020,Ian Heinisch,Gerald Meerschaert,Red,Middleweight
+06/06/2020,Cody Stamann,Brian Kelleher,Red,Featherweight
+06/06/2020,Maki Pitolo,Charles Byrd,Red,Middleweight
+06/06/2020,Alex Perez,Jussier Formiga,Red,Flyweight
+06/06/2020,Devin Clark,Alonzo Menifield,Red,Light Heavyweight
+06/06/2020,Herbert Burns,Evan Dunham,Red,Catch Weight
+05/30/2020,Gilbert Burns,Tyron Woodley,Red,Welterweight
+05/30/2020,Augusto Sakai,Blagoy Ivanov,Red,Heavyweight
+05/30/2020,Billy Quarantillo,Spike Carlyle,Red,Catch Weight
+05/30/2020,Roosevelt Roberts,Brok Weaver,Red,Lightweight
+05/30/2020,Mackenzie Dern,Hannah Cifers,Red,Women's Strawweight
+05/30/2020,Katlyn Cerminara,Antonina Shevchenko,Red,Women's Flyweight
+05/30/2020,Daniel Rodriguez,Gabe Green,Red,Welterweight
+05/30/2020,Brandon Royval,Tim Elliott,Red,Flyweight
+05/30/2020,Casey Kenney,Louis Smolka,Red,Bantamweight
+05/30/2020,Chris Gutierrez,Vince Morales,Red,Featherweight
+05/16/2020,Alistair Overeem,Walt Harris,Red,Heavyweight
+05/16/2020,Claudia Gadelha,Angela Hill,Red,Women's Strawweight
+05/16/2020,Dan Ige,Edson Barboza,Red,Featherweight
+05/16/2020,Krzysztof Jotko,Eryk Anders,Red,Middleweight
+05/16/2020,Song Yadong,Marlon Vera,Red,Featherweight
+05/16/2020,Miguel Baeza,Matt Brown,Red,Welterweight
+05/16/2020,Kevin Holland,Anthony Hernandez,Red,Middleweight
+05/16/2020,Giga Chikadze,Irwin Rivera,Red,Featherweight
+05/16/2020,Nate Landwehr,Darren Elkins,Red,Featherweight
+05/16/2020,Cortney Casey,Mara Romero Borella,Red,Women's Flyweight
+05/16/2020,Rodrigo Nascimento,Don'Tale Mayes,Red,Heavyweight
+05/13/2020,Glover Teixeira,Anthony Smith,Red,Light Heavyweight
+05/13/2020,Ben Rothwell,Ovince Saint Preux,Red,Heavyweight
+05/13/2020,Drew Dober,Alexander Hernandez,Red,Lightweight
+05/13/2020,Ricky Simon,Ray Borg,Red,Bantamweight
+05/13/2020,Andrei Arlovski,Philipe Lins,Red,Heavyweight
+05/13/2020,Thiago Moises,Michael Johnson,Red,Lightweight
+05/13/2020,Sijara Eubanks,Sarah Moras,Red,Women's Bantamweight
+05/13/2020,Omar Morales,Gabriel Benitez,Red,Lightweight
+05/13/2020,Brian Kelleher,Hunter Azure,Red,Featherweight
+05/13/2020,Chase Sherman,Ike Villanueva,Red,Heavyweight
+05/09/2020,Justin Gaethje,Tony Ferguson,Red,UFC Interim Lightweight Title
+05/09/2020,Henry Cejudo,Dominick Cruz,Red,UFC Bantamweight Title
+05/09/2020,Francis Ngannou,Jairzinho Rozenstruik,Red,Heavyweight
+05/09/2020,Calvin Kattar,Jeremy Stephens,Red,Featherweight
+05/09/2020,Greg Hardy,Yorgan De Castro,Red,Heavyweight
+05/09/2020,Anthony Pettis,Donald Cerrone,Red,Welterweight
+05/09/2020,Aleksei Oleinik,Fabricio Werdum,Red,Heavyweight
+05/09/2020,Carla Esparza,Michelle Waterson-Gomez,Red,Women's Strawweight
+05/09/2020,Vicente Luque,Niko Price,Red,Welterweight
+05/09/2020,Bryce Mitchell,Charles Rosa,Red,Featherweight
+05/09/2020,Ryan Spann,Sam Alvey,Red,Light Heavyweight
+03/14/2020,Charles Oliveira,Kevin Lee,Red,Lightweight
+03/14/2020,Gilbert Burns,Demian Maia,Red,Welterweight
+03/14/2020,Renato Moicano,Damir Hadzovic,Red,Lightweight
+03/14/2020,Nikita Krylov,Johnny Walker,Red,Light Heavyweight
+03/14/2020,Francisco Trinaldo,John Makdessi,Red,Lightweight
+03/14/2020,Brandon Moreno,Jussier Formiga,Red,Flyweight
+03/14/2020,Amanda Ribas,Randa Markos,Red,Women's Strawweight
+03/14/2020,Elizeu Zaleski dos Santos,Aleksei Kunchenko,Red,Welterweight
+03/14/2020,Maryna Moroz,Mayra Bueno Silva,Red,Women's Flyweight
+03/14/2020,David Dvorak,Bruno Silva,Red,Flyweight
+03/14/2020,Bea Malecki,Veronica Hardy,Red,Women's Bantamweight
+03/07/2020,Israel Adesanya,Yoel Romero,Red,UFC Middleweight Title
+03/07/2020,Zhang Weili,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+03/07/2020,Beneil Dariush,Drakkar Klose,Red,Lightweight
+03/07/2020,Neil Magny,Li Jingliang,Red,Welterweight
+03/07/2020,Alex Oliveira,Max Griffin,Red,Welterweight
+03/07/2020,Sean O'Malley,Jose Quinonez,Red,Bantamweight
+03/07/2020,Mark Madsen,Austin Hubbard,Red,Lightweight
+03/07/2020,Rodolfo Vieira,Saparbeg Safarov,Red,Middleweight
+03/07/2020,Gerald Meerschaert,Deron Winn,Red,Middleweight
+03/07/2020,Giga Chikadze,Jamall Emmers,Red,Featherweight
+03/07/2020,Batgerel Danaa,Guido Cannetti,Red,Bantamweight
+02/29/2020,Deiveson Figueiredo,Joseph Benavidez,Red,Flyweight
+02/29/2020,Felicia Spencer,Zarah Fairn,Red,Women's Featherweight
+02/29/2020,Magomed Ankalaev,Ion Cutelaba,Red,Light Heavyweight
+02/29/2020,Megan Anderson,Norma Dumont,Red,Women's Featherweight
+02/29/2020,Grant Dawson,Darrick Minner,Red,Featherweight
+02/29/2020,Kyler Phillips,Gabriel Silva,Red,Bantamweight
+02/29/2020,Brendan Allen,Tom Breese,Red,Middleweight
+02/29/2020,Marcin Tybura,Serghei Spivac,Red,Heavyweight
+02/29/2020,Luis Pena,Steve Garcia,Red,Lightweight
+02/29/2020,Jordan Griffin,TJ Brown,Red,Featherweight
+02/29/2020,Spike Carlyle,Aalon Cruz,Red,Featherweight
+02/29/2020,Sean Brady,Ismail Naurdiev,Red,Welterweight
+02/22/2020,Dan Hooker,Paul Felder,Red,Lightweight
+02/22/2020,Jimmy Crute,Michal Oleksiejczuk,Red,Light Heavyweight
+02/22/2020,Yan Xiaonan,Karolina Kowalkiewicz,Red,Women's Strawweight
+02/22/2020,Marcos Rogerio de Lima,Ben Sosoli,Red,Heavyweight
+02/22/2020,Brad Riddell,Magomed Mustafaev,Red,Lightweight
+02/22/2020,Zubaira Tukhugov,Kevin Aguilar,Red,Featherweight
+02/22/2020,Jalin Turner,Josh Culibao,Red,Lightweight
+02/22/2020,Jake Matthews,Emil Meek,Red,Welterweight
+02/22/2020,Song Kenan,Callan Potter,Red,Welterweight
+02/22/2020,Kai Kara-France,Tyson Nam,Red,Flyweight
+02/22/2020,Angela Hill,Loma Lookboonmee,Red,Women's Strawweight
+02/22/2020,Priscila Cachoeira,Shana Dobson,Red,Women's Flyweight
+02/15/2020,Jan Blachowicz,Corey Anderson,Red,Light Heavyweight
+02/15/2020,Diego Sanchez,Michel Pereira,Red,Welterweight
+02/15/2020,Montana De La Rosa,Mara Romero Borella,Red,Women's Flyweight
+02/15/2020,Brok Weaver,Kazula Vargas,Red,Lightweight
+02/15/2020,Ray Borg,Rogerio Bontorin,Red,Flyweight
+02/15/2020,Lando Vannata,Yancy Medeiros,Red,Lightweight
+02/15/2020,Daniel Rodriguez,Tim Means,Red,Welterweight
+02/15/2020,John Dodson,Nathaniel Wood,Red,Bantamweight
+02/15/2020,Scott Holtzman,Jim Miller,Red,Lightweight
+02/15/2020,Devin Clark,Dequan Townsend,Red,Light Heavyweight
+02/15/2020,Merab Dvalishvili,Casey Kenney,Red,Bantamweight
+02/15/2020,Macy Chiasson,Shanna Young,Red,Women's Bantamweight
+02/15/2020,Raulian Paiva,Mark De La Rosa,Red,Flyweight
+02/08/2020,Jon Jones,Dominick Reyes,Red,UFC Light Heavyweight Title
+02/08/2020,Valentina Shevchenko,Katlyn Cerminara,Red,UFC Women's Flyweight Title
+02/08/2020,Justin Tafa,Juan Adams,Red,Heavyweight
+02/08/2020,Dan Ige,Mirsad Bektic,Red,Featherweight
+02/08/2020,Derrick Lewis,Ilir Latifi,Red,Heavyweight
+02/08/2020,Trevin Giles,James Krause,Red,Middleweight
+02/08/2020,Lauren Murphy,Andrea Lee,Red,Women's Flyweight
+02/08/2020,Khaos Williams,Alex Morono,Red,Welterweight
+02/08/2020,Mario Bautista,Miles Johns,Red,Bantamweight
+02/08/2020,Andre Ewell,Jonathan Martinez,Red,Bantamweight
+02/08/2020,Youssef Zalal,Austin Lingo,Red,Featherweight
+01/25/2020,Curtis Blaydes,Junior Dos Santos,Red,Heavyweight
+01/25/2020,Michael Chiesa,Rafael Dos Anjos,Red,Welterweight
+01/25/2020,Alex Perez,Jordan Espinosa,Red,Flyweight
+01/25/2020,Angela Hill,Hannah Cifers,Red,Women's Strawweight
+01/25/2020,Jamahal Hill,Darko Stosic,Red,Light Heavyweight
+01/25/2020,Bevon Lewis,Dequan Townsend,Red,Middleweight
+01/25/2020,Arnold Allen,Nik Lentz,Red,Featherweight
+01/25/2020,Justine Kish,Lucie Pudilova,Red,Women's Flyweight
+01/25/2020,Montel Jackson,Felipe Colares,Red,Bantamweight
+01/25/2020,Sara McMann,Lina Lansberg,Red,Women's Bantamweight
+01/25/2020,Brett Johns,Tony Gravely,Red,Bantamweight
+01/25/2020,Herbert Burns,Nate Landwehr,Red,Featherweight
+01/18/2020,Conor McGregor,Donald Cerrone,Red,Welterweight
+01/18/2020,Holly Holm,Raquel Pennington,Red,Women's Bantamweight
+01/18/2020,Aleksei Oleinik,Maurice Greene,Red,Heavyweight
+01/18/2020,Brian Kelleher,Ode Osbourne,Red,Bantamweight
+01/18/2020,Diego Ferreira,Anthony Pettis,Red,Lightweight
+01/18/2020,Roxanne Modafferi,Maycee Barber,Red,Women's Flyweight
+01/18/2020,Sodiq Yusuff,Andre Fili,Red,Featherweight
+01/18/2020,Askar Askarov,Tim Elliott,Red,Flyweight
+01/18/2020,Drew Dober,Nasrat Haqparast,Red,Lightweight
+01/18/2020,Aleksa Camur,Justin Ledet,Red,Light Heavyweight
+01/18/2020,Sabina Mazo,JJ Aldrich,Red,Women's Flyweight
+12/21/2019,Chan Sung Jung,Frankie Edgar,Red,Featherweight
+12/21/2019,Volkan Oezdemir,Aleksandar Rakic,Red,Light Heavyweight
+12/21/2019,Charles Jourdain,Dooho Choi,Red,Featherweight
+12/21/2019,Da Woon Jung,Mike Rodriguez,Red,Light Heavyweight
+12/21/2019,JunYong Park,Marc-Andre Barriault,Red,Middleweight
+12/21/2019,Kyung Ho Kang,Pingyuan Liu,Red,Bantamweight
+12/21/2019,Ciryl Gane,Tanner Boser,Red,Heavyweight
+12/21/2019,SeungWoo Choi,Suman Mokhtarian,Red,Featherweight
+12/21/2019,Omar Morales,Dong Hyun Ma,Red,Lightweight
+12/21/2019,Alexandre Pantoja,Matt Schnell,Red,Flyweight
+12/21/2019,Raoni Barcelos,Said Nurmagomedov,Red,Bantamweight
+12/21/2019,Amanda Lemos,Miranda Granger,Red,Women's Strawweight
+12/21/2019,Alatengheili,Ryan Benoit,Red,Bantamweight
+12/14/2019,Kamaru Usman,Colby Covington,Red,UFC Welterweight Title
+12/14/2019,Alexander Volkanovski,Max Holloway,Red,UFC Featherweight Title
+12/14/2019,Amanda Nunes,Germaine de Randamie,Red,UFC Women's Bantamweight Title
+12/14/2019,Marlon Moraes,Jose Aldo,Red,Bantamweight
+12/14/2019,Petr Yan,Urijah Faber,Red,Bantamweight
+12/14/2019,Geoff Neal,Mike Perry,Red,Welterweight
+12/14/2019,Irene Aldana,Ketlen Vieira,Red,Women's Bantamweight
+12/14/2019,Omari Akhmedov,Ian Heinisch,Red,Middleweight
+12/14/2019,Matt Brown,Ben Saunders,Red,Welterweight
+12/14/2019,Chase Hooper,Daniel Teymur,Red,Featherweight
+12/14/2019,Brandon Moreno,Kai Kara-France,Red,Flyweight
+12/14/2019,Jessica Eye,Viviane Araujo,Red,Women's Flyweight
+12/14/2019,Punahele Soriano,Oskar Piechota,Red,Middleweight
+12/07/2019,Jairzinho Rozenstruik,Alistair Overeem,Red,Heavyweight
+12/07/2019,Ben Rothwell,Stefan Struve,Red,Heavyweight
+12/07/2019,Aspen Ladd,Yana Santos,Red,Women's Bantamweight
+12/07/2019,Rob Font,Ricky Simon,Red,Bantamweight
+12/07/2019,Tim Means,Thiago Alves,Red,Welterweight
+12/07/2019,Billy Quarantillo,Jacob Kilburn,Red,Featherweight
+12/07/2019,Bryce Mitchell,Matt Sayles,Red,Featherweight
+12/07/2019,Joe Solecki,Matt Wiman,Red,Lightweight
+12/07/2019,Virna Jandiroba,Mallory Martin,Red,Women's Strawweight
+12/07/2019,Makhmud Muradov,Trevor Smith,Red,Middleweight
+11/16/2019,Jan Blachowicz,Jacare Souza,Red,Light Heavyweight
+11/16/2019,Charles Oliveira,Jared Gordon,Red,Lightweight
+11/16/2019,Andre Muniz,Antonio Arroyo,Red,Middleweight
+11/16/2019,Wellington Turman,Markus Perez,Red,Middleweight
+11/16/2019,James Krause,Sergio Moraes,Red,Welterweight
+11/16/2019,Ricardo Ramos,Eduardo Garagorri,Red,Featherweight
+11/16/2019,Francisco Trinaldo,Bobby Green,Red,Lightweight
+11/16/2019,Randy Brown,Warlley Alves,Red,Welterweight
+11/16/2019,Douglas Silva de Andrade,Renan Barao,Red,Featherweight
+11/16/2019,Ariane Lipski,Isabela de Padua,Red,Women's Flyweight
+11/16/2019,Tracy Cortez,Vanessa Melo,Red,Women's Bantamweight
+11/09/2019,Zabit Magomedsharipov,Calvin Kattar,Red,Featherweight
+11/09/2019,Alexander Volkov,Greg Hardy,Red,Heavyweight
+11/09/2019,Danny Roberts,Zelim Imadaev,Red,Welterweight
+11/09/2019,Ed Herman,Khadis Ibragimov,Red,Light Heavyweight
+11/09/2019,Anthony Rocco Martin,Ramazan Emeev,Red,Welterweight
+11/09/2019,Shamil Gamzatov,Klidson Abreu,Red,Light Heavyweight
+11/09/2019,Magomed Ankalaev,Dalcha Lungiambula,Red,Light Heavyweight
+11/09/2019,Rustam Khabilov,Sergey Khandozhko,Red,Welterweight
+11/09/2019,Karl Roberson,Roman Kopylov,Red,Middleweight
+11/09/2019,David Zawada,Abubakar Nurmagomedov,Red,Welterweight
+11/09/2019,Roosevelt Roberts,Alexander Yakovlev,Red,Lightweight
+11/09/2019,Pannie Kianzad,Jessica-Rose Clark,Red,Women's Bantamweight
+11/09/2019,Davey Grant,Grigory Popov,Red,Bantamweight
+11/02/2019,Jorge Masvidal,Nate Diaz,Red,Welterweight
+11/02/2019,Darren Till,Kelvin Gastelum,Red,Middleweight
+11/02/2019,Stephen Thompson,Vicente Luque,Red,Welterweight
+11/02/2019,Derrick Lewis,Blagoy Ivanov,Red,Heavyweight
+11/02/2019,Kevin Lee,Gregor Gillespie,Red,Lightweight
+11/02/2019,Corey Anderson,Johnny Walker,Red,Light Heavyweight
+11/02/2019,Shane Burgos,Makwan Amirkhani,Red,Featherweight
+11/02/2019,Edmen Shahbazyan,Brad Tavares,Red,Middleweight
+11/02/2019,Jairzinho Rozenstruik,Andrei Arlovski,Red,Heavyweight
+11/02/2019,Katlyn Cerminara,Jennifer Maia,Red,Women's Flyweight
+11/02/2019,Lyman Good,Chance Rencountre,Red,Welterweight
+11/02/2019,Hakeem Dawodu,Julio Arce,Red,Featherweight
+10/26/2019,Demian Maia,Ben Askren,Red,Welterweight
+10/26/2019,Stevie Ray,Michael Johnson,Red,Lightweight
+10/26/2019,Beneil Dariush,Frank Camacho,Red,Lightweight
+10/26/2019,Ciryl Gane,Don'Tale Mayes,Red,Heavyweight
+10/26/2019,Muslim Salikhov,Laureano Staropoli,Red,Welterweight
+10/26/2019,Randa Markos,Ashley Yoder,Red,Women's Strawweight
+10/26/2019,Rafael Fiziev,Alex White,Red,Lightweight
+10/26/2019,Movsar Evloev,Enrique Barzola,Red,Featherweight
+10/26/2019,Sergei Pavlovich,Maurice Greene,Red,Heavyweight
+10/26/2019,Loma Lookboonmee,Aleksandra Albu,Red,Women's Strawweight
+10/26/2019,Raphael Pessoa,Jeff Hughes,Red,Heavyweight
+10/18/2019,Dominick Reyes,Chris Weidman,Red,Light Heavyweight
+10/18/2019,Yair Rodriguez,Jeremy Stephens,Red,Featherweight
+10/18/2019,Joe Lauzon,Jonathan Pearce,Red,Lightweight
+10/18/2019,Maycee Barber,Gillian Robertson,Red,Women's Flyweight
+10/18/2019,Darren Stewart,Deron Winn,Red,Middleweight
+10/18/2019,Charles Rosa,Manny Bermudez,Red,Featherweight
+10/18/2019,Molly McCann,Diana Belbita,Red,Women's Flyweight
+10/18/2019,Sean Woodson,Kyle Bochniak,Red,Featherweight
+10/18/2019,Randy Costa,Boston Salmon,Red,Bantamweight
+10/18/2019,Sean Brady,Court McGee,Red,Welterweight
+10/18/2019,Brendan Allen,Kevin Holland,Red,Middleweight
+10/18/2019,Tanner Boser,Daniel Spitz,Red,Heavyweight
+10/12/2019,Joanna Jedrzejczyk,Michelle Waterson-Gomez,Red,Women's Strawweight
+10/12/2019,Cub Swanson,Kron Gracie,Red,Featherweight
+10/12/2019,Niko Price,James Vick,Red,Welterweight
+10/12/2019,Amanda Ribas,Mackenzie Dern,Red,Women's Strawweight
+10/12/2019,Matt Frevola,Luis Pena,Red,Lightweight
+10/12/2019,Eryk Anders,Gerald Meerschaert,Red,Middleweight
+10/12/2019,Ryan Spann,Devin Clark,Red,Light Heavyweight
+10/12/2019,Mike Davis,Thomas Gifford,Red,Lightweight
+10/12/2019,Alex Morono,Max Griffin,Red,Welterweight
+10/12/2019,Deiveson Figueiredo,Tim Elliott,Red,Flyweight
+10/12/2019,Marlon Vera,Andre Ewell,Red,Bantamweight
+10/12/2019,Miguel Baeza,Hector Aldana,Red,Welterweight
+10/12/2019,Marvin Vettori,Andrew Sanchez,Red,Middleweight
+10/12/2019,JJ Aldrich,Lauren Mueller,Red,Women's Flyweight
+10/05/2019,Israel Adesanya,Robert Whittaker,Red,UFC Middleweight Title
+10/05/2019,Dan Hooker,Al Iaquinta,Red,Lightweight
+10/05/2019,Serghei Spivac,Tai Tuivasa,Red,Heavyweight
+10/05/2019,Dhiego Lima,Luke Jumeau,Red,Welterweight
+10/05/2019,Yorgan De Castro,Justin Tafa,Red,Heavyweight
+10/05/2019,Jake Matthews,Rostem Akman,Red,Welterweight
+10/05/2019,Callan Potter,Maki Pitolo,Red,Welterweight
+10/05/2019,Brad Riddell,Jamie Mullarkey,Red,Lightweight
+10/05/2019,Megan Anderson,Zarah Fairn,Red,Women's Featherweight
+10/05/2019,Ji Yeon Kim,Nadia Kassem,Red,Women's Flyweight
+09/28/2019,Jared Cannonier,Jack Hermansson,Red,Middleweight
+09/28/2019,Mark Madsen,Danilo Belluardo,Red,Lightweight
+09/28/2019,Gilbert Burns,Gunnar Nelson,Red,Welterweight
+09/28/2019,Ion Cutelaba,Khalil Rountree Jr.,Red,Light Heavyweight
+09/28/2019,Ovince Saint Preux,Michal Oleksiejczuk,Red,Light Heavyweight
+09/28/2019,Nicolas Dalby,Alex Oliveira,Red,Welterweight
+09/28/2019,John Phillips,Alen Amedovski,Red,Middleweight
+09/28/2019,Makhmud Muradov,Alessio Di Chirico,Red,Middleweight
+09/28/2019,Ismail Naurdiev,Siyar Bahadurzada,Red,Welterweight
+09/28/2019,Giga Chikadze,Brandon Davis,Red,Featherweight
+09/28/2019,Lina Lansberg,Macy Chiasson,Red,Women's Bantamweight
+09/28/2019,Marc Diakiese,Lando Vannata,Red,Lightweight
+09/28/2019,Jack Shore,Nohelin Hernandez,Red,Bantamweight
+09/21/2019,Carla Esparza,Alexa Grasso,Red,Women's Strawweight
+09/21/2019,Irene Aldana,Vanessa Melo,Red,Women's Bantamweight
+09/21/2019,Steven Peterson,Martin Bravo,Red,Featherweight
+09/21/2019,Jose Quinonez,Carlos Huachin,Red,Bantamweight
+09/21/2019,Kyle Nelson,Marco Polo Reyes,Red,Featherweight
+09/21/2019,Angela Hill,Ariane Carnelossi,Red,Women's Strawweight
+09/21/2019,Sergio Pettis,Tyson Nam,Red,Flyweight
+09/21/2019,Paul Craig,Vinicius Moreira,Red,Light Heavyweight
+09/21/2019,Bethe Correia,Sijara Eubanks,Red,Women's Bantamweight
+09/21/2019,Claudio Puelles,Marcos Mariano,Red,Lightweight
+09/14/2019,Justin Gaethje,Donald Cerrone,Red,Lightweight
+09/14/2019,Glover Teixeira,Nikita Krylov,Red,Light Heavyweight
+09/14/2019,Tristan Connelly,Michel Pereira,Red,Welterweight
+09/14/2019,Uriah Hall,Antonio Carlos Junior,Red,Middleweight
+09/14/2019,Misha Cirkunov,Jimmy Crute,Red,Light Heavyweight
+09/14/2019,Augusto Sakai,Marcin Tybura,Red,Heavyweight
+09/14/2019,Miles Johns,Cole Smith,Red,Bantamweight
+09/14/2019,Hunter Azure,Brad Katona,Red,Bantamweight
+09/14/2019,Chas Skelly,Jordan Griffin,Red,Featherweight
+09/14/2019,Louis Smolka,Ryan MacDonald,Red,Bantamweight
+09/14/2019,Austin Hubbard,Kyle Prepolec,Red,Lightweight
+09/07/2019,Khabib Nurmagomedov,Dustin Poirier,Red,UFC Lightweight Title
+09/07/2019,Paul Felder,Edson Barboza,Red,Lightweight
+09/07/2019,Islam Makhachev,Davi Ramos,Red,Lightweight
+09/07/2019,Curtis Blaydes,Shamil Abdurakhimov,Red,Heavyweight
+09/07/2019,Diego Ferreira,Mairbek Taisumov,Red,Lightweight
+09/07/2019,Joanne Wood,Andrea Lee,Red,Women's Flyweight
+09/07/2019,Sarah Moras,Liana Jojua,Red,Women's Bantamweight
+09/07/2019,Ottman Azaitar,Teemu Packalen,Red,Lightweight
+09/07/2019,Belal Muhammad,Takashi Sato,Red,Welterweight
+09/07/2019,Muslim Salikhov,Nordine Taleb,Red,Welterweight
+09/07/2019,Omari Akhmedov,Zak Cummings,Red,Middleweight
+09/07/2019,Don Madge,Fares Ziam,Red,Lightweight
+08/31/2019,Zhang Weili,Jessica Andrade,Red,UFC Women's Strawweight Title
+08/31/2019,Li Jingliang,Elizeu Zaleski dos Santos,Red,Welterweight
+08/31/2019,Kai Kara-France,Mark De La Rosa,Red,Flyweight
+08/31/2019,Song Kenan,Derrick Krantz,Red,Welterweight
+08/31/2019,Mizuki,Wu Yanan,Red,Women's Flyweight
+08/31/2019,Anthony Hernandez,JunYong Park,Red,Middleweight
+08/31/2019,Sumudaerji,Andre Soukhamthath,Red,Bantamweight
+08/31/2019,Da Woon Jung,Khadis Ibragimov,Red,Light Heavyweight
+08/31/2019,Damir Ismagulov,Thiago Moises,Red,Lightweight
+08/31/2019,Alatengheili,Batgerel Danaa,Red,Bantamweight
+08/31/2019,Karol Rosa,Lara Procopio,Red,Women's Bantamweight
+08/17/2019,Stipe Miocic,Daniel Cormier,Red,UFC Heavyweight Title
+08/17/2019,Nate Diaz,Anthony Pettis,Red,Welterweight
+08/17/2019,Paulo Costa,Yoel Romero,Red,Middleweight
+08/17/2019,Sodiq Yusuff,Gabriel Benitez,Red,Featherweight
+08/17/2019,Derek Brunson,Ian Heinisch,Red,Middleweight
+08/17/2019,Khama Worthy,Devonte Smith,Red,Lightweight
+08/17/2019,Cory Sandhagen,Raphael Assuncao,Red,Bantamweight
+08/17/2019,Drakkar Klose,Christos Giagos,Red,Lightweight
+08/17/2019,Casey Kenney,Manny Bermudez,Red,Catch Weight
+08/17/2019,Hannah Cifers,Jodie Esquibel,Red,Women's Strawweight
+08/17/2019,Kyung Ho Kang,Brandon Davis,Red,Bantamweight
+08/17/2019,Sabina Mazo,Shana Dobson,Red,Women's Flyweight
+08/10/2019,Valentina Shevchenko,Liz Carmouche,Red,UFC Women's Flyweight Title
+08/10/2019,Vicente Luque,Mike Perry,Red,Welterweight
+08/10/2019,Eduardo Garagorri,Humberto Bandenay,Red,Featherweight
+08/10/2019,Volkan Oezdemir,Ilir Latifi,Red,Light Heavyweight
+08/10/2019,Rodolfo Vieira,Oskar Piechota,Red,Middleweight
+08/10/2019,Enrique Barzola,Bobby Moffett,Red,Featherweight
+08/10/2019,Gilbert Burns,Aleksei Kunchenko,Red,Welterweight
+08/10/2019,Ciryl Gane,Raphael Pessoa,Red,Heavyweight
+08/10/2019,Marina Rodriguez,Tecia Torres,Red,Women's Strawweight
+08/10/2019,Rogerio Bontorin,Raulian Paiva,Red,Flyweight
+08/10/2019,Chris Gutierrez,Geraldo de Freitas,Red,Bantamweight
+08/10/2019,Alex Da Silva,Kazula Vargas,Red,Lightweight
+08/10/2019,Veronica Hardy,Polyana Viana,Red,Women's Flyweight
+08/03/2019,Colby Covington,Robbie Lawler,Red,Welterweight
+08/03/2019,Jim Miller,Clay Guida,Red,Lightweight
+08/03/2019,Nasrat Haqparast,Joaquim Silva,Red,Lightweight
+08/03/2019,Gerald Meerschaert,Trevin Giles,Red,Middleweight
+08/03/2019,Scott Holtzman,Dong Hyun Ma,Red,Lightweight
+08/03/2019,Kennedy Nzechukwu,Darko Stosic,Red,Light Heavyweight
+08/03/2019,Mickey Gall,Salim Touahri,Red,Welterweight
+08/03/2019,Antonina Shevchenko,Lucie Pudilova,Red,Women's Flyweight
+08/03/2019,Matt Schnell,Jordan Espinosa,Red,Flyweight
+08/03/2019,Lauren Murphy,Mara Romero Borella,Red,Women's Flyweight
+08/03/2019,Claudio Silva,Cole Williams,Red,Welterweight
+08/03/2019,Miranda Granger,Hannah Goldy,Red,Women's Flyweight
+07/27/2019,Max Holloway,Frankie Edgar,Red,UFC Featherweight Title
+07/27/2019,Cristiane Justino,Felicia Spencer,Red,Women's Featherweight
+07/27/2019,Geoff Neal,Niko Price,Red,Welterweight
+07/27/2019,Arman Tsarukyan,Olivier Aubin-Mercier,Red,Lightweight
+07/27/2019,Krzysztof Jotko,Marc-Andre Barriault,Red,Middleweight
+07/27/2019,Viviane Araujo,Alexis Davis,Red,Women's Flyweight
+07/27/2019,Hakeem Dawodu,Yoshinori Horie,Red,Featherweight
+07/27/2019,Gavin Tucker,SeungWoo Choi,Red,Featherweight
+07/27/2019,Deiveson Figueiredo,Alexandre Pantoja,Red,Flyweight
+07/27/2019,Gillian Robertson,Sarah Frota,Red,Women's Flyweight
+07/27/2019,Erik Koch,Kyle Stewart,Red,Welterweight
+07/20/2019,Leon Edwards,Rafael Dos Anjos,Red,Welterweight
+07/20/2019,Walt Harris,Aleksei Oleinik,Red,Heavyweight
+07/20/2019,Greg Hardy,Juan Adams,Red,Heavyweight
+07/20/2019,Dan Hooker,James Vick,Red,Lightweight
+07/20/2019,Alexander Hernandez,Francisco Trinaldo,Red,Lightweight
+07/20/2019,Andrei Arlovski,Ben Rothwell,Red,Heavyweight
+07/20/2019,Alex Caceres,Steven Peterson,Red,Featherweight
+07/20/2019,Raquel Pennington,Irene Aldana,Red,Women's Bantamweight
+07/20/2019,Klidson Abreu,Sam Alvey,Red,Light Heavyweight
+07/20/2019,Jennifer Maia,Roxanne Modafferi,Red,Women's Flyweight
+07/20/2019,Ray Borg,Gabriel Silva,Red,Bantamweight
+07/20/2019,Mario Bautista,Jin Soo Son,Red,Bantamweight
+07/20/2019,Felipe Colares,Domingo Pilarte,Red,Bantamweight
+07/13/2019,Germaine de Randamie,Aspen Ladd,Red,Women's Bantamweight
+07/13/2019,Urijah Faber,Ricky Simon,Red,Bantamweight
+07/13/2019,Josh Emmett,Mirsad Bektic,Red,Featherweight
+07/13/2019,Karl Roberson,Wellington Turman,Red,Middleweight
+07/13/2019,Marvin Vettori,Cezar Ferreira,Red,Middleweight
+07/13/2019,Andre Fili,Sheymon Moraes,Red,Featherweight
+07/13/2019,Julianna Pena,Nicco Montano,Red,Women's Bantamweight
+07/13/2019,Ryan Hall,Darren Elkins,Red,Featherweight
+07/13/2019,Jonathan Martinez,Pingyuan Liu,Red,Bantamweight
+07/13/2019,Brianna Fortino,Livinha Souza,Red,Women's Strawweight
+07/13/2019,Benito Lopez,Vince Morales,Red,Bantamweight
+07/06/2019,Jon Jones,Thiago Santos,Red,UFC Light Heavyweight Title
+07/06/2019,Amanda Nunes,Holly Holm,Red,UFC Women's Bantamweight Title
+07/06/2019,Jorge Masvidal,Ben Askren,Red,Welterweight
+07/06/2019,Jan Blachowicz,Luke Rockhold,Red,Light Heavyweight
+07/06/2019,Michael Chiesa,Diego Sanchez,Red,Welterweight
+07/06/2019,Arnold Allen,Gilbert Melendez,Red,Featherweight
+07/06/2019,Marlon Vera,Nohelin Hernandez,Red,Bantamweight
+07/06/2019,Claudia Gadelha,Randa Markos,Red,Women's Strawweight
+07/06/2019,Song Yadong,Alejandro Perez,Red,Bantamweight
+07/06/2019,Edmen Shahbazyan,Jack Marshman,Red,Middleweight
+07/06/2019,Chance Rencountre,Ismail Naurdiev,Red,Welterweight
+07/06/2019,Julia Avila,Pannie Kianzad,Red,Women's Bantamweight
+06/29/2019,Francis Ngannou,Junior Dos Santos,Red,Heavyweight
+06/29/2019,Joseph Benavidez,Jussier Formiga,Red,Flyweight
+06/29/2019,Demian Maia,Anthony Rocco Martin,Red,Welterweight
+06/29/2019,Vinc Pichel,Roosevelt Roberts,Red,Lightweight
+06/29/2019,Drew Dober,Marco Polo Reyes,Red,Lightweight
+06/29/2019,Alonzo Menifield,Paul Craig,Red,Light Heavyweight
+06/29/2019,Ricardo Ramos,Journey Newson,Red,Bantamweight
+06/29/2019,Eryk Anders,Vinicius Moreira,Red,Light Heavyweight
+06/29/2019,Jared Gordon,Dan Moret,Red,Lightweight
+06/29/2019,Dalcha Lungiambula,Dequan Townsend,Red,Light Heavyweight
+06/29/2019,Amanda Ribas,Emily Whitmire,Red,Women's Strawweight
+06/29/2019,Maurice Greene,Junior Albini,Red,Heavyweight
+06/22/2019,Chan Sung Jung,Renato Moicano,Red,Featherweight
+06/22/2019,Randy Brown,Bryan Barberena,Red,Welterweight
+06/22/2019,Andre Ewell,Anderson Dos Santos,Red,Bantamweight
+06/22/2019,Andrea Lee,Montana De La Rosa,Red,Women's Flyweight
+06/22/2019,Kevin Holland,Alessio Di Chirico,Red,Middleweight
+06/22/2019,Dan Ige,Kevin Aguilar,Red,Featherweight
+06/22/2019,Ashley Yoder,Syuri Kondo,Red,Women's Strawweight
+06/22/2019,Luis Pena,Matt Wiman,Red,Lightweight
+06/22/2019,Jairzinho Rozenstruik,Allen Crowder,Red,Heavyweight
+06/22/2019,Molly McCann,Ariane Lipski,Red,Women's Flyweight
+06/22/2019,Deron Winn,Eric Spicely,Red,Middleweight
+06/08/2019,Henry Cejudo,Marlon Moraes,Red,UFC Bantamweight Title
+06/08/2019,Valentina Shevchenko,Jessica Eye,Red,UFC Women's Flyweight Title
+06/08/2019,Tony Ferguson,Donald Cerrone,Red,Lightweight
+06/08/2019,Petr Yan,Jimmie Rivera,Red,Bantamweight
+06/08/2019,Blagoy Ivanov,Tai Tuivasa,Red,Heavyweight
+06/08/2019,Tatiana Suarez,Nina Nunes,Red,Women's Strawweight
+06/08/2019,Aljamain Sterling,Pedro Munhoz,Red,Bantamweight
+06/08/2019,Alexa Grasso,Karolina Kowalkiewicz,Red,Women's Strawweight
+06/08/2019,Calvin Kattar,Ricardo Lamas,Red,Featherweight
+06/08/2019,Yan Xiaonan,Angela Hill,Red,Women's Strawweight
+06/08/2019,Darren Stewart,Bevon Lewis,Red,Middleweight
+06/08/2019,Eddie Wineland,Grigory Popov,Red,Bantamweight
+06/08/2019,Katlyn Cerminara,Joanne Wood,Red,Women's Flyweight
+06/01/2019,Anthony Smith,Alexander Gustafsson,Red,Light Heavyweight
+06/01/2019,Aleksandar Rakic,Jimi Manuwa,Red,Light Heavyweight
+06/01/2019,Makwan Amirkhani,Chris Fishgold,Red,Featherweight
+06/01/2019,Christos Giagos,Damir Hadzovic,Red,Lightweight
+06/01/2019,Daniel Teymur,Sung Bin Jo,Red,Featherweight
+06/01/2019,Sergey Khandozhko,Rostem Akman,Red,Welterweight
+06/01/2019,Lina Lansberg,Tonya Evinger,Red,Women's Bantamweight
+06/01/2019,Leonardo Santos,Stevie Ray,Red,Lightweight
+06/01/2019,Frank Camacho,Nick Hein,Red,Lightweight
+06/01/2019,Bea Malecki,Duda Santana,Red,Women's Bantamweight
+06/01/2019,Devin Clark,Darko Stosic,Red,Light Heavyweight
+06/01/2019,Joel Alvarez,Danilo Belluardo,Red,Lightweight
+05/18/2019,Rafael Dos Anjos,Kevin Lee,Red,Welterweight
+05/18/2019,Ian Heinisch,Antonio Carlos Junior,Red,Middleweight
+05/18/2019,Felicia Spencer,Megan Anderson,Red,Women's Featherweight
+05/18/2019,Vicente Luque,Derrick Krantz,Red,Welterweight
+05/18/2019,Charles Oliveira,Nik Lentz,Red,Lightweight
+05/18/2019,Davi Ramos,Austin Hubbard,Red,Lightweight
+05/18/2019,Aspen Ladd,Sijara Eubanks,Red,Women's Bantamweight
+05/18/2019,Desmond Green,Charles Jourdain,Red,Lightweight
+05/18/2019,Michel Pereira,Danny Roberts,Red,Welterweight
+05/18/2019,Grant Dawson,Michael Trizano,Red,Featherweight
+05/18/2019,Ed Herman,Patrick Cummins,Red,Light Heavyweight
+05/18/2019,Zak Cummings,Trevin Giles,Red,Middleweight
+05/18/2019,Julio Arce,Julian Erosa,Red,Featherweight
+05/11/2019,Jessica Andrade,Rose Namajunas,Red,UFC Women's Strawweight Title
+05/11/2019,Jared Cannonier,Anderson Silva,Red,Middleweight
+05/11/2019,Alexander Volkanovski,Jose Aldo,Red,Featherweight
+05/11/2019,Laureano Staropoli,Thiago Alves,Red,Welterweight
+05/11/2019,Irene Aldana,Bethe Correia,Red,Women's Bantamweight
+05/11/2019,Ryan Spann,Rogerio Nogueira,Red,Light Heavyweight
+05/11/2019,Thiago Moises,Kurt Holobaugh,Red,Lightweight
+05/11/2019,Warlley Alves,Sergio Moraes,Red,Welterweight
+05/11/2019,Clay Guida,BJ Penn,Red,Lightweight
+05/11/2019,Luana Carolina,Priscila Cachoeira,Red,Women's Flyweight
+05/11/2019,Raoni Barcelos,Carlos Huachin,Red,Bantamweight
+05/11/2019,Viviane Araujo,Talita Bernardo,Red,Women's Bantamweight
+05/04/2019,Donald Cerrone,Al Iaquinta,Red,Lightweight
+05/04/2019,Derek Brunson,Elias Theodorou,Red,Middleweight
+05/04/2019,Shane Burgos,Cub Swanson,Red,Featherweight
+05/04/2019,Merab Dvalishvili,Brad Katona,Red,Bantamweight
+05/04/2019,Walt Harris,Serghei Spivac,Red,Heavyweight
+05/04/2019,Andrew Sanchez,Marc-Andre Barriault,Red,Middleweight
+05/04/2019,Macy Chiasson,Sarah Moras,Red,Women's Bantamweight
+05/04/2019,Vince Morales,Aiemann Zahabi,Red,Bantamweight
+05/04/2019,Nordine Taleb,Kyle Prepolec,Red,Welterweight
+05/04/2019,Matt Sayles,Kyle Nelson,Red,Featherweight
+05/04/2019,Arjan Bhullar,Juan Adams,Red,Heavyweight
+05/04/2019,Cole Smith,Mitch Gagnon,Red,Bantamweight
+04/27/2019,Jack Hermansson,Jacare Souza,Red,Middleweight
+04/27/2019,Greg Hardy,Dmitrii Smoliakov,Red,Heavyweight
+04/27/2019,Mike Perry,Alex Oliveira,Red,Welterweight
+04/27/2019,Glover Teixeira,Ion Cutelaba,Red,Light Heavyweight
+04/27/2019,Cory Sandhagen,John Lineker,Red,Bantamweight
+04/27/2019,Roosevelt Roberts,Thomas Gifford,Red,Lightweight
+04/27/2019,Takashi Sato,Ben Saunders,Red,Welterweight
+04/27/2019,Augusto Sakai,Andrei Arlovski,Red,Heavyweight
+04/27/2019,Carla Esparza,Virna Jandiroba,Red,Women's Strawweight
+04/27/2019,Gilbert Burns,Mike Davis,Red,Lightweight
+04/27/2019,Jim Miller,Jason Gonzalez,Red,Lightweight
+04/27/2019,Angela Hill,Jodie Esquibel,Red,Women's Strawweight
+04/27/2019,Dhiego Lima,Court McGee,Red,Welterweight
+04/20/2019,Alistair Overeem,Aleksei Oleinik,Red,Heavyweight
+04/20/2019,Islam Makhachev,Arman Tsarukyan,Red,Lightweight
+04/20/2019,Sergei Pavlovich,Marcelo Golm,Red,Heavyweight
+04/20/2019,Roxanne Modafferi,Antonina Shevchenko,Red,Women's Flyweight
+04/20/2019,Krzysztof Jotko,Alen Amedovski,Red,Middleweight
+04/20/2019,Movsar Evloev,SeungWoo Choi,Red,Featherweight
+04/20/2019,Sultan Aliev,Keita Nakamura,Red,Welterweight
+04/20/2019,Alexander Yakovlev,Alex Da Silva,Red,Lightweight
+04/20/2019,Shamil Abdurakhimov,Marcin Tybura,Red,Heavyweight
+04/20/2019,Michal Oleksiejczuk,Gadzhimurad Antigulov,Red,Light Heavyweight
+04/20/2019,Magomed Mustafaev,Rafael Fiziev,Red,Lightweight
+04/13/2019,Dustin Poirier,Max Holloway,Red,UFC Interim Lightweight Title
+04/13/2019,Israel Adesanya,Kelvin Gastelum,Red,UFC Interim Middleweight Title
+04/13/2019,Khalil Rountree Jr.,Eryk Anders,Red,Light Heavyweight
+04/13/2019,Dwight Grant,Alan Jouban,Red,Welterweight
+04/13/2019,Nikita Krylov,Ovince Saint Preux,Red,Light Heavyweight
+04/13/2019,Matt Frevola,Jalin Turner,Red,Lightweight
+04/13/2019,Alexandre Pantoja,Wilson Reis,Red,Flyweight
+04/13/2019,Max Griffin,Zelim Imadaev,Red,Welterweight
+04/13/2019,Khalid Taha,Boston Salmon,Red,Bantamweight
+04/13/2019,Belal Muhammad,Curtis Millender,Red,Welterweight
+04/13/2019,Montel Jackson,Andre Soukhamthath,Red,Bantamweight
+04/13/2019,Poliana Botelho,Lauren Mueller,Red,Women's Flyweight
+04/13/2019,Brandon Davis,Randy Costa,Red,Bantamweight
+03/30/2019,Justin Gaethje,Edson Barboza,Red,Lightweight
+03/30/2019,Jack Hermansson,David Branch,Red,Middleweight
+03/30/2019,Josh Emmett,Michael Johnson,Red,Featherweight
+03/30/2019,Michelle Waterson-Gomez,Karolina Kowalkiewicz,Red,Women's Strawweight
+03/30/2019,Paul Craig,Kennedy Nzechukwu,Red,Light Heavyweight
+03/30/2019,Sodiq Yusuff,Sheymon Moraes,Red,Featherweight
+03/30/2019,Marina Rodriguez,Jessica Aguilar,Red,Women's Strawweight
+03/30/2019,Desmond Green,Ross Pearson,Red,Lightweight
+03/30/2019,Kevin Aguilar,Enrique Barzola,Red,Featherweight
+03/30/2019,Kevin Holland,Gerald Meerschaert,Red,Middleweight
+03/30/2019,Casey Kenney,Ray Borg,Red,Bantamweight
+03/30/2019,Maryna Moroz,Sabina Mazo,Red,Women's Flyweight
+03/30/2019,Alex Perez,Mark De La Rosa,Red,Bantamweight
+03/23/2019,Anthony Pettis,Stephen Thompson,Red,Welterweight
+03/23/2019,Curtis Blaydes,Justin Willis,Red,Heavyweight
+03/23/2019,John Makdessi,Jesus Pinedo,Red,Lightweight
+03/23/2019,Jussier Formiga,Deiveson Figueiredo,Red,Flyweight
+03/23/2019,Luis Pena,Steven Peterson,Red,Featherweight
+03/23/2019,Maycee Barber,JJ Aldrich,Red,Women's Flyweight
+03/23/2019,Bryce Mitchell,Bobby Moffett,Red,Featherweight
+03/23/2019,Marlon Vera,Frankie Saenz,Red,Bantamweight
+03/23/2019,Jennifer Maia,Alexis Davis,Red,Women's Flyweight
+03/23/2019,Randa Markos,Angela Hill,Red,Women's Strawweight
+03/23/2019,Chris Gutierrez,Ryan MacDonald,Red,Bantamweight
+03/23/2019,Jordan Espinosa,Eric Shelton,Red,Flyweight
+03/16/2019,Jorge Masvidal,Darren Till,Red,Welterweight
+03/16/2019,Leon Edwards,Gunnar Nelson,Red,Welterweight
+03/16/2019,Dominick Reyes,Volkan Oezdemir,Red,Light Heavyweight
+03/16/2019,Nathaniel Wood,Jose Quinonez,Red,Bantamweight
+03/16/2019,Claudio Silva,Danny Roberts,Red,Welterweight
+03/16/2019,Jack Marshman,John Phillips,Red,Middleweight
+03/16/2019,Arnold Allen,Jordan Rinaldi,Red,Featherweight
+03/16/2019,Marc Diakiese,Joe Duffy,Red,Lightweight
+03/16/2019,Saparbeg Safarov,Nicolae Negumereanu,Red,Light Heavyweight
+03/16/2019,Dan Ige,Danny Henry,Red,Featherweight
+03/16/2019,Molly McCann,Priscila Cachoeira,Red,Women's Flyweight
+03/16/2019,Mike Grundy,Nad Narimani,Red,Featherweight
+03/09/2019,Junior Dos Santos,Derrick Lewis,Red,Heavyweight
+03/09/2019,Elizeu Zaleski dos Santos,Curtis Millender,Red,Welterweight
+03/09/2019,Niko Price,Tim Means,Red,Welterweight
+03/09/2019,Blagoy Ivanov,Ben Rothwell,Red,Heavyweight
+03/09/2019,Beneil Dariush,Drew Dober,Red,Lightweight
+03/09/2019,Omari Akhmedov,Tim Boetsch,Red,Middleweight
+03/09/2019,Anthony Rocco Martin,Sergio Moraes,Red,Welterweight
+03/09/2019,Yana Santos,Marion Reneau,Red,Women's Bantamweight
+03/09/2019,Grant Dawson,Julian Erosa,Red,Featherweight
+03/09/2019,Maurice Greene,Jeff Hughes,Red,Heavyweight
+03/09/2019,Matt Schnell,Louis Smolka,Red,Bantamweight
+03/09/2019,Alex Morono,Zak Ottow,Red,Welterweight
+03/09/2019,Alex White,Dan Moret,Red,Lightweight
+03/02/2019,Jon Jones,Anthony Smith,Red,UFC Light Heavyweight Title
+03/02/2019,Kamaru Usman,Tyron Woodley,Red,UFC Welterweight Title
+03/02/2019,Ben Askren,Robbie Lawler,Red,Welterweight
+03/02/2019,Zhang Weili,Tecia Torres,Red,Women's Strawweight
+03/02/2019,Pedro Munhoz,Cody Garbrandt,Red,Bantamweight
+03/02/2019,Zabit Magomedsharipov,Jeremy Stephens,Red,Featherweight
+03/02/2019,Johnny Walker,Misha Cirkunov,Red,Light Heavyweight
+03/02/2019,Cody Stamann,Alejandro Perez,Red,Bantamweight
+03/02/2019,Diego Sanchez,Mickey Gall,Red,Welterweight
+03/02/2019,Edmen Shahbazyan,Charles Byrd,Red,Middleweight
+03/02/2019,Macy Chiasson,Gina Mazany,Red,Women's Bantamweight
+03/02/2019,Hannah Cifers,Polyana Viana,Red,Women's Strawweight
+02/23/2019,Thiago Santos,Jan Blachowicz,Red,Light Heavyweight
+02/23/2019,Stefan Struve,Marcos Rogerio de Lima,Red,Heavyweight
+02/23/2019,Michal Oleksiejczuk,Gian Villante,Red,Light Heavyweight
+02/23/2019,Liz Carmouche,Lucie Pudilova,Red,Women's Flyweight
+02/23/2019,Petr Yan,John Dodson,Red,Bantamweight
+02/23/2019,Magomed Ankalaev,Klidson Abreu,Red,Light Heavyweight
+02/23/2019,Dwight Grant,Carlo Pedersoli Jr.,Red,Welterweight
+02/23/2019,Chris Fishgold,Daniel Teymur,Red,Featherweight
+02/23/2019,Gillian Robertson,Veronica Hardy,Red,Women's Flyweight
+02/23/2019,Damir Hadzovic,Marco Polo Reyes,Red,Lightweight
+02/23/2019,Ismail Naurdiev,Michel Prazeres,Red,Welterweight
+02/23/2019,Diego Ferreira,Rustam Khabilov,Red,Lightweight
+02/23/2019,Damir Ismagulov,Joel Alvarez,Red,Lightweight
+02/17/2019,Francis Ngannou,Cain Velasquez,Red,Heavyweight
+02/17/2019,Paul Felder,James Vick,Red,Lightweight
+02/17/2019,Cynthia Calvillo,Cortney Casey,Red,Women's Strawweight
+02/17/2019,Kron Gracie,Alex Caceres,Red,Featherweight
+02/17/2019,Vicente Luque,Bryan Barberena,Red,Welterweight
+02/17/2019,Andre Fili,Myles Jury,Red,Featherweight
+02/17/2019,Aljamain Sterling,Jimmie Rivera,Red,Bantamweight
+02/17/2019,Manny Bermudez,Benito Lopez,Red,Bantamweight
+02/17/2019,Andrea Lee,Ashlee Evans-Smith,Red,Women's Flyweight
+02/17/2019,Nik Lentz,Scott Holtzman,Red,Lightweight
+02/17/2019,Luke Sanders,Renan Barao,Red,Bantamweight
+02/17/2019,Emily Whitmire,Aleksandra Albu,Red,Women's Strawweight
+02/09/2019,Israel Adesanya,Anderson Silva,Red,Middleweight
+02/09/2019,Lando Vannata,Marcos Mariano,Red,Lightweight
+02/09/2019,Ricky Simon,Rani Yahya,Red,Bantamweight
+02/09/2019,Montana De La Rosa,Nadia Kassem,Red,Women's Flyweight
+02/09/2019,Jimmy Crute,Sam Alvey,Red,Light Heavyweight
+02/09/2019,Devonte Smith,Dong Hyun Ma,Red,Lightweight
+02/09/2019,Shane Young,Austin Arnett,Red,Featherweight
+02/09/2019,Kai Kara-France,Raulian Paiva,Red,Flyweight
+02/09/2019,Kyung Ho Kang,Teruto Ishihara,Red,Bantamweight
+02/09/2019,Jalin Turner,Callan Potter,Red,Lightweight
+02/09/2019,Jonathan Martinez,Wulijiburen,Red,Bantamweight
+02/02/2019,Marlon Moraes,Raphael Assuncao,Red,Bantamweight
+02/02/2019,Jose Aldo,Renato Moicano,Red,Featherweight
+02/02/2019,Demian Maia,Lyman Good,Red,Welterweight
+02/02/2019,Charles Oliveira,David Teymur,Red,Lightweight
+02/02/2019,Johnny Walker,Justin Ledet,Red,Light Heavyweight
+02/02/2019,Livinha Souza,Sarah Frota,Red,Women's Strawweight
+02/02/2019,Markus Perez,Anthony Hernandez,Red,Middleweight
+02/02/2019,Mara Romero Borella,Taila Santos,Red,Women's Flyweight
+02/02/2019,Thiago Alves,Max Griffin,Red,Welterweight
+02/02/2019,Jairzinho Rozenstruik,Junior Albini,Red,Heavyweight
+02/02/2019,Geraldo de Freitas,Felipe Colares,Red,Featherweight
+02/02/2019,Said Nurmagomedov,Ricardo Ramos,Red,Bantamweight
+02/02/2019,Rogerio Bontorin,Bibulatov Magomed,Red,Flyweight
+01/19/2019,Henry Cejudo,TJ Dillashaw,Red,UFC Flyweight Title
+01/19/2019,Allen Crowder,Greg Hardy,Red,Heavyweight
+01/19/2019,Gregor Gillespie,Yancy Medeiros,Red,Lightweight
+01/19/2019,Joseph Benavidez,Dustin Ortiz,Red,Flyweight
+01/19/2019,Paige VanZant,Rachael Ostovich,Red,Women's Flyweight
+01/19/2019,Glover Teixeira,Karl Roberson,Red,Light Heavyweight
+01/19/2019,Donald Cerrone,Alexander Hernandez,Red,Lightweight
+01/19/2019,Joanne Wood,Ariane Lipski,Red,Women's Flyweight
+01/19/2019,Alonzo Menifield,Vinicius Moreira,Red,Light Heavyweight
+01/19/2019,Cory Sandhagen,Mario Bautista,Red,Bantamweight
+01/19/2019,Dennis Bermudez,Te Edwards,Red,Lightweight
+01/19/2019,Geoff Neal,Belal Muhammad,Red,Welterweight
+01/19/2019,Chance Rencountre,Kyle Stewart,Red,Welterweight
+12/29/2018,Jon Jones,Alexander Gustafsson,Red,UFC Light Heavyweight Title
+12/29/2018,Amanda Nunes,Cristiane Justino,Red,UFC Women's Featherweight Title
+12/29/2018,Michael Chiesa,Carlos Condit,Red,Welterweight
+12/29/2018,Corey Anderson,Ilir Latifi,Red,Light Heavyweight
+12/29/2018,Alexander Volkanovski,Chad Mendes,Red,Featherweight
+12/29/2018,Megan Anderson,Cat Zingano,Red,Women's Featherweight
+12/29/2018,Petr Yan,Douglas Silva de Andrade,Red,Bantamweight
+12/29/2018,Ryan Hall,BJ Penn,Red,Lightweight
+12/29/2018,Nathaniel Wood,Andre Ewell,Red,Bantamweight
+12/29/2018,Uriah Hall,Bevon Lewis,Red,Middleweight
+12/29/2018,Curtis Millender,Siyar Bahadurzada,Red,Welterweight
+12/29/2018,Montel Jackson,Brian Kelleher,Red,Bantamweight
+12/15/2018,Al Iaquinta,Kevin Lee,Red,Lightweight
+12/15/2018,Edson Barboza,Dan Hooker,Red,Lightweight
+12/15/2018,Rob Font,Sergio Pettis,Red,Bantamweight
+12/15/2018,Charles Oliveira,Jim Miller,Red,Lightweight
+12/15/2018,Zak Ottow,Dwight Grant,Red,Welterweight
+12/15/2018,Drakkar Klose,Bobby Green,Red,Lightweight
+12/15/2018,Joaquim Silva,Jared Gordon,Red,Lightweight
+12/15/2018,Jack Hermansson,Gerald Meerschaert,Red,Middleweight
+12/15/2018,Zak Cummings,Trevor Smith,Red,Middleweight
+12/15/2018,Dan Ige,Jordan Griffin,Red,Featherweight
+12/15/2018,Mike Rodriguez,Adam Milstead,Red,Light Heavyweight
+12/15/2018,Juan Adams,Chris de la Rocha,Red,Heavyweight
+12/08/2018,Max Holloway,Brian Ortega,Red,UFC Featherweight Title
+12/08/2018,Valentina Shevchenko,Joanna Jedrzejczyk,Red,UFC Women's Flyweight Title
+12/08/2018,Gunnar Nelson,Alex Oliveira,Red,Welterweight
+12/08/2018,Hakeem Dawodu,Kyle Bochniak,Red,Featherweight
+12/08/2018,Thiago Santos,Jimi Manuwa,Red,Light Heavyweight
+12/08/2018,Nina Nunes,Claudia Gadelha,Red,Women's Strawweight
+12/08/2018,Gilbert Burns,Olivier Aubin-Mercier,Red,Lightweight
+12/08/2018,Jessica Eye,Katlyn Cerminara,Red,Women's Flyweight
+12/08/2018,Elias Theodorou,Eryk Anders,Red,Middleweight
+12/08/2018,Brad Katona,Matthew Lopez,Red,Bantamweight
+12/08/2018,Dhiego Lima,Chad Laprise,Red,Welterweight
+12/08/2018,Diego Ferreira,Kyle Nelson,Red,Lightweight
+12/08/2018,Aleksandar Rakic,Devin Clark,Red,Light Heavyweight
+12/01/2018,Junior Dos Santos,Tai Tuivasa,Red,Heavyweight
+12/01/2018,Mauricio Rua,Tyson Pedro,Red,Light Heavyweight
+12/01/2018,Justin Willis,Mark Hunt,Red,Heavyweight
+12/01/2018,Anthony Rocco Martin,Jake Matthews,Red,Welterweight
+12/01/2018,Sodiq Yusuff,Suman Mokhtarian,Red,Featherweight
+12/01/2018,Jimmy Crute,Paul Craig,Red,Light Heavyweight
+12/01/2018,Aleksei Kunchenko,Yushin Okami,Red,Welterweight
+12/01/2018,Wilson Reis,Ben Nguyen,Red,Flyweight
+12/01/2018,Keita Nakamura,Salim Touahri,Red,Welterweight
+12/01/2018,Kai Kara-France,Elias Garcia,Red,Flyweight
+12/01/2018,Christos Giagos,Mizuto Hirota,Red,Lightweight
+12/01/2018,Damir Ismagulov,Alex Gorgees,Red,Lightweight
+11/30/2018,Kamaru Usman,Rafael Dos Anjos,Red,Welterweight
+11/30/2018,Juan Espino,Justin Frazier,Red,Ultimate Fighter 28 Heavyweight Tournament Title
+11/30/2018,Macy Chiasson,Pannie Kianzad,Red,Ultimate Fighter 28 Women's Featherweight Tournament Title
+11/30/2018,Pedro Munhoz,Bryan Caraway,Red,Bantamweight
+11/30/2018,Edmen Shahbazyan,Darren Stewart,Red,Middleweight
+11/30/2018,Antonina Shevchenko,Ji Yeon Kim,Red,Women's Flyweight
+11/30/2018,Kevin Aguilar,Ricky Glenn,Red,Featherweight
+11/30/2018,Joseph Benavidez,Alex Perez,Red,Flyweight
+11/30/2018,Maurice Greene,Michel Batista,Red,Heavyweight
+11/30/2018,Leah Letson,Julija Stoliarenko,Red,Women's Featherweight
+11/30/2018,Roosevelt Roberts,Darrell Horcher,Red,Lightweight
+11/30/2018,Tim Means,Ricky Rainey,Red,Welterweight
+11/30/2018,Raoni Barcelos,Chris Gutierrez,Red,Bantamweight
+11/24/2018,Francis Ngannou,Curtis Blaydes,Red,Heavyweight
+11/24/2018,Alistair Overeem,Sergei Pavlovich,Red,Heavyweight
+11/24/2018,Song Yadong,Vince Morales,Red,Bantamweight
+11/24/2018,Li Jingliang,David Zawada,Red,Welterweight
+11/24/2018,Alex Morono,Song Kenan,Red,Welterweight
+11/24/2018,Wu Yanan,Lauren Mueller,Red,Women's Flyweight
+11/24/2018,Rashad Coulter,Hu Yaozong,Red,Light Heavyweight
+11/24/2018,Zhang Weili,Jessica Aguilar,Red,Women's Strawweight
+11/24/2018,Pingyuan Liu,Martin Day,Red,Bantamweight
+11/24/2018,Yan Xiaonan,Syuri Kondo,Red,Women's Strawweight
+11/24/2018,Kevin Holland,John Phillips,Red,Middleweight
+11/24/2018,Louis Smolka,Sumudaerji,Red,Bantamweight
+11/17/2018,Santiago Ponzinibbio,Neil Magny,Red,Welterweight
+11/17/2018,Ricardo Lamas,Darren Elkins,Red,Featherweight
+11/17/2018,Johnny Walker,Khalil Rountree Jr.,Red,Light Heavyweight
+11/17/2018,Ian Heinisch,Cezar Ferreira,Red,Middleweight
+11/17/2018,Marlon Vera,Guido Cannetti,Red,Bantamweight
+11/17/2018,Cynthia Calvillo,Poliana Botelho,Red,Women's Strawweight
+11/17/2018,Michel Prazeres,Bartosz Fabinski,Red,Welterweight
+11/17/2018,Alexandre Pantoja,Yuta Sasaki,Red,Flyweight
+11/17/2018,Austin Arnett,Humberto Bandenay,Red,Featherweight
+11/17/2018,Laureano Staropoli,Hector Aldana,Red,Welterweight
+11/17/2018,Jesus Pinedo,Devin Powell,Red,Lightweight
+11/17/2018,Nad Narimani,Anderson Dos Santos,Red,Featherweight
+11/10/2018,Yair Rodriguez,Chan Sung Jung,Red,Featherweight
+11/10/2018,Donald Cerrone,Mike Perry,Red,Welterweight
+11/10/2018,Germaine de Randamie,Raquel Pennington,Red,Women's Bantamweight
+11/10/2018,Beneil Dariush,Thiago Moises,Red,Lightweight
+11/10/2018,Maycee Barber,Hannah Cifers,Red,Women's Strawweight
+11/10/2018,Michael Trizano,Luis Pena,Red,Lightweight
+11/10/2018,Ashley Yoder,Amanda Cooper,Red,Women's Strawweight
+11/10/2018,Davi Ramos,John Gunther,Red,Lightweight
+11/10/2018,Devonte Smith,Julian Erosa,Red,Lightweight
+11/10/2018,Eric Shelton,Joseph Morales,Red,Flyweight
+11/10/2018,Mark De La Rosa,Joby Sanchez,Red,Bantamweight
+11/03/2018,Daniel Cormier,Derrick Lewis,Red,UFC Heavyweight Title
+11/03/2018,Jacare Souza,Chris Weidman,Red,Middleweight
+11/03/2018,Jared Cannonier,David Branch,Red,Middleweight
+11/03/2018,Karl Roberson,Jack Marshman,Red,Middleweight
+11/03/2018,Israel Adesanya,Derek Brunson,Red,Middleweight
+11/03/2018,Jordan Rinaldi,Jason Knight,Red,Featherweight
+11/03/2018,Sijara Eubanks,Roxanne Modafferi,Red,Women's Flyweight
+11/03/2018,Sheymon Moraes,Julio Arce,Red,Featherweight
+11/03/2018,Lyman Good,Ben Saunders,Red,Welterweight
+11/03/2018,Shane Burgos,Kurt Holobaugh,Red,Featherweight
+11/03/2018,Marcos Rogerio de Lima,Adam Wieczorek,Red,Heavyweight
+10/27/2018,Anthony Smith,Volkan Oezdemir,Red,Light Heavyweight
+10/27/2018,Michael Johnson,Artem Lobov,Red,Featherweight
+10/27/2018,Misha Cirkunov,Patrick Cummins,Red,Light Heavyweight
+10/27/2018,Andre Soukhamthath,Jonathan Martinez,Red,Bantamweight
+10/27/2018,Gian Villante,Ed Herman,Red,Light Heavyweight
+10/27/2018,Court McGee,Alex Garcia,Red,Welterweight
+10/27/2018,Sean Strickland,Nordine Taleb,Red,Welterweight
+10/27/2018,Nasrat Haqparast,Thibault Gouti,Red,Lightweight
+10/27/2018,Calvin Kattar,Chris Fishgold,Red,Featherweight
+10/27/2018,Talita Bernardo,Sarah Moras,Red,Women's Bantamweight
+10/27/2018,Don Madge,Te Edwards,Red,Lightweight
+10/27/2018,Arjan Bhullar,Marcelo Golm,Red,Heavyweight
+10/27/2018,Stevie Ray,Jessin Ayari,Red,Lightweight
+10/06/2018,Khabib Nurmagomedov,Conor McGregor,Red,UFC Lightweight Title
+10/06/2018,Tony Ferguson,Anthony Pettis,Red,Lightweight
+10/06/2018,Dominick Reyes,Ovince Saint Preux,Red,Light Heavyweight
+10/06/2018,Derrick Lewis,Alexander Volkov,Red,Heavyweight
+10/06/2018,Michelle Waterson-Gomez,Felice Herrig,Red,Women's Strawweight
+10/06/2018,Jussier Formiga,Sergio Pettis,Red,Flyweight
+10/06/2018,Vicente Luque,Jalin Turner,Red,Welterweight
+10/06/2018,Aspen Ladd,Tonya Evinger,Red,Women's Bantamweight
+10/06/2018,Scott Holtzman,Alan Patrick,Red,Lightweight
+10/06/2018,Yana Santos,Lina Lansberg,Red,Women's Bantamweight
+10/06/2018,Nik Lentz,Gray Maynard,Red,Lightweight
+10/06/2018,Anthony Rocco Martin,Ryan LaFlare,Red,Welterweight
+09/22/2018,Thiago Santos,Eryk Anders,Red,Light Heavyweight
+09/22/2018,Alex Oliveira,Carlo Pedersoli Jr.,Red,Welterweight
+09/22/2018,Rogerio Nogueira,Sam Alvey,Red,Light Heavyweight
+09/22/2018,Andre Ewell,Renan Barao,Red,Bantamweight
+09/22/2018,Charles Oliveira,Christos Giagos,Red,Lightweight
+09/22/2018,Francisco Trinaldo,Evan Dunham,Red,Lightweight
+09/22/2018,Ryan Spann,Luis Henrique,Red,Light Heavyweight
+09/22/2018,Augusto Sakai,Chase Sherman,Red,Heavyweight
+09/22/2018,Sergio Moraes,Ben Saunders,Red,Welterweight
+09/22/2018,Mayra Bueno Silva,Gillian Robertson,Red,Women's Flyweight
+09/22/2018,Thales Leites,Hector Lombard,Red,Middleweight
+09/22/2018,Elizeu Zaleski dos Santos,Luigi Vendramini,Red,Welterweight
+09/22/2018,Livinha Souza,Alex Chambers,Red,Women's Strawweight
+09/15/2018,Aleksei Oleinik,Mark Hunt,Red,Heavyweight
+09/15/2018,Jan Blachowicz,Nikita Krylov,Red,Light Heavyweight
+09/15/2018,Shamil Abdurakhimov,Andrei Arlovski,Red,Heavyweight
+09/15/2018,Aleksei Kunchenko,Thiago Alves,Red,Welterweight
+09/15/2018,Khalid Murtazaliev,CB Dollaway,Red,Middleweight
+09/15/2018,Petr Yan,Jin Soo Son,Red,Bantamweight
+09/15/2018,Rustam Khabilov,Kajan Johnson,Red,Lightweight
+09/15/2018,Mairbek Taisumov,Desmond Green,Red,Lightweight
+09/15/2018,Magomed Ankalaev,Marcin Prachnio,Red,Light Heavyweight
+09/15/2018,Jordan Johnson,Adam Yandiev,Red,Middleweight
+09/15/2018,Ramazan Emeev,Stefan Sekulic,Red,Welterweight
+09/15/2018,Merab Dvalishvili,Terrion Ware,Red,Bantamweight
+09/08/2018,Tyron Woodley,Darren Till,Red,UFC Welterweight Title
+09/08/2018,Jessica Andrade,Karolina Kowalkiewicz,Red,Women's Strawweight
+09/08/2018,Zabit Magomedsharipov,Brandon Davis,Red,Featherweight
+09/08/2018,Jimmie Rivera,John Dodson,Red,Bantamweight
+09/08/2018,Abdul Razak Alhassan,Niko Price,Red,Welterweight
+09/08/2018,Tatiana Suarez,Carla Esparza,Red,Women's Strawweight
+09/08/2018,Aljamain Sterling,Cody Stamann,Red,Bantamweight
+09/08/2018,Geoff Neal,Frank Camacho,Red,Welterweight
+09/08/2018,Darren Stewart,Charles Byrd,Red,Middleweight
+09/08/2018,Diego Sanchez,Craig White,Red,Welterweight
+09/08/2018,Jim Miller,Alex White,Red,Lightweight
+09/08/2018,Irene Aldana,Lucie Pudilova,Red,Women's Bantamweight
+09/08/2018,Jarred Brooks,Robert Sanchez,Red,Flyweight
+08/25/2018,Justin Gaethje,James Vick,Red,Lightweight
+08/25/2018,Michael Johnson,Andre Fili,Red,Featherweight
+08/25/2018,Cortney Casey,Angela Hill,Red,Women's Strawweight
+08/25/2018,Bryan Barberena,Jake Ellenberger,Red,Welterweight
+08/25/2018,Deiveson Figueiredo,John Moraga,Red,Flyweight
+08/25/2018,Eryk Anders,Tim Williams,Red,Middleweight
+08/25/2018,James Krause,Warlley Alves,Red,Welterweight
+08/25/2018,Cory Sandhagen,Iuri Alcantara,Red,Bantamweight
+08/25/2018,Andrew Sanchez,Markus Perez,Red,Middleweight
+08/25/2018,Mickey Gall,George Sullivan,Red,Welterweight
+08/25/2018,Joanne Wood,Kalindra Faria,Red,Women's Flyweight
+08/25/2018,Drew Dober,Jon Tuck,Red,Lightweight
+08/25/2018,Rani Yahya,Luke Sanders,Red,Bantamweight
+08/04/2018,TJ Dillashaw,Cody Garbrandt,Red,UFC Bantamweight Title
+08/04/2018,Henry Cejudo,Demetrious Johnson,Red,UFC Flyweight Title
+08/04/2018,Renato Moicano,Cub Swanson,Red,Featherweight
+08/04/2018,JJ Aldrich,Polyana Viana,Red,Women's Strawweight
+08/04/2018,Thiago Santos,Kevin Holland,Red,Middleweight
+08/04/2018,Pedro Munhoz,Brett Johns,Red,Bantamweight
+08/04/2018,Ricky Simon,Montel Jackson,Red,Bantamweight
+08/04/2018,Ricardo Ramos,Kyung Ho Kang,Red,Bantamweight
+08/04/2018,Sheymon Moraes,Matt Sayles,Red,Featherweight
+08/04/2018,Alex Perez,Jose Torres,Red,Flyweight
+08/04/2018,Zhang Weili,Danielle Taylor,Red,Women's Strawweight
+08/04/2018,Marlon Vera,Wulijiburen,Red,Bantamweight
+07/28/2018,Dustin Poirier,Eddie Alvarez,Red,Lightweight
+07/28/2018,Jose Aldo,Jeremy Stephens,Red,Featherweight
+07/28/2018,Joanna Jedrzejczyk,Tecia Torres,Red,Women's Strawweight
+07/28/2018,Alexander Hernandez,Olivier Aubin-Mercier,Red,Lightweight
+07/28/2018,Jordan Mein,Alex Morono,Red,Welterweight
+07/28/2018,Hakeem Dawodu,Austin Arnett,Red,Featherweight
+07/28/2018,Islam Makhachev,Kajan Johnson,Red,Lightweight
+07/28/2018,Ion Cutelaba,Gadzhimurad Antigulov,Red,Light Heavyweight
+07/28/2018,John Makdessi,Ross Pearson,Red,Lightweight
+07/28/2018,Katlyn Cerminara,Alexis Davis,Red,Women's Flyweight
+07/28/2018,Dustin Ortiz,Matheus Nicolau,Red,Flyweight
+07/28/2018,Nina Nunes,Randa Markos,Red,Women's Strawweight
+07/28/2018,Devin Powell,Alvaro Herrera Mendoza,Red,Lightweight
+07/22/2018,Anthony Smith,Mauricio Rua,Red,Light Heavyweight
+07/22/2018,Corey Anderson,Glover Teixeira,Red,Light Heavyweight
+07/22/2018,Abu Azaitar,Vitor Miranda,Red,Middleweight
+07/22/2018,Marcin Tybura,Stefan Struve,Red,Heavyweight
+07/22/2018,Danny Roberts,David Zawada,Red,Welterweight
+07/22/2018,Nasrat Haqparast,Marc Diakiese,Red,Lightweight
+07/22/2018,Damir Hadzovic,Nick Hein,Red,Lightweight
+07/22/2018,Bartosz Fabinski,Emil Meek,Red,Welterweight
+07/22/2018,Nad Narimani,Khalid Taha,Red,Featherweight
+07/22/2018,Aleksandar Rakic,Justin Ledet,Red,Light Heavyweight
+07/22/2018,Manny Bermudez,Davey Grant,Red,Bantamweight
+07/22/2018,Darko Stosic,Jeremy Kimball,Red,Light Heavyweight
+07/22/2018,Pingyuan Liu,Damian Stasiak,Red,Bantamweight
+07/14/2018,Junior Dos Santos,Blagoy Ivanov,Red,Heavyweight
+07/14/2018,Sage Northcutt,Zak Ottow,Red,Welterweight
+07/14/2018,Ricky Glenn,Dennis Bermudez,Red,Featherweight
+07/14/2018,Niko Price,Randy Brown,Red,Welterweight
+07/14/2018,Chad Mendes,Myles Jury,Red,Featherweight
+07/14/2018,Cat Zingano,Marion Reneau,Red,Women's Bantamweight
+07/14/2018,Alejandro Perez,Eddie Wineland,Red,Bantamweight
+07/14/2018,Alexander Volkanovski,Darren Elkins,Red,Featherweight
+07/14/2018,Said Nurmagomedov,Justin Scoggins,Red,Flyweight
+07/14/2018,Raoni Barcelos,Kurt Holobaugh,Red,Featherweight
+07/14/2018,Liz Carmouche,Jennifer Maia,Red,Women's Flyweight
+07/14/2018,Mark De La Rosa,Elias Garcia,Red,Flyweight
+07/14/2018,Jessica Aguilar,Jodie Esquibel,Red,Women's Strawweight
+07/07/2018,Daniel Cormier,Stipe Miocic,Red,UFC Heavyweight Title
+07/07/2018,Derrick Lewis,Francis Ngannou,Red,Heavyweight
+07/07/2018,Mike Perry,Paul Felder,Red,Welterweight
+07/07/2018,Anthony Pettis,Michael Chiesa,Red,Lightweight
+07/07/2018,Khalil Rountree Jr.,Gokhan Saki,Red,Light Heavyweight
+07/07/2018,Paulo Costa,Uriah Hall,Red,Middleweight
+07/07/2018,Raphael Assuncao,Rob Font,Red,Bantamweight
+07/07/2018,Drakkar Klose,Lando Vannata,Red,Lightweight
+07/07/2018,Curtis Millender,Max Griffin,Red,Welterweight
+07/07/2018,Dan Hooker,Gilbert Burns,Red,Lightweight
+07/07/2018,Emily Whitmire,Jamie Moyle,Red,Women's Strawweight
+07/06/2018,Israel Adesanya,Brad Tavares,Red,Middleweight
+07/06/2018,Michael Trizano,Joe Giannetti,Red,Ultimate Fighter 27 Lightweight Tournament Title
+07/06/2018,Brad Katona,Jay Cucciniello,Red,Ultimate Fighter 27 Featherweight Tournament Title
+07/06/2018,Alex Caceres,Martin Bravo,Red,Featherweight
+07/06/2018,Roxanne Modafferi,Barb Honchak,Red,Women's Flyweight
+07/06/2018,Alessio Di Chirico,Julian Marquez,Red,Middleweight
+07/06/2018,Montana De La Rosa,Rachael Ostovich,Red,Women's Flyweight
+07/06/2018,Luis Pena,Richie Smullen,Red,Lightweight
+07/06/2018,John Gunther,Allan Zuniga,Red,Lightweight
+07/06/2018,Bryce Mitchell,Tyler Diamond,Red,Featherweight
+07/06/2018,Steven Peterson,Matt Bessette,Red,Featherweight
+07/06/2018,Gerald Meerschaert,Oskar Piechota,Red,Middleweight
+06/23/2018,Leon Edwards,Donald Cerrone,Red,Welterweight
+06/23/2018,Ovince Saint Preux,Tyson Pedro,Red,Light Heavyweight
+06/23/2018,Jessica Eye,Jessica-Rose Clark,Red,Women's Flyweight
+06/23/2018,Li Jingliang,Daichi Abe,Red,Welterweight
+06/23/2018,Petr Yan,Teruto Ishihara,Red,Bantamweight
+06/23/2018,Song Yadong,Felipe Arantes,Red,Bantamweight
+06/23/2018,Shane Young,Rolando Dy,Red,Featherweight
+06/23/2018,Song Kenan,Hector Aldana,Red,Welterweight
+06/23/2018,Jake Matthews,Shinsho Anzai,Red,Welterweight
+06/23/2018,Yan Xiaonan,Viviane Pereira,Red,Women's Strawweight
+06/23/2018,Matt Schnell,Naoki Inoue,Red,Flyweight
+06/23/2018,Yuta Sasaki,Jenel Lausa,Red,Flyweight
+06/23/2018,Ji Yeon Kim,Melinda Fabian,Red,Women's Flyweight
+06/09/2018,Robert Whittaker,Yoel Romero,Red,Middleweight
+06/09/2018,Colby Covington,Rafael Dos Anjos,Red,UFC Interim Welterweight Title
+06/09/2018,Holly Holm,Megan Anderson,Red,Women's Featherweight
+06/09/2018,Tai Tuivasa,Andrei Arlovski,Red,Heavyweight
+06/09/2018,Curtis Blaydes,Alistair Overeem,Red,Heavyweight
+06/09/2018,Claudia Gadelha,Carla Esparza,Red,Women's Strawweight
+06/09/2018,Mirsad Bektic,Ricardo Lamas,Red,Featherweight
+06/09/2018,Chris de la Rocha,Rashad Coulter,Red,Heavyweight
+06/09/2018,Anthony Smith,Rashad Evans,Red,Light Heavyweight
+06/09/2018,Sergio Pettis,Joseph Benavidez,Red,Flyweight
+06/09/2018,Charles Oliveira,Clay Guida,Red,Lightweight
+06/09/2018,Dan Ige,Mike Santiago,Red,Featherweight
+06/01/2018,Marlon Moraes,Jimmie Rivera,Red,Bantamweight
+06/01/2018,Gregor Gillespie,Vinc Pichel,Red,Lightweight
+06/01/2018,Walt Harris,Daniel Spitz,Red,Heavyweight
+06/01/2018,Ben Saunders,Jake Ellenberger,Red,Welterweight
+06/01/2018,Julio Arce,Daniel Teymur,Red,Featherweight
+06/01/2018,Sam Alvey,Gian Villante,Red,Light Heavyweight
+06/01/2018,Sijara Eubanks,Lauren Murphy,Red,Women's Flyweight
+06/01/2018,David Teymur,Nik Lentz,Red,Lightweight
+06/01/2018,Belal Muhammad,Chance Rencountre,Red,Welterweight
+06/01/2018,Desmond Green,Gleison Tibau,Red,Lightweight
+06/01/2018,Nathaniel Wood,Johnny Eduardo,Red,Bantamweight
+06/01/2018,Jose Torres,Jarred Brooks,Red,Flyweight
+05/27/2018,Darren Till,Stephen Thompson,Red,Welterweight
+05/27/2018,Neil Magny,Craig White,Red,Welterweight
+05/27/2018,Arnold Allen,Mads Burnell,Red,Featherweight
+05/27/2018,Makwan Amirkhani,Jason Knight,Red,Featherweight
+05/27/2018,Claudio Silva,Nordine Taleb,Red,Welterweight
+05/27/2018,Darren Stewart,Eric Spicely,Red,Middleweight
+05/27/2018,Tom Breese,Daniel Kelly,Red,Middleweight
+05/27/2018,Lina Lansberg,Gina Mazany,Red,Women's Bantamweight
+05/27/2018,Carlo Pedersoli Jr.,Brad Scott,Red,Welterweight
+05/27/2018,Gillian Robertson,Molly McCann,Red,Women's Flyweight
+05/27/2018,Elias Theodorou,Trevor Smith,Red,Middleweight
+05/19/2018,Kamaru Usman,Demian Maia,Red,Welterweight
+05/19/2018,Tatiana Suarez,Alexa Grasso,Red,Women's Strawweight
+05/19/2018,Dominick Reyes,Jared Cannonier,Red,Light Heavyweight
+05/19/2018,Guido Cannetti,Diego Rivas,Red,Bantamweight
+05/19/2018,Andrea Lee,Veronica Hardy,Red,Women's Flyweight
+05/19/2018,Vicente Luque,Chad Laprise,Red,Welterweight
+05/19/2018,Michel Prazeres,Zak Cummings,Red,Welterweight
+05/19/2018,Alexandre Pantoja,Brandon Moreno,Red,Flyweight
+05/19/2018,Poliana Botelho,Syuri Kondo,Red,Women's Strawweight
+05/19/2018,Gabriel Benitez,Humberto Bandenay,Red,Featherweight
+05/19/2018,Enrique Barzola,Brandon Davis,Red,Featherweight
+05/19/2018,Frankie Saenz,Henry Briones,Red,Bantamweight
+05/19/2018,Claudio Puelles,Felipe Silva,Red,Lightweight
+05/12/2018,Amanda Nunes,Raquel Pennington,Red,UFC Women's Bantamweight Title
+05/12/2018,Kelvin Gastelum,Jacare Souza,Red,Middleweight
+05/12/2018,Mackenzie Dern,Amanda Cooper,Red,Women's Strawweight
+05/12/2018,John Lineker,Brian Kelleher,Red,Bantamweight
+05/12/2018,Lyoto Machida,Vitor Belfort,Red,Middleweight
+05/12/2018,Cezar Ferreira,Karl Roberson,Red,Middleweight
+05/12/2018,Aleksei Oleinik,Junior Albini,Red,Heavyweight
+05/12/2018,Davi Ramos,Nick Hein,Red,Lightweight
+05/12/2018,Elizeu Zaleski dos Santos,Sean Strickland,Red,Welterweight
+05/12/2018,Warlley Alves,Sultan Aliev,Red,Welterweight
+05/12/2018,Jack Hermansson,Thales Leites,Red,Middleweight
+05/12/2018,Ramazan Emeev,Alberto Mina,Red,Welterweight
+05/12/2018,Markus Perez,James Bochnovic,Red,Middleweight
+04/21/2018,Kevin Lee,Edson Barboza,Red,Lightweight
+04/21/2018,Frankie Edgar,Cub Swanson,Red,Featherweight
+04/21/2018,Justin Willis,Chase Sherman,Red,Heavyweight
+04/21/2018,David Branch,Thiago Santos,Red,Middleweight
+04/21/2018,Aljamain Sterling,Brett Johns,Red,Bantamweight
+04/21/2018,Dan Hooker,Jim Miller,Red,Lightweight
+04/21/2018,Ryan LaFlare,Alex Garcia,Red,Welterweight
+04/21/2018,Ricky Simon,Merab Dvalishvili,Red,Bantamweight
+04/21/2018,Siyar Bahadurzada,Luan Chagas,Red,Welterweight
+04/21/2018,Corey Anderson,Patrick Cummins,Red,Light Heavyweight
+04/21/2018,Anthony Rocco Martin,Keita Nakamura,Red,Welterweight
+04/14/2018,Dustin Poirier,Justin Gaethje,Red,Lightweight
+04/14/2018,Alex Oliveira,Carlos Condit,Red,Welterweight
+04/14/2018,Israel Adesanya,Marvin Vettori,Red,Middleweight
+04/14/2018,Michelle Waterson-Gomez,Cortney Casey,Red,Women's Strawweight
+04/14/2018,Antonio Carlos Junior,Tim Boetsch,Red,Middleweight
+04/14/2018,Muslim Salikhov,Ricky Rainey,Red,Welterweight
+04/14/2018,John Moraga,Wilson Reis,Red,Flyweight
+04/14/2018,Brad Tavares,Krzysztof Jotko,Red,Middleweight
+04/14/2018,Gilbert Burns,Dan Moret,Red,Lightweight
+04/14/2018,Lauren Mueller,Shana Dobson,Red,Women's Flyweight
+04/14/2018,Yushin Okami,Dhiego Lima,Red,Welterweight
+04/14/2018,Adam Wieczorek,Arjan Bhullar,Red,Heavyweight
+04/14/2018,Alejandro Perez,Matthew Lopez,Red,Bantamweight
+04/14/2018,Luke Sanders,Patrick Williams,Red,Bantamweight
+04/07/2018,Khabib Nurmagomedov,Al Iaquinta,Red,UFC Lightweight Title
+04/07/2018,Rose Namajunas,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+04/07/2018,Renato Moicano,Calvin Kattar,Red,Featherweight
+04/07/2018,Zabit Magomedsharipov,Kyle Bochniak,Red,Featherweight
+04/07/2018,Chris Gruetzemacher,Joe Lauzon,Red,Lightweight
+04/07/2018,Karolina Kowalkiewicz,Felice Herrig,Red,Women's Strawweight
+04/07/2018,Olivier Aubin-Mercier,Evan Dunham,Red,Lightweight
+04/07/2018,Ashlee Evans-Smith,Bec Rawlings,Red,Women's Flyweight
+04/07/2018,Devin Clark,Mike Rodriguez,Red,Light Heavyweight
+03/17/2018,Alexander Volkov,Fabricio Werdum,Red,Heavyweight
+03/17/2018,Jan Blachowicz,Jimi Manuwa,Red,Light Heavyweight
+03/17/2018,Tom Duquesnoy,Terrion Ware,Red,Bantamweight
+03/17/2018,Leon Edwards,Peter Sobotta,Red,Welterweight
+03/17/2018,Charles Byrd,John Phillips,Red,Middleweight
+03/17/2018,Danny Roberts,Oliver Enkamp,Red,Welterweight
+03/17/2018,Danny Henry,Hakeem Dawodu,Red,Featherweight
+03/17/2018,Paul Craig,Magomed Ankalaev,Red,Light Heavyweight
+03/17/2018,Kajan Johnson,Stevie Ray,Red,Lightweight
+03/17/2018,Dmitry Sosnovskiy,Mark Godbeer,Red,Heavyweight
+03/03/2018,Cristiane Justino,Yana Santos,Red,UFC Women's Featherweight Title
+03/03/2018,Brian Ortega,Frankie Edgar,Red,Featherweight
+03/03/2018,Sean O'Malley,Andre Soukhamthath,Red,Bantamweight
+03/03/2018,Andrei Arlovski,Stefan Struve,Red,Heavyweight
+03/03/2018,Ketlen Vieira,Cat Zingano,Red,Women's Bantamweight
+03/03/2018,Mackenzie Dern,Ashley Yoder,Red,Women's Strawweight
+03/03/2018,Alexander Hernandez,Beneil Dariush,Red,Lightweight
+03/03/2018,John Dodson,Pedro Munhoz,Red,Bantamweight
+03/03/2018,CB Dollaway,Hector Lombard,Red,Middleweight
+03/03/2018,Zak Ottow,Mike Pyle,Red,Welterweight
+03/03/2018,Cody Stamann,Bryan Caraway,Red,Bantamweight
+03/03/2018,Jordan Johnson,Adam Milstead,Red,Light Heavyweight
+02/24/2018,Jeremy Stephens,Josh Emmett,Red,Featherweight
+02/24/2018,Jessica Andrade,Tecia Torres,Red,Women's Strawweight
+02/24/2018,Ilir Latifi,Ovince Saint Preux,Red,Light Heavyweight
+02/24/2018,Max Griffin,Mike Perry,Red,Welterweight
+02/24/2018,Brian Kelleher,Renan Barao,Red,Bantamweight
+02/24/2018,Marion Reneau,Sara McMann,Red,Women's Bantamweight
+02/24/2018,Angela Hill,Maryna Moroz,Red,Women's Strawweight
+02/24/2018,Alan Jouban,Ben Saunders,Red,Welterweight
+02/24/2018,Sam Alvey,Marcin Prachnio,Red,Light Heavyweight
+02/24/2018,Rani Yahya,Russell Doane,Red,Bantamweight
+02/24/2018,Alex Perez,Eric Shelton,Red,Flyweight
+02/24/2018,Manny Bermudez,Albert Morales,Red,Bantamweight
+02/18/2018,Donald Cerrone,Yancy Medeiros,Red,Welterweight
+02/18/2018,Derrick Lewis,Marcin Tybura,Red,Heavyweight
+02/18/2018,James Vick,Francisco Trinaldo,Red,Lightweight
+02/18/2018,Curtis Millender,Thiago Alves,Red,Welterweight
+02/18/2018,Brandon Davis,Steven Peterson,Red,Featherweight
+02/18/2018,Sage Northcutt,Thibault Gouti,Red,Lightweight
+02/18/2018,Diego Ferreira,Jared Gordon,Red,Lightweight
+02/18/2018,Geoff Neal,Brian Camozzi,Red,Welterweight
+02/18/2018,Robert Sanchez,Joby Sanchez,Red,Flyweight
+02/18/2018,Lucie Pudilova,Sarah Moras,Red,Women's Bantamweight
+02/18/2018,Alex Morono,Joshua Burkman,Red,Welterweight
+02/18/2018,Oskar Piechota,Tim Williams,Red,Middleweight
+02/10/2018,Yoel Romero,Luke Rockhold,Red,Middleweight
+02/10/2018,Curtis Blaydes,Mark Hunt,Red,Heavyweight
+02/10/2018,Tai Tuivasa,Cyril Asker,Red,Heavyweight
+02/10/2018,Jake Matthews,Li Jingliang,Red,Welterweight
+02/10/2018,Tyson Pedro,Saparbeg Safarov,Red,Light Heavyweight
+02/10/2018,Dong Hyun Ma,Damien Brown,Red,Lightweight
+02/10/2018,Israel Adesanya,Rob Wilkinson,Red,Middleweight
+02/10/2018,Alexander Volkanovski,Jeremy Kennedy,Red,Featherweight
+02/10/2018,Jussier Formiga,Ben Nguyen,Red,Flyweight
+02/10/2018,Ross Pearson,Mizuto Hirota,Red,Lightweight
+02/10/2018,Jose Quinonez,Teruto Ishihara,Red,Bantamweight
+02/10/2018,Luke Jumeau,Daichi Abe,Red,Welterweight
+02/03/2018,Lyoto Machida,Eryk Anders,Red,Middleweight
+02/03/2018,Valentina Shevchenko,Priscila Cachoeira,Red,Women's Flyweight
+02/03/2018,Michel Prazeres,Desmond Green,Red,Lightweight
+02/03/2018,Timothy Johnson,Marcelo Golm,Red,Heavyweight
+02/03/2018,Douglas Silva de Andrade,Marlon Vera,Red,Bantamweight
+02/03/2018,Thiago Santos,Anthony Smith,Red,Middleweight
+02/03/2018,Sergio Moraes,Tim Means,Red,Welterweight
+02/03/2018,Alan Patrick,Damir Hadzovic,Red,Lightweight
+02/03/2018,Polyana Viana,Maia Stevenson,Red,Women's Strawweight
+02/03/2018,Iuri Alcantara,Joe Soto,Red,Bantamweight
+02/03/2018,Deiveson Figueiredo,Joseph Morales,Red,Flyweight
+01/27/2018,Jacare Souza,Derek Brunson,Red,Middleweight
+01/27/2018,Andre Fili,Dennis Bermudez,Red,Featherweight
+01/27/2018,Gregor Gillespie,Jordan Rinaldi,Red,Lightweight
+01/27/2018,Drew Dober,Frank Camacho,Red,Welterweight
+01/27/2018,Bobby Green,Erik Koch,Red,Lightweight
+01/27/2018,Mirsad Bektic,Godofredo Pepey,Red,Featherweight
+01/27/2018,Katlyn Cerminara,Mara Romero Borella,Red,Women's Flyweight
+01/27/2018,Randa Markos,Juliana Lima,Red,Women's Strawweight
+01/27/2018,Ji Yeon Kim,Justine Kish,Red,Women's Flyweight
+01/27/2018,Vinc Pichel,Joaquim Silva,Red,Lightweight
+01/27/2018,Niko Price,George Sullivan,Red,Welterweight
+01/27/2018,Cory Sandhagen,Austin Arnett,Red,Featherweight
+01/20/2018,Stipe Miocic,Francis Ngannou,Red,UFC Heavyweight Title
+01/20/2018,Daniel Cormier,Volkan Oezdemir,Red,UFC Light Heavyweight Title
+01/20/2018,Calvin Kattar,Shane Burgos,Red,Featherweight
+01/20/2018,Gian Villante,Francimar Barroso,Red,Light Heavyweight
+01/20/2018,Rob Font,Thomas Almeida,Red,Bantamweight
+01/20/2018,Kyle Bochniak,Brandon Davis,Red,Featherweight
+01/20/2018,Abdul Razak Alhassan,Sabah Homasi,Red,Welterweight
+01/20/2018,Dustin Ortiz,Alexandre Pantoja,Red,Flyweight
+01/20/2018,Julio Arce,Dan Ige,Red,Featherweight
+01/20/2018,Enrique Barzola,Matt Bessette,Red,Featherweight
+01/20/2018,Islam Makhachev,Gleison Tibau,Red,Lightweight
+01/14/2018,Jeremy Stephens,Dooho Choi,Red,Featherweight
+01/14/2018,Jessica-Rose Clark,Paige VanZant,Red,Women's Flyweight
+01/14/2018,Kamaru Usman,Emil Meek,Red,Welterweight
+01/14/2018,Darren Elkins,Michael Johnson,Red,Featherweight
+01/14/2018,James Krause,Alex White,Red,Lightweight
+01/14/2018,Marco Polo Reyes,Matt Frevola,Red,Lightweight
+01/14/2018,Irene Aldana,Talita Bernardo,Red,Women's Bantamweight
+01/14/2018,Kyung Ho Kang,Guido Cannetti,Red,Bantamweight
+01/14/2018,Jessica Eye,Kalindra Faria,Red,Women's Flyweight
+01/14/2018,JJ Aldrich,Danielle Taylor,Red,Women's Strawweight
+01/14/2018,Mads Burnell,Mike Santiago,Red,Featherweight
+12/30/2017,Cristiane Justino,Holly Holm,Red,UFC Women's Featherweight Title
+12/30/2017,Khabib Nurmagomedov,Edson Barboza,Red,Lightweight
+12/30/2017,Dan Hooker,Marc Diakiese,Red,Lightweight
+12/30/2017,Carla Esparza,Cynthia Calvillo,Red,Women's Strawweight
+12/30/2017,Neil Magny,Carlos Condit,Red,Welterweight
+12/30/2017,Myles Jury,Ricky Glenn,Red,Featherweight
+12/30/2017,Matheus Nicolau,Louis Smolka,Red,Flyweight
+12/30/2017,Tim Elliott,Mark De La Rosa,Red,Bantamweight
+12/16/2017,Rafael Dos Anjos,Robbie Lawler,Red,Welterweight
+12/16/2017,Josh Emmett,Ricardo Lamas,Red,Featherweight
+12/16/2017,Santiago Ponzinibbio,Mike Perry,Red,Welterweight
+12/16/2017,Glover Teixeira,Misha Cirkunov,Red,Light Heavyweight
+12/16/2017,Jan Blachowicz,Jared Cannonier,Red,Light Heavyweight
+12/16/2017,Julian Marquez,Darren Stewart,Red,Middleweight
+12/16/2017,Chad Laprise,Galore Bofando,Red,Welterweight
+12/16/2017,Nordine Taleb,Danny Roberts,Red,Welterweight
+12/16/2017,John Makdessi,Abel Trujillo,Red,Lightweight
+12/16/2017,Alessio Di Chirico,Oluwale Bamgbose,Red,Middleweight
+12/16/2017,Jordan Mein,Erick Silva,Red,Welterweight
+12/09/2017,Brian Ortega,Cub Swanson,Red,Featherweight
+12/09/2017,Gabriel Benitez,Jason Knight,Red,Featherweight
+12/09/2017,Marlon Moraes,Aljamain Sterling,Red,Bantamweight
+12/09/2017,Scott Holtzman,Darrell Horcher,Red,Lightweight
+12/09/2017,Eryk Anders,Markus Perez,Red,Middleweight
+12/09/2017,Benito Lopez,Albert Morales,Red,Bantamweight
+12/09/2017,Alexis Davis,Liz Carmouche,Red,Women's Flyweight
+12/09/2017,Andre Soukhamthath,Luke Sanders,Red,Bantamweight
+12/09/2017,Alex Perez,Carls John De Tomas,Red,Bantamweight
+12/09/2017,Frankie Saenz,Merab Dvalishvili,Red,Bantamweight
+12/09/2017,Alejandro Perez,Iuri Alcantara,Red,Bantamweight
+12/09/2017,Davi Ramos,Chris Gruetzemacher,Red,Lightweight
+12/09/2017,Trevin Giles,Antonio Braga Neto,Red,Middleweight
+12/02/2017,Max Holloway,Jose Aldo,Red,UFC Featherweight Title
+12/02/2017,Francis Ngannou,Alistair Overeem,Red,Heavyweight
+12/02/2017,Henry Cejudo,Sergio Pettis,Red,Flyweight
+12/02/2017,Eddie Alvarez,Justin Gaethje,Red,Lightweight
+12/02/2017,Tecia Torres,Michelle Waterson-Gomez,Red,Women's Strawweight
+12/02/2017,Paul Felder,Charles Oliveira,Red,Lightweight
+12/02/2017,Yancy Medeiros,Alex Oliveira,Red,Welterweight
+12/02/2017,David Teymur,Drakkar Klose,Red,Lightweight
+12/02/2017,Felice Herrig,Cortney Casey,Red,Women's Strawweight
+12/02/2017,Amanda Cooper,Angela Magana,Red,Women's Strawweight
+12/02/2017,Abdul Razak Alhassan,Sabah Homasi,Red,Welterweight
+12/02/2017,Dominick Reyes,Jeremy Kimball,Red,Light Heavyweight
+12/02/2017,Justin Willis,Allen Crowder,Red,Heavyweight
+12/01/2017,Nicco Montano,Roxanne Modafferi,Red,UFC Women's Flyweight Title
+12/01/2017,Sean O'Malley,Terrion Ware,Red,Bantamweight
+12/01/2017,Lauren Murphy,Barb Honchak,Red,Women's Flyweight
+12/01/2017,Gerald Meerschaert,Eric Spicely,Red,Middleweight
+12/01/2017,Brett Johns,Joe Soto,Red,Bantamweight
+12/01/2017,Montana De La Rosa,Christina Marks,Red,Women's Flyweight
+12/01/2017,Ryan Janes,Andrew Sanchez,Red,Middleweight
+12/01/2017,Rachael Ostovich,Karine Gevorgyan,Red,Women's Flyweight
+12/01/2017,Shana Dobson,Ariel Beck,Red,Women's Flyweight
+12/01/2017,Gillian Robertson,Emily Whitmire,Red,Women's Flyweight
+11/25/2017,Kelvin Gastelum,Michael Bisping,Red,Middleweight
+11/25/2017,Li Jingliang,Zak Ottow,Red,Welterweight
+11/25/2017,Wang Guan,Alex Caceres,Red,Featherweight
+11/25/2017,Alex Garcia,Muslim Salikhov,Red,Welterweight
+11/25/2017,Zabit Magomedsharipov,Sheymon Moraes,Red,Featherweight
+11/25/2017,Song Kenan,Bobby Nash,Red,Welterweight
+11/25/2017,Yan Xiaonan,Kailin Curran,Red,Women's Strawweight
+11/25/2017,Song Yadong,Bharat Kandare,Red,Featherweight
+11/25/2017,Shamil Abdurakhimov,Chase Sherman,Red,Heavyweight
+11/25/2017,Gina Mazany,Wu Yanan,Red,Women's Bantamweight
+11/25/2017,Rolando Dy,Wulijiburen,Red,Featherweight
+11/25/2017,Cyril Asker,Hu Yaozong,Red,Heavyweight
+11/18/2017,Fabricio Werdum,Marcin Tybura,Red,Heavyweight
+11/18/2017,Jessica-Rose Clark,Bec Rawlings,Red,Women's Flyweight
+11/18/2017,Belal Muhammad,Tim Means,Red,Welterweight
+11/18/2017,Jake Matthews,Bojan Velickovic,Red,Welterweight
+11/18/2017,Elias Theodorou,Daniel Kelly,Red,Middleweight
+11/18/2017,Alexander Volkanovski,Shane Young,Red,Catch Weight
+11/18/2017,Ryan Benoit,Ashkan Mokhtarian,Red,Flyweight
+11/18/2017,Nik Lentz,Will Brooks,Red,Lightweight
+11/18/2017,Tai Tuivasa,Rashad Coulter,Red,Heavyweight
+11/18/2017,Frank Camacho,Damien Brown,Red,Lightweight
+11/18/2017,Nadia Kassem,Alex Chambers,Red,Women's Strawweight
+11/18/2017,Eric Shelton,Jenel Lausa,Red,Flyweight
+11/18/2017,Adam Wieczorek,Anthony Hamilton,Red,Heavyweight
+11/11/2017,Dustin Poirier,Anthony Pettis,Red,Lightweight
+11/11/2017,Matt Brown,Diego Sanchez,Red,Welterweight
+11/11/2017,Andrei Arlovski,Junior Albini,Red,Heavyweight
+11/11/2017,Cezar Ferreira,Nate Marquardt,Red,Middleweight
+11/11/2017,Raphael Assuncao,Matthew Lopez,Red,Bantamweight
+11/11/2017,Clay Guida,Joe Lauzon,Red,Lightweight
+11/11/2017,Marlon Moraes,John Dodson,Red,Bantamweight
+11/11/2017,Tatiana Suarez,Viviane Pereira,Red,Women's Strawweight
+11/11/2017,Sage Northcutt,Michel Quinones,Red,Lightweight
+11/11/2017,Nina Nunes,Angela Hill,Red,Women's Strawweight
+11/11/2017,Sean Strickland,Court McGee,Red,Welterweight
+11/11/2017,Jake Collier,Marcel Fortuna,Red,Light Heavyweight
+11/11/2017,Karl Roberson,Darren Stewart,Red,Middleweight
+11/04/2017,Georges St-Pierre,Michael Bisping,Red,UFC Middleweight Title
+11/04/2017,TJ Dillashaw,Cody Garbrandt,Red,UFC Bantamweight Title
+11/04/2017,Rose Namajunas,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+11/04/2017,Stephen Thompson,Jorge Masvidal,Red,Welterweight
+11/04/2017,Paulo Costa,Johny Hendricks,Red,Middleweight
+11/04/2017,James Vick,Joe Duffy,Red,Lightweight
+11/04/2017,Mark Godbeer,Walt Harris,Red,Heavyweight
+11/04/2017,Ovince Saint Preux,Corey Anderson,Red,Light Heavyweight
+11/04/2017,Randy Brown,Mickey Gall,Red,Welterweight
+11/04/2017,Curtis Blaydes,Aleksei Oleinik,Red,Heavyweight
+11/04/2017,Ricardo Ramos,Aiemann Zahabi,Red,Bantamweight
+10/28/2017,Derek Brunson,Lyoto Machida,Red,Middleweight
+10/28/2017,Colby Covington,Demian Maia,Red,Welterweight
+10/28/2017,Pedro Munhoz,Rob Font,Red,Bantamweight
+10/28/2017,Francisco Trinaldo,Jim Miller,Red,Lightweight
+10/28/2017,Thiago Santos,Jack Hermansson,Red,Middleweight
+10/28/2017,John Lineker,Marlon Vera,Red,Bantamweight
+10/28/2017,Vicente Luque,Niko Price,Red,Welterweight
+10/28/2017,Antonio Carlos Junior,Jack Marshman,Red,Middleweight
+10/28/2017,Jared Gordon,Hacran Dias,Red,Lightweight
+10/28/2017,Elizeu Zaleski dos Santos,Max Griffin,Red,Welterweight
+10/28/2017,Deiveson Figueiredo,Jarred Brooks,Red,Flyweight
+10/28/2017,Marcelo Golm,Christian Colombo,Red,Heavyweight
+10/21/2017,Darren Till,Donald Cerrone,Red,Welterweight
+10/21/2017,Karolina Kowalkiewicz,Jodie Esquibel,Red,Women's Strawweight
+10/21/2017,Jan Blachowicz,Devin Clark,Red,Light Heavyweight
+10/21/2017,Oskar Piechota,Jonathan Wilson,Red,Middleweight
+10/21/2017,Marcin Held,Nasrat Haqparast,Red,Lightweight
+10/21/2017,Brian Kelleher,Damian Stasiak,Red,Bantamweight
+10/21/2017,Ramazan Emeev,Sam Alvey,Red,Middleweight
+10/21/2017,Andre Fili,Artem Lobov,Red,Featherweight
+10/21/2017,Warlley Alves,Salim Touahri,Red,Welterweight
+10/21/2017,Aspen Ladd,Lina Lansberg,Red,Women's Bantamweight
+10/21/2017,Josh Emmett,Felipe Arantes,Red,Featherweight
+10/07/2017,Tony Ferguson,Kevin Lee,Red,UFC Interim Lightweight Title
+10/07/2017,Demetrious Johnson,Ray Borg,Red,UFC Flyweight Title
+10/07/2017,Fabricio Werdum,Walt Harris,Red,Heavyweight
+10/07/2017,Mara Romero Borella,Kalindra Faria,Red,Women's Flyweight
+10/07/2017,Cody Stamann,Tom Duquesnoy,Red,Bantamweight
+10/07/2017,Poliana Botelho,Pearl Gonzalez,Red,Women's Strawweight
+10/07/2017,Matt Schnell,Marco Beltran,Red,Flyweight
+10/07/2017,John Moraga,Bibulatov Magomed,Red,Flyweight
+10/07/2017,Brad Tavares,Thales Leites,Red,Middleweight
+09/22/2017,Ovince Saint Preux,Yushin Okami,Red,Light Heavyweight
+09/22/2017,Jessica Andrade,Claudia Gadelha,Red,Women's Strawweight
+09/22/2017,Dong Hyun Ma,Takanori Gomi,Red,Lightweight
+09/22/2017,Gokhan Saki,Henrique da Silva,Red,Light Heavyweight
+09/22/2017,Teruto Ishihara,Rolando Dy,Red,Featherweight
+09/22/2017,Jussier Formiga,Yuta Sasaki,Red,Flyweight
+09/22/2017,Keita Nakamura,Alex Morono,Red,Welterweight
+09/22/2017,Syuri Kondo,Chan-Mi Jeon,Red,Women's Strawweight
+09/22/2017,Shinsho Anzai,Luke Jumeau,Red,Welterweight
+09/22/2017,Daichi Abe,Hyun Gyu Lim,Red,Welterweight
+09/16/2017,Luke Rockhold,David Branch,Red,Middleweight
+09/16/2017,Mike Perry,Alex Reyes,Red,Welterweight
+09/16/2017,Anthony Smith,Hector Lombard,Red,Middleweight
+09/16/2017,Gregor Gillespie,Jason Gonzalez,Red,Lightweight
+09/16/2017,Kamaru Usman,Sergio Moraes,Red,Welterweight
+09/16/2017,Justin Ledet,Azunna Anyanwu,Red,Heavyweight
+09/16/2017,Olivier Aubin-Mercier,Anthony Rocco Martin,Red,Lightweight
+09/16/2017,Daniel Spitz,Anthony Hamilton,Red,Heavyweight
+09/16/2017,Uriah Hall,Krzysztof Jotko,Red,Middleweight
+09/16/2017,Gilbert Burns,Jason Saggo,Red,Lightweight
+09/09/2017,Amanda Nunes,Valentina Shevchenko,Red,UFC Women's Bantamweight Title
+09/09/2017,Rafael Dos Anjos,Neil Magny,Red,Welterweight
+09/09/2017,Henry Cejudo,Wilson Reis,Red,Flyweight
+09/09/2017,Ilir Latifi,Tyson Pedro,Red,Light Heavyweight
+09/09/2017,Jeremy Stephens,Gilbert Melendez,Red,Featherweight
+09/09/2017,Ketlen Vieira,Sara McMann,Red,Women's Bantamweight
+09/09/2017,Sarah Moras,Ashlee Evans-Smith,Red,Women's Bantamweight
+09/09/2017,Ricky Glenn,Gavin Tucker,Red,Featherweight
+09/09/2017,Alex White,Mitch Clarke,Red,Lightweight
+09/09/2017,Arjan Bhullar,Luis Henrique,Red,Heavyweight
+09/09/2017,Kajan Johnson,Adriano Martins,Red,Lightweight
+09/02/2017,Alexander Volkov,Stefan Struve,Red,Heavyweight
+09/02/2017,Siyar Bahadurzada,Rob Wilkinson,Red,Middleweight
+09/02/2017,Marion Reneau,Talita Bernardo,Red,Women's Bantamweight
+09/02/2017,Leon Edwards,Bryan Barberena,Red,Welterweight
+09/02/2017,Darren Till,Bojan Velickovic,Red,Welterweight
+09/02/2017,Mairbek Taisumov,Felipe Silva,Red,Lightweight
+09/02/2017,Michel Prazeres,Mads Burnell,Red,Lightweight
+09/02/2017,Rustam Khabilov,Desmond Green,Red,Lightweight
+09/02/2017,Aleksandar Rakic,Francimar Barroso,Red,Light Heavyweight
+09/02/2017,Zabit Magomedsharipov,Mike Santiago,Red,Featherweight
+09/02/2017,Abdul-Kerim Edilov,Bojan Mihajlovic,Red,Light Heavyweight
+09/02/2017,Thibault Gouti,Andrew Holbrook,Red,Lightweight
+08/05/2017,Sergio Pettis,Brandon Moreno,Red,Flyweight
+08/05/2017,Alexa Grasso,Randa Markos,Red,Women's Strawweight
+08/05/2017,Niko Price,Alan Jouban,Red,Welterweight
+08/05/2017,Humberto Bandenay,Martin Bravo,Red,Featherweight
+08/05/2017,Sam Alvey,Rashad Evans,Red,Middleweight
+08/05/2017,Alejandro Perez,Andre Soukhamthath,Red,Bantamweight
+08/05/2017,Jack Hermansson,Brad Scott,Red,Middleweight
+08/05/2017,Dustin Ortiz,Hector Sandoval,Red,Flyweight
+08/05/2017,Rani Yahya,Henry Briones,Red,Bantamweight
+08/05/2017,Jose Quinonez,Diego Rivas,Red,Bantamweight
+08/05/2017,Joseph Morales,Robert Sanchez,Red,Flyweight
+08/05/2017,Jordan Rinaldi,Alvaro Herrera Mendoza,Red,Lightweight
+07/29/2017,Tyron Woodley,Demian Maia,Red,UFC Welterweight Title
+07/29/2017,Cristiane Justino,Tonya Evinger,Red,UFC Women's Featherweight Title
+07/29/2017,Robbie Lawler,Donald Cerrone,Red,Welterweight
+07/29/2017,Volkan Oezdemir,Jimi Manuwa,Red,Light Heavyweight
+07/29/2017,Ricardo Lamas,Jason Knight,Red,Featherweight
+07/29/2017,Aljamain Sterling,Renan Barao,Red,Catch Weight
+07/29/2017,Brian Ortega,Renato Moicano,Red,Featherweight
+07/29/2017,Calvin Kattar,Andre Fili,Red,Featherweight
+07/29/2017,Aleksandra Albu,Kailin Curran,Red,Women's Strawweight
+07/29/2017,Jarred Brooks,Eric Shelton,Red,Flyweight
+07/29/2017,Drew Dober,Joshua Burkman,Red,Lightweight
+07/22/2017,Chris Weidman,Kelvin Gastelum,Red,Middleweight
+07/22/2017,Darren Elkins,Dennis Bermudez,Red,Featherweight
+07/22/2017,Patrick Cummins,Gian Villante,Red,Light Heavyweight
+07/22/2017,Jimmie Rivera,Thomas Almeida,Red,Bantamweight
+07/22/2017,Elizeu Zaleski dos Santos,Lyman Good,Red,Welterweight
+07/22/2017,Eryk Anders,Rafael Natal,Red,Middleweight
+07/22/2017,Alex Oliveira,Ryan LaFlare,Red,Welterweight
+07/22/2017,Chase Sherman,Damian Grabowski,Red,Heavyweight
+07/22/2017,Jeremy Kennedy,Kyle Bochniak,Red,Featherweight
+07/22/2017,Marlon Vera,Brian Kelleher,Red,Bantamweight
+07/22/2017,Junior Albini,Timothy Johnson,Red,Heavyweight
+07/22/2017,Shane Burgos,Godofredo Pepey,Red,Featherweight
+07/22/2017,Chris Wade,Frankie Perez,Red,Lightweight
+07/16/2017,Santiago Ponzinibbio,Gunnar Nelson,Red,Welterweight
+07/16/2017,Cynthia Calvillo,Joanne Wood,Red,Women's Strawweight
+07/16/2017,Paul Felder,Stevie Ray,Red,Lightweight
+07/16/2017,Jack Marshman,Ryan Janes,Red,Middleweight
+07/16/2017,Khalil Rountree Jr.,Paul Craig,Red,Light Heavyweight
+07/16/2017,Justin Willis,James Mulheron,Red,Heavyweight
+07/16/2017,Danny Roberts,Bobby Nash,Red,Welterweight
+07/16/2017,Alexandre Pantoja,Neil Seery,Red,Flyweight
+07/16/2017,Galore Bofando,Charlie Ward,Red,Welterweight
+07/16/2017,Danny Henry,Daniel Teymur,Red,Lightweight
+07/16/2017,Brett Johns,Albert Morales,Red,Bantamweight
+07/16/2017,Leslie Smith,Amanda Lemos,Red,Women's Bantamweight
+07/08/2017,Robert Whittaker,Yoel Romero,Red,UFC Interim Middleweight Title
+07/08/2017,Alistair Overeem,Fabricio Werdum,Red,Heavyweight
+07/08/2017,Curtis Blaydes,Daniel Omielanczuk,Red,Heavyweight
+07/08/2017,Anthony Pettis,Jim Miller,Red,Lightweight
+07/08/2017,Rob Font,Douglas Silva de Andrade,Red,Bantamweight
+07/08/2017,Aleksei Oleinik,Travis Browne,Red,Heavyweight
+07/08/2017,Chad Laprise,Brian Camozzi,Red,Welterweight
+07/08/2017,Thiago Santos,Gerald Meerschaert,Red,Middleweight
+07/08/2017,Belal Muhammad,Jordan Mein,Red,Welterweight
+07/08/2017,Cody Stamann,Terrion Ware,Red,Featherweight
+07/08/2017,Trevin Giles,James Bochnovic,Red,Light Heavyweight
+07/07/2017,Justin Gaethje,Michael Johnson,Red,Lightweight
+07/07/2017,Jesse Taylor,Dhiego Lima,Red,Ultimate Fighter 25 Welterweight Tournament Title
+07/07/2017,Drakkar Klose,Marc Diakiese,Red,Lightweight
+07/07/2017,Jared Cannonier,Nick Roehrick,Red,Light Heavyweight
+07/07/2017,Brad Tavares,Elias Theodorou,Red,Middleweight
+07/07/2017,Jordan Johnson,Marcel Fortuna,Red,Light Heavyweight
+07/07/2017,Angela Hill,Ashley Yoder,Red,Women's Strawweight
+07/07/2017,James Krause,Tom Gallicchio,Red,Welterweight
+07/07/2017,CB Dollaway,Ed Herman,Red,Light Heavyweight
+07/07/2017,Tecia Torres,Juliana Lima,Red,Women's Strawweight
+07/07/2017,Gray Maynard,Teruto Ishihara,Red,Featherweight
+06/25/2017,Kevin Lee,Michael Chiesa,Red,Lightweight
+06/25/2017,Tim Boetsch,Johny Hendricks,Red,Middleweight
+06/25/2017,Felice Herrig,Justine Kish,Red,Women's Strawweight
+06/25/2017,Dominick Reyes,Joachim Christensen,Red,Light Heavyweight
+06/25/2017,Tim Means,Alex Garcia,Red,Welterweight
+06/25/2017,Dennis Siver,BJ Penn,Red,Featherweight
+06/25/2017,Clay Guida,Erik Koch,Red,Lightweight
+06/25/2017,Marvin Vettori,Vitor Miranda,Red,Middleweight
+06/25/2017,Carla Esparza,Maryna Moroz,Red,Women's Strawweight
+06/25/2017,Darrell Horcher,Devin Powell,Red,Lightweight
+06/25/2017,Jared Gordon,Michel Quinones,Red,Featherweight
+06/25/2017,Anthony Rocco Martin,Johnny Case,Red,Lightweight
+06/25/2017,Jeremy Kimball,Josh Stansbury,Red,Light Heavyweight
+06/17/2017,Holly Holm,Bethe Correia,Red,Women's Bantamweight
+06/17/2017,Marcin Tybura,Andrei Arlovski,Red,Heavyweight
+06/17/2017,Colby Covington,Dong Hyun Kim,Red,Welterweight
+06/17/2017,Rafael Dos Anjos,Tarec Saffiedine,Red,Welterweight
+06/17/2017,Jon Tuck,Takanori Gomi,Red,Lightweight
+06/17/2017,Walt Harris,Cyril Asker,Red,Heavyweight
+06/17/2017,Alex Caceres,Rolando Dy,Red,Featherweight
+06/17/2017,Yuta Sasaki,Justin Scoggins,Red,Flyweight
+06/17/2017,Li Jingliang,Frank Camacho,Red,Welterweight
+06/17/2017,Russell Doane,Kwan Ho Kwak,Red,Bantamweight
+06/17/2017,Naoki Inoue,Carls John De Tomas,Red,Flyweight
+06/17/2017,Lucie Pudilova,Ji Yeon Kim,Red,Women's Bantamweight
+06/10/2017,Mark Hunt,Derrick Lewis,Red,Heavyweight
+06/10/2017,Derek Brunson,Daniel Kelly,Red,Middleweight
+06/10/2017,Dan Hooker,Ross Pearson,Red,Lightweight
+06/10/2017,Ion Cutelaba,Henrique da Silva,Red,Light Heavyweight
+06/10/2017,Ben Nguyen,Tim Elliott,Red,Flyweight
+06/10/2017,Alexander Volkanovski,Mizuto Hirota,Red,Featherweight
+06/10/2017,Vinc Pichel,Damien Brown,Red,Lightweight
+06/10/2017,Luke Jumeau,Dominique Steele,Red,Welterweight
+06/10/2017,John Moraga,Ashkan Mokhtarian,Red,Flyweight
+06/10/2017,Zak Ottow,Kiichi Kunimoto,Red,Welterweight
+06/10/2017,JJ Aldrich,Chan-Mi Jeon,Red,Women's Strawweight
+06/03/2017,Max Holloway,Jose Aldo,Red,UFC Featherweight Title
+06/03/2017,Claudia Gadelha,Karolina Kowalkiewicz,Red,Women's Strawweight
+06/03/2017,Vitor Belfort,Nate Marquardt,Red,Middleweight
+06/03/2017,Paulo Costa,Oluwale Bamgbose,Red,Middleweight
+06/03/2017,Yancy Medeiros,Erick Silva,Red,Welterweight
+06/03/2017,Raphael Assuncao,Marlon Moraes,Red,Bantamweight
+06/03/2017,Antonio Carlos Junior,Eric Spicely,Red,Middleweight
+06/03/2017,Matthew Lopez,Johnny Eduardo,Red,Bantamweight
+06/03/2017,Brian Kelleher,Iuri Alcantara,Red,Bantamweight
+06/03/2017,Viviane Pereira,Jamie Moyle,Red,Women's Strawweight
+06/03/2017,Luan Chagas,Jim Wallhead,Red,Welterweight
+06/03/2017,Deiveson Figueiredo,Marco Beltran,Red,Flyweight
+05/28/2017,Alexander Gustafsson,Glover Teixeira,Red,Light Heavyweight
+05/28/2017,Volkan Oezdemir,Misha Cirkunov,Red,Light Heavyweight
+05/28/2017,Peter Sobotta,Ben Saunders,Red,Welterweight
+05/28/2017,Omari Akhmedov,Abdul Razak Alhassan,Red,Welterweight
+05/28/2017,Nordine Taleb,Oliver Enkamp,Red,Welterweight
+05/28/2017,Jack Hermansson,Alex Nicholson,Red,Middleweight
+05/28/2017,Pedro Munhoz,Damian Stasiak,Red,Bantamweight
+05/28/2017,Trevor Smith,Chris Camozzi,Red,Middleweight
+05/28/2017,Joaquim Silva,Reza Madadi,Red,Lightweight
+05/28/2017,Bojan Velickovic,Nicholas Musoke,Red,Welterweight
+05/28/2017,Darren Till,Jessin Ayari,Red,Welterweight
+05/28/2017,Damir Hadzovic,Marcin Held,Red,Lightweight
+05/13/2017,Stipe Miocic,Junior Dos Santos,Red,UFC Heavyweight Title
+05/13/2017,Joanna Jedrzejczyk,Jessica Andrade,Red,UFC Women's Strawweight Title
+05/13/2017,Demian Maia,Jorge Masvidal,Red,Welterweight
+05/13/2017,Frankie Edgar,Yair Rodriguez,Red,Featherweight
+05/13/2017,David Branch,Krzysztof Jotko,Red,Middleweight
+05/13/2017,Jason Knight,Chas Skelly,Red,Featherweight
+05/13/2017,Chase Sherman,Rashad Coulter,Red,Heavyweight
+05/13/2017,James Vick,Marco Polo Reyes,Red,Lightweight
+05/13/2017,Cortney Casey,Jessica Aguilar,Red,Women's Strawweight
+05/13/2017,Enrique Barzola,Gabriel Benitez,Red,Featherweight
+05/13/2017,Gadzhimurad Antigulov,Joachim Christensen,Red,Light Heavyweight
+04/22/2017,Cub Swanson,Artem Lobov,Red,Featherweight
+04/22/2017,Al Iaquinta,Diego Sanchez,Red,Lightweight
+04/22/2017,Ovince Saint Preux,Marcos Rogerio de Lima,Red,Light Heavyweight
+04/22/2017,John Dodson,Eddie Wineland,Red,Bantamweight
+04/22/2017,Stevie Ray,Joe Lauzon,Red,Lightweight
+04/22/2017,Mike Perry,Jake Ellenberger,Red,Welterweight
+04/22/2017,Thales Leites,Sam Alvey,Red,Middleweight
+04/22/2017,Brandon Moreno,Dustin Ortiz,Red,Flyweight
+04/22/2017,Scott Holtzman,Michael McBride,Red,Lightweight
+04/22/2017,Danielle Taylor,Jessica Penne,Red,Women's Strawweight
+04/22/2017,Alexis Davis,Cindy Dandois,Red,Women's Bantamweight
+04/22/2017,Bryan Barberena,Joe Proctor,Red,Welterweight
+04/22/2017,Hector Sandoval,Matt Schnell,Red,Flyweight
+04/15/2017,Demetrious Johnson,Wilson Reis,Red,UFC Flyweight Title
+04/15/2017,Rose Namajunas,Michelle Waterson-Gomez,Red,Women's Strawweight
+04/15/2017,Robert Whittaker,Jacare Souza,Red,Middleweight
+04/15/2017,Renato Moicano,Jeremy Stephens,Red,Featherweight
+04/15/2017,Alexander Volkov,Roy Nelson,Red,Heavyweight
+04/15/2017,Tom Duquesnoy,Patrick Williams,Red,Bantamweight
+04/15/2017,Rashid Magomedov,Bobby Green,Red,Lightweight
+04/15/2017,Tim Elliott,Louis Smolka,Red,Flyweight
+04/15/2017,Aljamain Sterling,Augusto Mendes,Red,Bantamweight
+04/15/2017,Devin Clark,Jake Collier,Red,Light Heavyweight
+04/15/2017,Anthony Smith,Andrew Sanchez,Red,Middleweight
+04/15/2017,Zak Cummings,Nathan Coy,Red,Welterweight
+04/15/2017,Ketlen Vieira,Ashlee Evans-Smith,Red,Women's Bantamweight
+04/08/2017,Daniel Cormier,Anthony Johnson,Red,UFC Light Heavyweight Title
+04/08/2017,Gegard Mousasi,Chris Weidman,Red,Middleweight
+04/08/2017,Cynthia Calvillo,Pearl Gonzalez,Red,Women's Strawweight
+04/08/2017,Thiago Alves,Patrick Cote,Red,Welterweight
+04/08/2017,Charles Oliveira,Will Brooks,Red,Lightweight
+04/08/2017,Myles Jury,Mike de la Torre,Red,Featherweight
+04/08/2017,Kamaru Usman,Sean Strickland,Red,Welterweight
+04/08/2017,Shane Burgos,Charles Rosa,Red,Featherweight
+04/08/2017,Patrick Cummins,Jan Blachowicz,Red,Light Heavyweight
+04/08/2017,Gregor Gillespie,Andrew Holbrook,Red,Lightweight
+04/08/2017,Desmond Green,Josh Emmett,Red,Lightweight
+04/08/2017,Katlyn Cerminara,Irene Aldana,Red,Women's Bantamweight
+04/08/2017,Bibulatov Magomed,Jenel Lausa,Red,Flyweight
+03/18/2017,Jimi Manuwa,Corey Anderson,Red,Light Heavyweight
+03/18/2017,Gunnar Nelson,Alan Jouban,Red,Welterweight
+03/18/2017,Marlon Vera,Brad Pickett,Red,Catch Weight
+03/18/2017,Arnold Allen,Makwan Amirkhani,Red,Featherweight
+03/18/2017,Joe Duffy,Reza Madadi,Red,Lightweight
+03/18/2017,Francimar Barroso,Darren Stewart,Red,Light Heavyweight
+03/18/2017,Timothy Johnson,Daniel Omielanczuk,Red,Heavyweight
+03/18/2017,Leon Edwards,Vicente Luque,Red,Welterweight
+03/18/2017,Marc Diakiese,Teemu Packalen,Red,Lightweight
+03/18/2017,Brad Scott,Scott Askham,Red,Middleweight
+03/18/2017,Lina Lansberg,Lucie Pudilova,Red,Women's Bantamweight
+03/11/2017,Mauricio Rua,Gian Villante,Red,Light Heavyweight
+03/11/2017,Edson Barboza,Beneil Dariush,Red,Lightweight
+03/11/2017,Ray Borg,Jussier Formiga,Red,Flyweight
+03/11/2017,Alex Oliveira,Tim Means,Red,Welterweight
+03/11/2017,Kevin Lee,Francisco Trinaldo,Red,Lightweight
+03/11/2017,Sergio Moraes,Davi Ramos,Red,Welterweight
+03/11/2017,Joe Soto,Rani Yahya,Red,Bantamweight
+03/11/2017,Michel Prazeres,Joshua Burkman,Red,Lightweight
+03/11/2017,Jeremy Kennedy,Rony Jason,Red,Featherweight
+03/11/2017,Paulo Costa,Garreth McLellan,Red,Middleweight
+03/04/2017,Tyron Woodley,Stephen Thompson,Red,UFC Welterweight Title
+03/04/2017,David Teymur,Lando Vannata,Red,Lightweight
+03/04/2017,Daniel Kelly,Rashad Evans,Red,Middleweight
+03/04/2017,Cynthia Calvillo,Amanda Cooper,Red,Women's Strawweight
+03/04/2017,Alistair Overeem,Mark Hunt,Red,Heavyweight
+03/04/2017,Marcin Tybura,Luis Henrique,Red,Heavyweight
+03/04/2017,Darren Elkins,Mirsad Bektic,Red,Featherweight
+03/04/2017,Iuri Alcantara,Luke Sanders,Red,Bantamweight
+03/04/2017,Mark Godbeer,Daniel Spitz,Red,Heavyweight
+03/04/2017,Tyson Pedro,Paul Craig,Red,Light Heavyweight
+03/04/2017,Albert Morales,Andre Soukhamthath,Red,Bantamweight
+02/19/2017,Derrick Lewis,Travis Browne,Red,Heavyweight
+02/19/2017,Johny Hendricks,Hector Lombard,Red,Middleweight
+02/19/2017,Gavin Tucker,Sam Sicilia,Red,Featherweight
+02/19/2017,Elias Theodorou,Cezar Ferreira,Red,Middleweight
+02/19/2017,Sara McMann,Gina Mazany,Red,Women's Bantamweight
+02/19/2017,Paul Felder,Alex Ricci,Red,Lightweight
+02/19/2017,Santiago Ponzinibbio,Nordine Taleb,Red,Welterweight
+02/19/2017,Randa Markos,Carla Esparza,Red,Women's Strawweight
+02/19/2017,Aiemann Zahabi,Reginaldo Vieira,Red,Bantamweight
+02/19/2017,Thiago Santos,Jack Marshman,Red,Middleweight
+02/19/2017,Gerald Meerschaert,Ryan Janes,Red,Middleweight
+02/11/2017,Germaine de Randamie,Holly Holm,Red,UFC Women's Featherweight Title
+02/11/2017,Anderson Silva,Derek Brunson,Red,Middleweight
+02/11/2017,Jacare Souza,Tim Boetsch,Red,Middleweight
+02/11/2017,Glover Teixeira,Jared Cannonier,Red,Light Heavyweight
+02/11/2017,Dustin Poirier,Jim Miller,Red,Lightweight
+02/11/2017,Belal Muhammad,Randy Brown,Red,Welterweight
+02/11/2017,Wilson Reis,Yuta Sasaki,Red,Flyweight
+02/11/2017,Islam Makhachev,Nik Lentz,Red,Lightweight
+02/11/2017,Ricky Glenn,Phillipe Nover,Red,Featherweight
+02/11/2017,Ryan LaFlare,Roan Carneiro,Red,Welterweight
+02/04/2017,Chan Sung Jung,Dennis Bermudez,Red,Featherweight
+02/04/2017,Felice Herrig,Alexa Grasso,Red,Women's Strawweight
+02/04/2017,James Vick,Abel Trujillo,Red,Lightweight
+02/04/2017,Volkan Oezdemir,Ovince Saint Preux,Red,Light Heavyweight
+02/04/2017,Marcel Fortuna,Anthony Hamilton,Red,Heavyweight
+02/04/2017,Jessica Andrade,Angela Hill,Red,Women's Strawweight
+02/04/2017,Chas Skelly,Chris Gruetzemacher,Red,Featherweight
+02/04/2017,Ricardo Ramos,Michinori Tanaka,Red,Bantamweight
+02/04/2017,Tecia Torres,Bec Rawlings,Red,Women's Strawweight
+02/04/2017,Khalil Rountree Jr.,Daniel Jolly,Red,Light Heavyweight
+01/28/2017,Valentina Shevchenko,Julianna Pena,Red,Women's Bantamweight
+01/28/2017,Jorge Masvidal,Donald Cerrone,Red,Welterweight
+01/28/2017,Francis Ngannou,Andrei Arlovski,Red,Heavyweight
+01/28/2017,Jason Knight,Alex Caceres,Red,Featherweight
+01/28/2017,Sam Alvey,Nate Marquardt,Red,Middleweight
+01/28/2017,Raphael Assuncao,Aljamain Sterling,Red,Bantamweight
+01/28/2017,Li Jingliang,Bobby Nash,Red,Welterweight
+01/28/2017,Jordan Johnson,Henrique da Silva,Red,Light Heavyweight
+01/28/2017,Eric Spicely,Alessio Di Chirico,Red,Middleweight
+01/28/2017,Marcos Rogerio de Lima,Jeremy Kimball,Red,Light Heavyweight
+01/28/2017,Alexandre Pantoja,Eric Shelton,Red,Flyweight
+01/28/2017,Jason Gonzalez,JC Cottrell,Red,Lightweight
+01/15/2017,Yair Rodriguez,BJ Penn,Red,Featherweight
+01/15/2017,Joe Lauzon,Marcin Held,Red,Lightweight
+01/15/2017,Ben Saunders,Court McGee,Red,Welterweight
+01/15/2017,Sergio Pettis,John Moraga,Red,Flyweight
+01/15/2017,Drakkar Klose,Devin Powell,Red,Lightweight
+01/15/2017,Augusto Mendes,Frankie Saenz,Red,Bantamweight
+01/15/2017,Aleksei Oleinik,Viktor Pesta,Red,Heavyweight
+01/15/2017,Anthony Rocco Martin,Alex White,Red,Lightweight
+01/15/2017,Nina Nunes,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+01/15/2017,Walt Harris,Chase Sherman,Red,Heavyweight
+01/15/2017,Joachim Christensen,Bojan Mihajlovic,Red,Light Heavyweight
+01/15/2017,Cyril Asker,Dmitrii Smoliakov,Red,Heavyweight
+12/30/2016,Amanda Nunes,Ronda Rousey,Red,UFC Women's Bantamweight Title
+12/30/2016,Cody Garbrandt,Dominick Cruz,Red,UFC Bantamweight Title
+12/30/2016,TJ Dillashaw,John Lineker,Red,Bantamweight
+12/30/2016,Dong Hyun Kim,Tarec Saffiedine,Red,Welterweight
+12/30/2016,Ray Borg,Louis Smolka,Red,Flyweight
+12/30/2016,Neil Magny,Johny Hendricks,Red,Welterweight
+12/30/2016,Antonio Carlos Junior,Marvin Vettori,Red,Middleweight
+12/30/2016,Alex Garcia,Mike Pyle,Red,Welterweight
+12/30/2016,Niko Price,Brandon Thatch,Red,Welterweight
+12/17/2016,Michelle Waterson-Gomez,Paige VanZant,Red,Women's Strawweight
+12/17/2016,Mickey Gall,Sage Northcutt,Red,Welterweight
+12/17/2016,Urijah Faber,Brad Pickett,Red,Bantamweight
+12/17/2016,Alan Jouban,Mike Perry,Red,Welterweight
+12/17/2016,Paul Craig,Henrique da Silva,Red,Light Heavyweight
+12/17/2016,Mizuto Hirota,Cole Miller,Red,Featherweight
+12/17/2016,Colby Covington,Bryan Barberena,Red,Welterweight
+12/17/2016,Alex Morono,James Moontasri,Red,Welterweight
+12/17/2016,Josh Emmett,Scott Holtzman,Red,Lightweight
+12/17/2016,Leslie Smith,Irene Aldana,Red,Women's Bantamweight
+12/17/2016,Eddie Wineland,Takeya Mizugaki,Red,Bantamweight
+12/17/2016,Hector Sandoval,Fredy Serrano,Red,Flyweight
+12/17/2016,Sultan Aliev,Bojan Velickovic,Red,Welterweight
+12/10/2016,Max Holloway,Anthony Pettis,Red,UFC Interim Featherweight Title
+12/10/2016,Donald Cerrone,Matt Brown,Red,Welterweight
+12/10/2016,Cub Swanson,Dooho Choi,Red,Featherweight
+12/10/2016,Kelvin Gastelum,Tim Kennedy,Red,Middleweight
+12/10/2016,Emil Meek,Jordan Mein,Red,Welterweight
+12/10/2016,Misha Cirkunov,Nikita Krylov,Red,Light Heavyweight
+12/10/2016,Olivier Aubin-Mercier,Drew Dober,Red,Lightweight
+12/10/2016,Viviane Pereira,Valerie Letourneau,Red,Women's Strawweight
+12/10/2016,Matthew Lopez,Mitch Gagnon,Red,Bantamweight
+12/10/2016,Lando Vannata,John Makdessi,Red,Lightweight
+12/10/2016,Rustam Khabilov,Jason Saggo,Red,Lightweight
+12/10/2016,Dustin Ortiz,Zach Makovsky,Red,Flyweight
+12/09/2016,Derrick Lewis,Shamil Abdurakhimov,Red,Heavyweight
+12/09/2016,Francis Ngannou,Anthony Hamilton,Red,Heavyweight
+12/09/2016,Corey Anderson,Sean O'Connell,Red,Light Heavyweight
+12/09/2016,Gian Villante,Saparbeg Safarov,Red,Light Heavyweight
+12/09/2016,Justine Kish,Ashley Yoder,Red,Women's Strawweight
+12/09/2016,Randy Brown,Brian Camozzi,Red,Welterweight
+12/09/2016,Gerald Meerschaert,Joseph Gigliotti,Red,Middleweight
+12/09/2016,Andrew Sanchez,Trevor Smith,Red,Middleweight
+12/09/2016,Shane Burgos,Tiago dos Santos e Silva,Red,Featherweight
+12/09/2016,Marc Diakiese,Frankie Perez,Red,Lightweight
+12/09/2016,Ryan Janes,Keith Berish,Red,Middleweight
+12/09/2016,Juliana Lima,JJ Aldrich,Red,Women's Strawweight
+12/03/2016,Demetrious Johnson,Tim Elliott,Red,UFC Flyweight Title
+12/03/2016,Joseph Benavidez,Henry Cejudo,Red,Flyweight
+12/03/2016,Jorge Masvidal,Jake Ellenberger,Red,Welterweight
+12/03/2016,Jared Cannonier,Ion Cutelaba,Red,Light Heavyweight
+12/03/2016,Sara McMann,Alexis Davis,Red,Women's Bantamweight
+12/03/2016,Brandon Moreno,Ryan Benoit,Red,Flyweight
+12/03/2016,Ryan Hall,Gray Maynard,Red,Featherweight
+12/03/2016,Rob Font,Matt Schnell,Red,Bantamweight
+12/03/2016,Dong Hyun Ma,Brendan O'Reilly,Red,Lightweight
+12/03/2016,Jamie Moyle,Kailin Curran,Red,Women's Strawweight
+12/03/2016,Anthony Smith,Elvis Mutapcic,Red,Middleweight
+12/03/2016,Devin Clark,Josh Stansbury,Red,Light Heavyweight
+11/26/2016,Robert Whittaker,Derek Brunson,Red,Middleweight
+11/26/2016,Andrew Holbrook,Jake Matthews,Red,Lightweight
+11/26/2016,Omari Akhmedov,Kyle Noke,Red,Welterweight
+11/26/2016,Alexander Volkanovski,Yusuke Kasuya,Red,Lightweight
+11/26/2016,Tyson Pedro,Khalil Rountree Jr.,Red,Light Heavyweight
+11/26/2016,Danielle Taylor,Seo Hee Ham,Red,Women's Strawweight
+11/26/2016,Daniel Kelly,Chris Camozzi,Red,Middleweight
+11/26/2016,Damien Brown,Jon Tuck,Red,Lightweight
+11/26/2016,Jonathan Meunier,Richard Walsh,Red,Welterweight
+11/26/2016,Ben Nguyen,Geane Herrera,Red,Flyweight
+11/26/2016,Jason Knight,Dan Hooker,Red,Featherweight
+11/26/2016,Marlon Vera,Guangyou Ning,Red,Featherweight
+11/26/2016,Jenel Lausa,Yao Zhikui,Red,Flyweight
+11/19/2016,Ryan Bader,Rogerio Nogueira,Red,Light Heavyweight
+11/19/2016,Thomas Almeida,Albert Morales,Red,Bantamweight
+11/19/2016,Claudia Gadelha,Cortney Casey,Red,Women's Strawweight
+11/19/2016,Krzysztof Jotko,Thales Leites,Red,Middleweight
+11/19/2016,Kamaru Usman,Warlley Alves,Red,Welterweight
+11/19/2016,Sergio Moraes,Zak Ottow,Red,Welterweight
+11/19/2016,Cezar Ferreira,Jack Hermansson,Red,Middleweight
+11/19/2016,Gadzhimurad Antigulov,Marcos Rogerio de Lima,Red,Light Heavyweight
+11/19/2016,Johnny Eduardo,Manvel Gamburyan,Red,Bantamweight
+11/19/2016,Luis Henrique,Christian Colombo,Red,Heavyweight
+11/19/2016,Pedro Munhoz,Justin Scoggins,Red,Bantamweight
+11/19/2016,Gegard Mousasi,Uriah Hall,Red,Middleweight
+11/19/2016,Stevie Ray,Ross Pearson,Red,Lightweight
+11/19/2016,Alexander Volkov,Timothy Johnson,Red,Heavyweight
+11/19/2016,Artem Lobov,Teruto Ishihara,Red,Featherweight
+11/19/2016,Jack Marshman,Magnus Cedenblad,Red,Middleweight
+11/19/2016,Kyoji Horiguchi,Ali Bagautinov,Red,Flyweight
+11/19/2016,Kevin Lee,Magomed Mustafaev,Red,Lightweight
+11/19/2016,Amanda Cooper,Anna Elmose,Red,Women's Strawweight
+11/19/2016,Justin Ledet,Mark Godbeer,Red,Heavyweight
+11/19/2016,Zak Cummings,Alexander Yakovlev,Red,Welterweight
+11/19/2016,Marion Reneau,Milana Dudieva,Red,Women's Bantamweight
+11/19/2016,Brett Johns,Kwan Ho Kwak,Red,Bantamweight
+11/19/2016,Abdul Razak Alhassan,Charlie Ward,Red,Welterweight
+11/12/2016,Conor McGregor,Eddie Alvarez,Red,UFC Lightweight Title
+11/12/2016,Joanna Jedrzejczyk,Karolina Kowalkiewicz,Red,UFC Women's Strawweight Title
+11/12/2016,Yoel Romero,Chris Weidman,Red,Middleweight
+11/12/2016,Raquel Pennington,Miesha Tate,Red,Women's Bantamweight
+11/12/2016,Frankie Edgar,Jeremy Stephens,Red,Featherweight
+11/12/2016,Khabib Nurmagomedov,Michael Johnson,Red,Lightweight
+11/12/2016,Tim Boetsch,Rafael Natal,Red,Middleweight
+11/12/2016,Vicente Luque,Belal Muhammad,Red,Welterweight
+11/12/2016,Jim Miller,Thiago Alves,Red,Catch Weight
+11/12/2016,Liz Carmouche,Katlyn Cerminara,Red,Women's Bantamweight
+11/05/2016,Tony Ferguson,Rafael Dos Anjos,Red,Lightweight
+11/05/2016,Diego Sanchez,Marcin Held,Red,Lightweight
+11/05/2016,Ricardo Lamas,Charles Oliveira,Red,Featherweight
+11/05/2016,Martin Bravo,Claudio Puelles,Red,Ultimate Fighter Latin America 3 Lightweight Tournament Title
+11/05/2016,Beneil Dariush,Rashid Magomedov,Red,Lightweight
+11/05/2016,Alexa Grasso,Heather Clark,Red,Women's Strawweight
+11/05/2016,Erik Perez,Felipe Arantes,Red,Bantamweight
+11/05/2016,Joe Soto,Marco Beltran,Red,Catch Weight
+11/05/2016,Max Griffin,Erick Montano,Red,Welterweight
+11/05/2016,Douglas Silva de Andrade,Henry Briones,Red,Bantamweight
+11/05/2016,Sam Alvey,Alex Nicholson,Red,Middleweight
+11/05/2016,Marco Polo Reyes,Jason Novelli,Red,Lightweight
+11/05/2016,Enrique Barzola,Chris Avila,Red,Featherweight
+10/08/2016,Michael Bisping,Dan Henderson,Red,UFC Middleweight Title
+10/08/2016,Gegard Mousasi,Vitor Belfort,Red,Middleweight
+10/08/2016,Jimi Manuwa,Ovince Saint Preux,Red,Light Heavyweight
+10/08/2016,Stefan Struve,Daniel Omielanczuk,Red,Heavyweight
+10/08/2016,Mirsad Bektic,Russell Doane,Red,Featherweight
+10/08/2016,Iuri Alcantara,Brad Pickett,Red,Bantamweight
+10/08/2016,Damian Stasiak,Davey Grant,Red,Bantamweight
+10/08/2016,Leon Edwards,Albert Tumenov,Red,Welterweight
+10/08/2016,Marc Diakiese,Lukasz Sajewski,Red,Lightweight
+10/08/2016,Mike Perry,Danny Roberts,Red,Welterweight
+10/08/2016,Leonardo Santos,Adriano Martins,Red,Lightweight
+10/01/2016,John Lineker,John Dodson,Red,Bantamweight
+10/01/2016,Alex Oliveira,Will Brooks,Red,Lightweight
+10/01/2016,Zak Ottow,Joshua Burkman,Red,Welterweight
+10/01/2016,Brandon Moreno,Louis Smolka,Red,Flyweight
+10/01/2016,Henrique da Silva,Joachim Christensen,Red,Light Heavyweight
+10/01/2016,Andre Fili,Hacran Dias,Red,Featherweight
+10/01/2016,Shamil Abdurakhimov,Walt Harris,Red,Heavyweight
+10/01/2016,Elizeu Zaleski dos Santos,Keita Nakamura,Red,Welterweight
+10/01/2016,Nate Marquardt,Tamdan McCrory,Red,Middleweight
+10/01/2016,Ion Cutelaba,Jonathan Wilson,Red,Light Heavyweight
+10/01/2016,Curtis Blaydes,Cody East,Red,Heavyweight
+10/01/2016,Ketlen Vieira,Kelly Faszholz,Red,Women's Bantamweight
+09/24/2016,Cristiane Justino,Lina Lansberg,Red,Catch Weight
+09/24/2016,Renan Barao,Phillipe Nover,Red,Featherweight
+09/24/2016,Roy Nelson,Antonio Silva,Red,Heavyweight
+09/24/2016,Francisco Trinaldo,Paul Felder,Red,Lightweight
+09/24/2016,Eric Spicely,Thiago Santos,Red,Middleweight
+09/24/2016,Godofredo Pepey,Mike de la Torre,Red,Featherweight
+09/24/2016,Michel Prazeres,Gilbert Burns,Red,Lightweight
+09/24/2016,Rani Yahya,Michinori Tanaka,Red,Bantamweight
+09/24/2016,Jussier Formiga,Dustin Ortiz,Red,Flyweight
+09/24/2016,Erick Silva,Luan Chagas,Red,Welterweight
+09/24/2016,Alan Patrick,Stevie Ray,Red,Lightweight
+09/24/2016,Vicente Luque,Hector Urbina,Red,Welterweight
+09/24/2016,Gregor Gillespie,Glaico Franca Moreira,Red,Lightweight
+09/17/2016,Michael Johnson,Dustin Poirier,Red,Lightweight
+09/17/2016,Derek Brunson,Uriah Hall,Red,Middleweight
+09/17/2016,Evan Dunham,Ricky Glenn,Red,Lightweight
+09/17/2016,Roan Carneiro,Kenny Robertson,Red,Welterweight
+09/17/2016,Islam Makhachev,Chris Wade,Red,Lightweight
+09/17/2016,Chas Skelly,Maximo Blanco,Red,Featherweight
+09/17/2016,Gabriel Benitez,Sam Sicilia,Red,Featherweight
+09/17/2016,Belal Muhammad,Augusto Montano,Red,Welterweight
+09/17/2016,Antonio Carlos Junior,Leonardo Guimaraes,Red,Middleweight
+09/17/2016,Jose Quinonez,Joey Gomez,Red,Bantamweight
+09/17/2016,Randy Brown,Erick Montano,Red,Welterweight
+09/10/2016,Stipe Miocic,Alistair Overeem,Red,UFC Heavyweight Title
+09/10/2016,Fabricio Werdum,Travis Browne,Red,Heavyweight
+09/10/2016,Mickey Gall,CM Punk,Red,Welterweight
+09/10/2016,Jimmie Rivera,Urijah Faber,Red,Bantamweight
+09/10/2016,Jessica Andrade,Joanne Wood,Red,Women's Strawweight
+09/10/2016,Bethe Correia,Jessica Eye,Red,Women's Bantamweight
+09/10/2016,Brad Tavares,Caio Magalhaes,Red,Middleweight
+09/10/2016,Nik Lentz,Michael McBride,Red,Lightweight
+09/10/2016,Drew Dober,Jason Gonzalez,Red,Lightweight
+09/10/2016,Yancy Medeiros,Sean Spencer,Red,Welterweight
+09/03/2016,Josh Barnett,Andrei Arlovski,Red,Heavyweight
+09/03/2016,Alexander Gustafsson,Jan Blachowicz,Red,Light Heavyweight
+09/03/2016,Ryan Bader,Ilir Latifi,Red,Light Heavyweight
+09/03/2016,Nick Hein,Tae Hyun Bang,Red,Lightweight
+09/03/2016,Jessin Ayari,Jim Wallhead,Red,Welterweight
+09/03/2016,Peter Sobotta,Nicolas Dalby,Red,Welterweight
+09/03/2016,Ashlee Evans-Smith,Veronica Hardy,Red,Women's Bantamweight
+09/03/2016,Taylor Lapilus,Leandro Issa,Red,Bantamweight
+09/03/2016,Jack Hermansson,Scott Askham,Red,Middleweight
+09/03/2016,Rustam Khabilov,Leandro Silva,Red,Lightweight
+08/27/2016,Demian Maia,Carlos Condit,Red,Welterweight
+08/27/2016,Anthony Pettis,Charles Oliveira,Red,Featherweight
+08/27/2016,Paige VanZant,Bec Rawlings,Red,Women's Strawweight
+08/27/2016,Jim Miller,Joe Lauzon,Red,Lightweight
+08/27/2016,Sam Alvey,Kevin Casey,Red,Middleweight
+08/27/2016,Kyle Bochniak,Enrique Barzola,Red,Featherweight
+08/27/2016,Alessio Di Chirico,Garreth McLellan,Red,Middleweight
+08/27/2016,Felipe Silva,Shane Campbell,Red,Lightweight
+08/27/2016,Chad Laprise,Thibault Gouti,Red,Lightweight
+08/27/2016,Jeremy Kennedy,Alex Ricci,Red,Lightweight
+08/20/2016,Conor McGregor,Nate Diaz,Red,Welterweight
+08/20/2016,Anthony Johnson,Glover Teixeira,Red,Light Heavyweight
+08/20/2016,Donald Cerrone,Rick Story,Red,Welterweight
+08/20/2016,Mike Perry,Hyun Gyu Lim,Red,Welterweight
+08/20/2016,Tim Means,Sabah Homasi,Red,Welterweight
+08/20/2016,Cody Garbrandt,Takeya Mizugaki,Red,Bantamweight
+08/20/2016,Raquel Pennington,Elizabeth Phillips,Red,Women's Bantamweight
+08/20/2016,Artem Lobov,Chris Avila,Red,Featherweight
+08/20/2016,Cortney Casey,Randa Markos,Red,Women's Strawweight
+08/20/2016,Lorenz Larkin,Neil Magny,Red,Welterweight
+08/20/2016,Colby Covington,Max Griffin,Red,Welterweight
+08/20/2016,Marvin Vettori,Alberto Uda,Red,Middleweight
+08/06/2016,Yair Rodriguez,Alex Caceres,Red,Featherweight
+08/06/2016,Dennis Bermudez,Rony Jason,Red,Featherweight
+08/06/2016,Thales Leites,Chris Camozzi,Red,Middleweight
+08/06/2016,Santiago Ponzinibbio,Zak Cummings,Red,Welterweight
+08/06/2016,Trevor Smith,Joseph Gigliotti,Red,Middleweight
+08/06/2016,Maryna Moroz,Danielle Taylor,Red,Women's Strawweight
+08/06/2016,Court McGee,Dominique Steele,Red,Welterweight
+08/06/2016,Marcin Tybura,Viktor Pesta,Red,Heavyweight
+08/06/2016,David Teymur,Jason Novelli,Red,Lightweight
+08/06/2016,Teruto Ishihara,Horacio Gutierrez,Red,Featherweight
+08/06/2016,Cub Swanson,Tatsuya Kawajiri,Red,Featherweight
+08/06/2016,Justin Ledet,Chase Sherman,Red,Heavyweight
+07/30/2016,Tyron Woodley,Robbie Lawler,Red,UFC Welterweight Title
+07/30/2016,Karolina Kowalkiewicz,Rose Namajunas,Red,Women's Strawweight
+07/30/2016,Jake Ellenberger,Matt Brown,Red,Welterweight
+07/30/2016,Erik Perez,Francisco Rivera,Red,Bantamweight
+07/30/2016,Ryan Benoit,Fredy Serrano,Red,Flyweight
+07/30/2016,Nikita Krylov,Ed Herman,Red,Light Heavyweight
+07/30/2016,Jorge Masvidal,Ross Pearson,Red,Welterweight
+07/30/2016,Anthony Hamilton,Damian Grabowski,Red,Heavyweight
+07/30/2016,Wilson Reis,Hector Sandoval,Red,Flyweight
+07/30/2016,Damien Brown,Cesar Arzamendia,Red,Lightweight
+07/23/2016,Valentina Shevchenko,Holly Holm,Red,Women's Bantamweight
+07/23/2016,Edson Barboza,Gilbert Melendez,Red,Lightweight
+07/23/2016,Francis Ngannou,Bojan Mihajlovic,Red,Heavyweight
+07/23/2016,Felice Herrig,Kailin Curran,Red,Women's Strawweight
+07/23/2016,Eddie Wineland,Frankie Saenz,Red,Bantamweight
+07/23/2016,Darren Elkins,Godofredo Pepey,Red,Featherweight
+07/23/2016,Kamaru Usman,Alexander Yakovlev,Red,Welterweight
+07/23/2016,Michel Prazeres,JC Cottrell,Red,Lightweight
+07/23/2016,Alex Oliveira,James Moontasri,Red,Welterweight
+07/23/2016,Jason Knight,Jim Alers,Red,Featherweight
+07/23/2016,Luis Henrique,Dmitrii Smoliakov,Red,Heavyweight
+07/13/2016,John Lineker,Michael McDonald,Red,Bantamweight
+07/13/2016,Tony Ferguson,Lando Vannata,Red,Lightweight
+07/13/2016,Tim Boetsch,Josh Samman,Red,Middleweight
+07/13/2016,Daniel Omielanczuk,Aleksei Oleinik,Red,Heavyweight
+07/13/2016,Keita Nakamura,Kyle Noke,Red,Welterweight
+07/13/2016,Louis Smolka,Ben Nguyen,Red,Flyweight
+07/13/2016,Katlyn Cerminara,Lauren Murphy,Red,Women's Bantamweight
+07/13/2016,Sam Alvey,Eric Spicely,Red,Middleweight
+07/13/2016,Cortney Casey,Cristina Stanciu,Red,Women's Strawweight
+07/13/2016,Scott Holtzman,Cody Pfister,Red,Lightweight
+07/13/2016,Rani Yahya,Matthew Lopez,Red,Bantamweight
+07/13/2016,Alex Nicholson,Devin Clark,Red,Middleweight
+07/09/2016,Amanda Nunes,Miesha Tate,Red,UFC Women's Bantamweight Title
+07/09/2016,Daniel Cormier,Anderson Silva,Red,Light Heavyweight
+07/09/2016,Jose Aldo,Frankie Edgar,Red,UFC Interim Featherweight Title
+07/09/2016,Cain Velasquez,Travis Browne,Red,Heavyweight
+07/09/2016,Julianna Pena,Cat Zingano,Red,Women's Bantamweight
+07/09/2016,Kelvin Gastelum,Johny Hendricks,Red,Welterweight
+07/09/2016,TJ Dillashaw,Raphael Assuncao,Red,Bantamweight
+07/09/2016,Sage Northcutt,Enrique Marin,Red,Lightweight
+07/09/2016,Joe Lauzon,Diego Sanchez,Red,Lightweight
+07/09/2016,Gegard Mousasi,Thiago Santos,Red,Middleweight
+07/09/2016,Jim Miller,Takanori Gomi,Red,Lightweight
+07/08/2016,Joanna Jedrzejczyk,Claudia Gadelha,Red,UFC Women's Strawweight Title
+07/08/2016,Andrew Sanchez,Khalil Rountree Jr.,Red,Ultimate Fighter 23 Light Heavyweight Tournament Title
+07/08/2016,Tatiana Suarez,Amanda Cooper,Red,Ultimate Fighter 23 Women's Strawweight Tournament Title
+07/08/2016,Will Brooks,Ross Pearson,Red,Lightweight
+07/08/2016,Dooho Choi,Thiago Tavares,Red,Featherweight
+07/08/2016,Joaquim Silva,Andrew Holbrook,Red,Lightweight
+07/08/2016,Gray Maynard,Fernando Bruno,Red,Featherweight
+07/08/2016,Matheus Nicolau,John Moraga,Red,Flyweight
+07/08/2016,Josh Stansbury,Cory Hendricks,Red,Light Heavyweight
+07/08/2016,Cezar Ferreira,Anthony Smith,Red,Middleweight
+07/08/2016,Kevin Lee,Jake Matthews,Red,Lightweight
+07/08/2016,Li Jingliang,Anton Zafir,Red,Welterweight
+07/07/2016,Eddie Alvarez,Rafael Dos Anjos,Red,UFC Lightweight Title
+07/07/2016,Derrick Lewis,Roy Nelson,Red,Heavyweight
+07/07/2016,Alan Jouban,Belal Muhammad,Red,Welterweight
+07/07/2016,Joe Duffy,Mitch Clarke,Red,Lightweight
+07/07/2016,Alberto Mina,Mike Pyle,Red,Welterweight
+07/07/2016,John Makdessi,Mehdi Baghdad,Red,Lightweight
+07/07/2016,Anthony Birchak,Dileno Lopes,Red,Bantamweight
+07/07/2016,Pedro Munhoz,Russell Doane,Red,Bantamweight
+07/07/2016,Felipe Arantes,Jerrod Sanders,Red,Bantamweight
+07/07/2016,Gilbert Burns,Lukasz Sajewski,Red,Lightweight
+07/07/2016,Marco Beltran,Reginaldo Vieira,Red,Bantamweight
+07/07/2016,Vicente Luque,Alvaro Herrera Mendoza,Red,Welterweight
+06/18/2016,Stephen Thompson,Rory MacDonald,Red,Welterweight
+06/18/2016,Donald Cerrone,Patrick Cote,Red,Welterweight
+06/18/2016,Steve Bosse,Sean O'Connell,Red,Light Heavyweight
+06/18/2016,Olivier Aubin-Mercier,Thibault Gouti,Red,Lightweight
+06/18/2016,Joanne Wood,Valerie Letourneau,Red,Women's Flyweight
+06/18/2016,Jason Saggo,Leandro Silva,Red,Lightweight
+06/18/2016,Misha Cirkunov,Ion Cutelaba,Red,Light Heavyweight
+06/18/2016,Krzysztof Jotko,Tamdan McCrory,Red,Middleweight
+06/18/2016,Joe Soto,Chris Beal,Red,Bantamweight
+06/18/2016,Elias Theodorou,Sam Alvey,Red,Middleweight
+06/18/2016,Randa Markos,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+06/18/2016,Colby Covington,Jonathan Meunier,Red,Welterweight
+06/18/2016,Ali Bagautinov,Geane Herrera,Red,Flyweight
+06/04/2016,Michael Bisping,Luke Rockhold,Red,UFC Middleweight Title
+06/04/2016,Dominick Cruz,Urijah Faber,Red,UFC Bantamweight Title
+06/04/2016,Max Holloway,Ricardo Lamas,Red,Featherweight
+06/04/2016,Dan Henderson,Hector Lombard,Red,Middleweight
+06/04/2016,Dustin Poirier,Bobby Green,Red,Lightweight
+06/04/2016,Brian Ortega,Clay Guida,Red,Featherweight
+06/04/2016,Beneil Dariush,James Vick,Red,Lightweight
+06/04/2016,Jessica Andrade,Jessica Penne,Red,Women's Strawweight
+06/04/2016,Alex Caceres,Cole Miller,Red,Featherweight
+06/04/2016,Sean Strickland,Tom Breese,Red,Welterweight
+06/04/2016,Henrique da Silva,Jonathan Wilson,Red,Light Heavyweight
+06/04/2016,Marco Polo Reyes,Dong Hyun Ma,Red,Lightweight
+05/29/2016,Cody Garbrandt,Thomas Almeida,Red,Bantamweight
+05/29/2016,Jeremy Stephens,Renan Barao,Red,Featherweight
+05/29/2016,Rick Story,Tarec Saffiedine,Red,Welterweight
+05/29/2016,Chris Camozzi,Vitor Miranda,Red,Middleweight
+05/29/2016,Lorenz Larkin,Jorge Masvidal,Red,Welterweight
+05/29/2016,Paul Felder,Joshua Burkman,Red,Lightweight
+05/29/2016,Sara McMann,Jessica Eye,Red,Women's Bantamweight
+05/29/2016,Abel Trujillo,Jordan Rinaldi,Red,Lightweight
+05/29/2016,Jake Collier,Alberto Uda,Red,Middleweight
+05/29/2016,Erik Koch,Shane Campbell,Red,Lightweight
+05/29/2016,Bryan Caraway,Aljamain Sterling,Red,Bantamweight
+05/29/2016,Adam Milstead,Chris de la Rocha,Red,Heavyweight
+05/14/2016,Stipe Miocic,Fabricio Werdum,Red,UFC Heavyweight Title
+05/14/2016,Jacare Souza,Vitor Belfort,Red,Middleweight
+05/14/2016,Cristiane Justino,Leslie Smith,Red,Catch Weight
+05/14/2016,Mauricio Rua,Corey Anderson,Red,Light Heavyweight
+05/14/2016,Bryan Barberena,Warlley Alves,Red,Welterweight
+05/14/2016,Demian Maia,Matt Brown,Red,Welterweight
+05/14/2016,Thiago Santos,Nate Marquardt,Red,Middleweight
+05/14/2016,Francisco Trinaldo,Yancy Medeiros,Red,Lightweight
+05/14/2016,John Lineker,Rob Font,Red,Bantamweight
+05/14/2016,Rogerio Nogueira,Patrick Cummins,Red,Light Heavyweight
+05/14/2016,Renato Moicano,Zubaira Tukhugov,Red,Featherweight
+05/08/2016,Alistair Overeem,Andrei Arlovski,Red,Heavyweight
+05/08/2016,Stefan Struve,Antonio Silva,Red,Heavyweight
+05/08/2016,Gunnar Nelson,Albert Tumenov,Red,Welterweight
+05/08/2016,Germaine de Randamie,Anna Elmose,Red,Women's Bantamweight
+05/08/2016,Nikita Krylov,Francimar Barroso,Red,Light Heavyweight
+05/08/2016,Karolina Kowalkiewicz,Heather Clark,Red,Women's Strawweight
+05/08/2016,Rustam Khabilov,Chris Wade,Red,Lightweight
+05/08/2016,Magnus Cedenblad,Garreth McLellan,Red,Middleweight
+05/08/2016,Josh Emmett,Jon Tuck,Red,Lightweight
+05/08/2016,Reza Madadi,Yan Cabral,Red,Lightweight
+05/08/2016,Kyoji Horiguchi,Neil Seery,Red,Flyweight
+05/08/2016,Leon Edwards,Dominic Waters,Red,Welterweight
+05/08/2016,Yuta Sasaki,Willie Gates,Red,Flyweight
+04/23/2016,Jon Jones,Ovince Saint Preux,Red,UFC Interim Light Heavyweight Title
+04/23/2016,Demetrious Johnson,Henry Cejudo,Red,UFC Flyweight Title
+04/23/2016,Edson Barboza,Anthony Pettis,Red,Lightweight
+04/23/2016,Robert Whittaker,Rafael Natal,Red,Middleweight
+04/23/2016,Yair Rodriguez,Andre Fili,Red,Featherweight
+04/23/2016,Sergio Pettis,Chris Kelades,Red,Flyweight
+04/23/2016,Danny Roberts,Dominique Steele,Red,Welterweight
+04/23/2016,Carla Esparza,Juliana Lima,Red,Women's Strawweight
+04/23/2016,James Vick,Glaico Franca Moreira,Red,Lightweight
+04/23/2016,Walt Harris,Cody East,Red,Heavyweight
+04/23/2016,Marcos Rogerio de Lima,Clint Hester,Red,Light Heavyweight
+04/23/2016,Kevin Lee,Efrain Escudero,Red,Lightweight
+04/16/2016,Glover Teixeira,Rashad Evans,Red,Light Heavyweight
+04/16/2016,Rose Namajunas,Tecia Torres,Red,Women's Strawweight
+04/16/2016,Khabib Nurmagomedov,Darrell Horcher,Red,Catch Weight
+04/16/2016,Cub Swanson,Hacran Dias,Red,Featherweight
+04/16/2016,Michael Chiesa,Beneil Dariush,Red,Lightweight
+04/16/2016,Raquel Pennington,Bethe Correia,Red,Women's Bantamweight
+04/16/2016,Santiago Ponzinibbio,Court McGee,Red,Welterweight
+04/16/2016,Michael Graves,Randy Brown,Red,Welterweight
+04/16/2016,John Dodson,Manvel Gamburyan,Red,Bantamweight
+04/16/2016,Cezar Ferreira,Oluwale Bamgbose,Red,Middleweight
+04/16/2016,Elizeu Zaleski dos Santos,Omari Akhmedov,Red,Welterweight
+04/10/2016,Junior Dos Santos,Ben Rothwell,Red,Heavyweight
+04/10/2016,Derrick Lewis,Gabriel Gonzaga,Red,Heavyweight
+04/10/2016,Francis Ngannou,Curtis Blaydes,Red,Heavyweight
+04/10/2016,Timothy Johnson,Marcin Tybura,Red,Heavyweight
+04/10/2016,Jan Blachowicz,Igor Pokrajac,Red,Light Heavyweight
+04/10/2016,Maryna Moroz,Cristina Stanciu,Red,Women's Strawweight
+04/10/2016,Zak Cummings,Nicolas Dalby,Red,Welterweight
+04/10/2016,Alejandro Perez,Ian Entwistle,Red,Bantamweight
+04/10/2016,Mairbek Taisumov,Damir Hadzovic,Red,Lightweight
+04/10/2016,Damian Stasiak,Filip Pejic,Red,Bantamweight
+04/10/2016,Lucas Martins,Robert Whiteford,Red,Featherweight
+04/10/2016,Jared Cannonier,Cyril Asker,Red,Heavyweight
+04/10/2016,Bojan Velickovic,Alessio Di Chirico,Red,Middleweight
+03/19/2016,Mark Hunt,Frank Mir,Red,Heavyweight
+03/19/2016,Neil Magny,Hector Lombard,Red,Welterweight
+03/19/2016,Jake Matthews,Johnny Case,Red,Lightweight
+03/19/2016,Daniel Kelly,Antonio Carlos Junior,Red,Middleweight
+03/19/2016,Steve Bosse,James Te Huna,Red,Light Heavyweight
+03/19/2016,Bec Rawlings,Seo Hee Ham,Red,Women's Strawweight
+03/19/2016,Alan Jouban,Brendan O'Reilly,Red,Welterweight
+03/19/2016,Dan Hooker,Mark Eddiva,Red,Featherweight
+03/19/2016,Leslie Smith,Rin Nakai,Red,Women's Bantamweight
+03/19/2016,Viscardi Andrade,Richard Walsh,Red,Welterweight
+03/19/2016,Ross Pearson,Chad Laprise,Red,Lightweight
+03/19/2016,Alan Patrick,Damien Brown,Red,Lightweight
+03/05/2016,Nate Diaz,Conor McGregor,Red,Welterweight
+03/05/2016,Miesha Tate,Holly Holm,Red,UFC Women's Bantamweight Title
+03/05/2016,Ilir Latifi,Gian Villante,Red,Light Heavyweight
+03/05/2016,Corey Anderson,Tom Lawlor,Red,Light Heavyweight
+03/05/2016,Amanda Nunes,Valentina Shevchenko,Red,Women's Bantamweight
+03/05/2016,Siyar Bahadurzada,Brandon Thatch,Red,Welterweight
+03/05/2016,Nordine Taleb,Erick Silva,Red,Welterweight
+03/05/2016,Vitor Miranda,Marcelo Guimaraes,Red,Middleweight
+03/05/2016,Darren Elkins,Chas Skelly,Red,Featherweight
+03/05/2016,Diego Sanchez,Jim Miller,Red,Lightweight
+03/05/2016,Jason Saggo,Justin Salas,Red,Lightweight
+03/05/2016,Teruto Ishihara,Julian Erosa,Red,Featherweight
+02/27/2016,Michael Bisping,Anderson Silva,Red,Middleweight
+02/27/2016,Gegard Mousasi,Thales Leites,Red,Middleweight
+02/27/2016,Tom Breese,Keita Nakamura,Red,Welterweight
+02/27/2016,Brad Pickett,Francisco Rivera,Red,Bantamweight
+02/27/2016,Makwan Amirkhani,Mike Wilkinson,Red,Featherweight
+02/27/2016,Davey Grant,Marlon Vera,Red,Bantamweight
+02/27/2016,Scott Askham,Chris Dempsey,Red,Middleweight
+02/27/2016,Arnold Allen,Yaotzin Meza,Red,Featherweight
+02/27/2016,Krzysztof Jotko,Brad Scott,Red,Middleweight
+02/27/2016,Rustam Khabilov,Norman Parke,Red,Lightweight
+02/27/2016,Daniel Omielanczuk,Jarjis Danho,Red,Heavyweight
+02/27/2016,Teemu Packalen,Thibault Gouti,Red,Lightweight
+02/27/2016,David Teymur,Martin Svensson,Red,Lightweight
+02/21/2016,Donald Cerrone,Alex Oliveira,Red,Welterweight
+02/21/2016,Derek Brunson,Roan Carneiro,Red,Middleweight
+02/21/2016,Cody Garbrandt,Augusto Mendes,Red,Catch Weight
+02/21/2016,Dennis Bermudez,Tatsuya Kawajiri,Red,Featherweight
+02/21/2016,Chris Camozzi,Joe Riggs,Red,Middleweight
+02/21/2016,James Krause,Shane Campbell,Red,Lightweight
+02/21/2016,Sean Strickland,Alex Garcia,Red,Welterweight
+02/21/2016,Oluwale Bamgbose,Daniel Sarafian,Red,Middleweight
+02/21/2016,Anthony Smith,Leonardo Guimaraes,Red,Middleweight
+02/21/2016,Nathan Coy,Jonavin Webb,Red,Welterweight
+02/21/2016,Ashlee Evans-Smith,Marion Reneau,Red,Women's Bantamweight
+02/21/2016,Lauren Murphy,Kelly Faszholz,Red,Women's Bantamweight
+02/21/2016,Shamil Abdurakhimov,Anthony Hamilton,Red,Heavyweight
+02/06/2016,Stephen Thompson,Johny Hendricks,Red,Welterweight
+02/06/2016,Roy Nelson,Jared Rosholt,Red,Heavyweight
+02/06/2016,Ovince Saint Preux,Rafael Cavalcante,Red,Light Heavyweight
+02/06/2016,Joseph Benavidez,Zach Makovsky,Red,Flyweight
+02/06/2016,Misha Cirkunov,Alex Nicholson,Red,Light Heavyweight
+02/06/2016,Mike Pyle,Sean Spencer,Red,Welterweight
+02/06/2016,Joshua Burkman,KJ Noons,Red,Lightweight
+02/06/2016,Derrick Lewis,Damian Grabowski,Red,Heavyweight
+02/06/2016,Justin Scoggins,Ray Borg,Red,Flyweight
+02/06/2016,Diego Rivas,Noad Lahat,Red,Featherweight
+02/06/2016,Mickey Gall,Mike Jackson,Red,Welterweight
+02/06/2016,Alex White,Artem Lobov,Red,Featherweight
+01/30/2016,Anthony Johnson,Ryan Bader,Red,Light Heavyweight
+01/30/2016,Ben Rothwell,Josh Barnett,Red,Heavyweight
+01/30/2016,Jimmie Rivera,Iuri Alcantara,Red,Bantamweight
+01/30/2016,Bryan Barberena,Sage Northcutt,Red,Welterweight
+01/30/2016,Tarec Saffiedine,Jake Ellenberger,Red,Welterweight
+01/30/2016,Diego Ferreira,Olivier Aubin-Mercier,Red,Lightweight
+01/30/2016,Rafael Natal,Kevin Casey,Red,Middleweight
+01/30/2016,Wilson Reis,Dustin Ortiz,Red,Flyweight
+01/30/2016,Alexander Yakovlev,George Sullivan,Red,Welterweight
+01/30/2016,Alex Caceres,Masio Fullen,Red,Featherweight
+01/30/2016,Randy Brown,Matt Dwyer,Red,Welterweight
+01/30/2016,Anthony Rocco Martin,Felipe Olivieri,Red,Lightweight
+01/17/2016,Dominick Cruz,TJ Dillashaw,Red,UFC Bantamweight Title
+01/17/2016,Eddie Alvarez,Anthony Pettis,Red,Lightweight
+01/17/2016,Travis Browne,Matt Mitrione,Red,Heavyweight
+01/17/2016,Francisco Trinaldo,Ross Pearson,Red,Lightweight
+01/17/2016,Patrick Cote,Ben Saunders,Red,Welterweight
+01/17/2016,Ed Herman,Tim Boetsch,Red,Light Heavyweight
+01/17/2016,Chris Wade,Mehdi Baghdad,Red,Lightweight
+01/17/2016,Luke Sanders,Maximo Blanco,Red,Featherweight
+01/17/2016,Paul Felder,Daron Cruickshank,Red,Lightweight
+01/17/2016,Ilir Latifi,Sean O'Connell,Red,Light Heavyweight
+01/17/2016,Charles Rosa,Kyle Bochniak,Red,Featherweight
+01/17/2016,Rob Font,Joey Gomez,Red,Bantamweight
+01/17/2016,Francimar Barroso,Elvis Mutapcic,Red,Light Heavyweight
+01/02/2016,Robbie Lawler,Carlos Condit,Red,UFC Welterweight Title
+01/02/2016,Stipe Miocic,Andrei Arlovski,Red,Heavyweight
+01/02/2016,Albert Tumenov,Lorenz Larkin,Red,Welterweight
+01/02/2016,Brian Ortega,Diego Brandao,Red,Featherweight
+01/02/2016,Abel Trujillo,Tony Sims,Red,Lightweight
+01/02/2016,Michael McDonald,Masanori Kanehara,Red,Bantamweight
+01/02/2016,Alex Morono,Kyle Noke,Red,Welterweight
+01/02/2016,Justine Kish,Nina Nunes,Red,Women's Strawweight
+01/02/2016,Drew Dober,Scott Holtzman,Red,Lightweight
+01/02/2016,Dustin Poirier,Joe Duffy,Red,Lightweight
+01/02/2016,Michinori Tanaka,Joe Soto,Red,Bantamweight
+01/02/2016,Sheldon Westcott,Edgar Garcia,Red,Welterweight
+12/19/2015,Rafael Dos Anjos,Donald Cerrone,Red,UFC Lightweight Title
+12/19/2015,Alistair Overeem,Junior Dos Santos,Red,Heavyweight
+12/19/2015,Nate Diaz,Michael Johnson,Red,Lightweight
+12/19/2015,Karolina Kowalkiewicz,Randa Markos,Red,Women's Strawweight
+12/19/2015,Charles Oliveira,Myles Jury,Red,Featherweight
+12/19/2015,Nate Marquardt,CB Dollaway,Red,Middleweight
+12/19/2015,Valentina Shevchenko,Sarah Kaufman,Red,Women's Bantamweight
+12/19/2015,Tamdan McCrory,Josh Samman,Red,Middleweight
+12/19/2015,Nik Lentz,Danny Castillo,Red,Lightweight
+12/19/2015,Kamaru Usman,Leon Edwards,Red,Welterweight
+12/19/2015,Vicente Luque,Hayder Hassan,Red,Welterweight
+12/19/2015,Francis Ngannou,Luis Henrique,Red,Heavyweight
+12/12/2015,Conor McGregor,Jose Aldo,Red,UFC Featherweight Title
+12/12/2015,Luke Rockhold,Chris Weidman,Red,UFC Middleweight Title
+12/12/2015,Yoel Romero,Jacare Souza,Red,Middleweight
+12/12/2015,Demian Maia,Gunnar Nelson,Red,Welterweight
+12/12/2015,Max Holloway,Jeremy Stephens,Red,Featherweight
+12/12/2015,Urijah Faber,Frankie Saenz,Red,Bantamweight
+12/12/2015,Tecia Torres,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+12/12/2015,Warlley Alves,Colby Covington,Red,Welterweight
+12/12/2015,Leonardo Santos,Kevin Lee,Red,Lightweight
+12/12/2015,Magomed Mustafaev,Joe Proctor,Red,Lightweight
+12/12/2015,Yancy Medeiros,John Makdessi,Red,Lightweight
+12/12/2015,Court McGee,Marcio Alexandre Junior,Red,Welterweight
+12/11/2015,Frankie Edgar,Chad Mendes,Red,Featherweight
+12/11/2015,Ryan Hall,Artem Lobov,Red,Ultimate Fighter 22 Lightweight Tournament Title
+12/11/2015,Tony Ferguson,Edson Barboza,Red,Lightweight
+12/11/2015,Evan Dunham,Joe Lauzon,Red,Lightweight
+12/11/2015,Tatsuya Kawajiri,Jason Knight,Red,Featherweight
+12/11/2015,Julian Erosa,Marcin Wrzosek,Red,Lightweight
+12/11/2015,Gabriel Gonzaga,Konstantin Erokhin,Red,Heavyweight
+12/11/2015,Ryan LaFlare,Mike Pierce,Red,Welterweight
+12/11/2015,Geane Herrera,Joby Sanchez,Red,Flyweight
+12/11/2015,Chris Gruetzemacher,Abner Lloveras,Red,Lightweight
+12/10/2015,Rose Namajunas,Paige VanZant,Red,Women's Strawweight
+12/10/2015,Michael Chiesa,Jim Miller,Red,Lightweight
+12/10/2015,Sage Northcutt,Cody Pfister,Red,Lightweight
+12/10/2015,Thiago Santos,Elias Theodorou,Red,Middleweight
+12/10/2015,Tim Means,John Howard,Red,Welterweight
+12/10/2015,Sergio Moraes,Omari Akhmedov,Red,Welterweight
+12/10/2015,Aljamain Sterling,Johnny Eduardo,Red,Bantamweight
+12/10/2015,Santiago Ponzinibbio,Andreas Stahl,Red,Welterweight
+12/10/2015,Danny Roberts,Nathan Coy,Red,Welterweight
+12/10/2015,Zubaira Tukhugov,Phillipe Nover,Red,Featherweight
+12/10/2015,Kailin Curran,Emily Kagan,Red,Women's Strawweight
+11/28/2015,Benson Henderson,Jorge Masvidal,Red,Welterweight
+11/28/2015,Dong Hyun Kim,Dominic Waters,Red,Welterweight
+11/28/2015,Alberto Mina,Yoshihiro Akiyama,Red,Welterweight
+11/28/2015,Dooho Choi,Sam Sicilia,Red,Featherweight
+11/28/2015,Dongi Yang,Jake Collier,Red,Middleweight
+11/28/2015,Mike de la Torre,Yui Chul Nam,Red,Featherweight
+11/28/2015,Tae Hyun Bang,Leo Kuntz,Red,Lightweight
+11/28/2015,Seo Hee Ham,Cortney Casey,Red,Women's Strawweight
+11/28/2015,Fredy Serrano,Yao Zhikui,Red,Flyweight
+11/28/2015,Marco Beltran,Guangyou Ning,Red,Bantamweight
+11/28/2015,Dominique Steele,Dong Hyun Ma,Red,Welterweight
+11/21/2015,Neil Magny,Kelvin Gastelum,Red,Welterweight
+11/21/2015,Ricardo Lamas,Diego Sanchez,Red,Featherweight
+11/21/2015,Henry Cejudo,Jussier Formiga,Red,Flyweight
+11/21/2015,Erick Montano,Enrique Marin,Red,Ultimate Fighter Latin America 2 Welterweight Tournament Title
+11/21/2015,Enrique Barzola,Horacio Gutierrez,Red,Ultimate Fighter Latin America 2 Lightweight Tournament Title
+11/21/2015,Leandro Silva,Efrain Escudero,Red,Lightweight
+11/21/2015,Erik Perez,Taylor Lapilus,Red,Bantamweight
+11/21/2015,Bartosz Fabinski,Hector Urbina,Red,Welterweight
+11/21/2015,Alejandro Perez,Scott Jorgensen,Red,Bantamweight
+11/21/2015,Andre Fili,Gabriel Benitez,Red,Featherweight
+11/21/2015,Alvaro Herrera Mendoza,Vernon Ramos Ho,Red,Welterweight
+11/21/2015,Marco Polo Reyes,Cesar Arzamendia,Red,Lightweight
+11/21/2015,Michel Prazeres,Valmir Lazaro,Red,Lightweight
+11/14/2015,Holly Holm,Ronda Rousey,Red,UFC Women's Bantamweight Title
+11/14/2015,Joanna Jedrzejczyk,Valerie Letourneau,Red,UFC Women's Strawweight Title
+11/14/2015,Mark Hunt,Antonio Silva,Red,Heavyweight
+11/14/2015,Robert Whittaker,Uriah Hall,Red,Middleweight
+11/14/2015,Jared Rosholt,Stefan Struve,Red,Heavyweight
+11/14/2015,Jake Matthews,Akbarh Arreola,Red,Lightweight
+11/14/2015,Kyle Noke,Peter Sobotta,Red,Welterweight
+11/14/2015,Gian Villante,Anthony Perosh,Red,Light Heavyweight
+11/14/2015,Danny Martinez,Richie Vaculik,Red,Flyweight
+11/14/2015,Daniel Kelly,Steve Montgomery,Red,Middleweight
+11/14/2015,Richard Walsh,Steve Kennedy,Red,Welterweight
+11/14/2015,James Moontasri,Anton Zafir,Red,Welterweight
+11/14/2015,Ben Nguyen,Ryan Benoit,Red,Flyweight
+11/07/2015,Vitor Belfort,Dan Henderson,Red,Middleweight
+11/07/2015,Glover Teixeira,Patrick Cummins,Red,Light Heavyweight
+11/07/2015,Thomas Almeida,Anthony Birchak,Red,Bantamweight
+11/07/2015,Alex Oliveira,Piotr Hallmann,Red,Lightweight
+11/07/2015,Rashid Magomedov,Gilbert Burns,Red,Lightweight
+11/07/2015,Corey Anderson,Fabio Maldonado,Red,Light Heavyweight
+11/07/2015,Abel Trujillo,Gleison Tibau,Red,Lightweight
+11/07/2015,Johnny Case,Yan Cabral,Red,Lightweight
+11/07/2015,Thiago Tavares,Clay Guida,Red,Featherweight
+11/07/2015,Chas Skelly,Edimilson Souza,Red,Featherweight
+11/07/2015,Viscardi Andrade,Gasan Umalatov,Red,Welterweight
+11/07/2015,Jimmie Rivera,Pedro Munhoz,Red,Bantamweight
+11/07/2015,Matheus Nicolau,Bruno Korea,Red,Bantamweight
+10/24/2015,Louis Smolka,Paddy Holohan,Red,Flyweight
+10/24/2015,Norman Parke,Reza Madadi,Red,Lightweight
+10/24/2015,Neil Seery,Jon Delos Reyes,Red,Flyweight
+10/24/2015,Stevie Ray,Mickael Lebout,Red,Lightweight
+10/24/2015,Aisling Daly,Ericka Almeida,Red,Women's Strawweight
+10/24/2015,Krzysztof Jotko,Scott Askham,Red,Middleweight
+10/24/2015,Tom Breese,Cathal Pendred,Red,Welterweight
+10/24/2015,Darren Elkins,Robert Whiteford,Red,Featherweight
+10/24/2015,Garreth McLellan,Bubba Bush,Red,Middleweight
+10/03/2015,Daniel Cormier,Alexander Gustafsson,Red,UFC Light Heavyweight Title
+10/03/2015,Ryan Bader,Rashad Evans,Red,Light Heavyweight
+10/03/2015,Ruslan Magomedov,Shawn Jordan,Red,Heavyweight
+10/03/2015,Joseph Benavidez,Ali Bagautinov,Red,Flyweight
+10/03/2015,Julianna Pena,Jessica Eye,Red,Women's Bantamweight
+10/03/2015,Yair Rodriguez,Dan Hooker,Red,Featherweight
+10/03/2015,Albert Tumenov,Alan Jouban,Red,Welterweight
+10/03/2015,Adriano Martins,Islam Makhachev,Red,Lightweight
+10/03/2015,Rose Namajunas,Angela Hill,Red,Women's Strawweight
+10/03/2015,Sage Northcutt,Francisco Trevino,Red,Lightweight
+10/03/2015,Sergio Pettis,Chris Cariaso,Red,Flyweight
+10/03/2015,Derrick Lewis,Viktor Pesta,Red,Heavyweight
+09/26/2015,Josh Barnett,Roy Nelson,Red,Heavyweight
+09/26/2015,Uriah Hall,Gegard Mousasi,Red,Middleweight
+09/26/2015,Kyoji Horiguchi,Chico Camus,Red,Flyweight
+09/26/2015,Takeya Mizugaki,George Roop,Red,Bantamweight
+09/26/2015,Diego Brandao,Katsunori Kikuno,Red,Featherweight
+09/26/2015,Keita Nakamura,Li Jingliang,Red,Welterweight
+09/26/2015,Nick Hein,Yusuke Kasuya,Red,Lightweight
+09/26/2015,Kajan Johnson,Naoyuki Kotani,Red,Lightweight
+09/26/2015,Shinsho Anzai,Roger Zapata,Red,Welterweight
+09/05/2015,Demetrious Johnson,John Dodson,Red,UFC Flyweight Title
+09/05/2015,Andrei Arlovski,Frank Mir,Red,Heavyweight
+09/05/2015,Anthony Johnson,Jimi Manuwa,Red,Light Heavyweight
+09/05/2015,Corey Anderson,Jan Blachowicz,Red,Light Heavyweight
+09/05/2015,Paige VanZant,Alex Chambers,Red,Women's Strawweight
+09/05/2015,Ross Pearson,Paul Felder,Red,Lightweight
+09/05/2015,John Lineker,Francisco Rivera,Red,Bantamweight
+09/05/2015,Raquel Pennington,Jessica Andrade,Red,Women's Bantamweight
+09/05/2015,Tiago dos Santos e Silva,Clay Collard,Red,Featherweight
+09/05/2015,Joe Riggs,Ron Stallings,Red,Middleweight
+09/05/2015,Joaquim Silva,Nazareno Malegarie,Red,Lightweight
+08/23/2015,Max Holloway,Charles Oliveira,Red,Featherweight
+08/23/2015,Neil Magny,Erick Silva,Red,Welterweight
+08/23/2015,Patrick Cote,Joshua Burkman,Red,Welterweight
+08/23/2015,Francisco Trinaldo,Chad Laprise,Red,Lightweight
+08/23/2015,Olivier Aubin-Mercier,Tony Sims,Red,Lightweight
+08/23/2015,Valerie Letourneau,Maryna Moroz,Red,Women's Strawweight
+08/23/2015,Frankie Perez,Sam Stout,Red,Lightweight
+08/23/2015,Felipe Arantes,Yves Jabouin,Red,Bantamweight
+08/23/2015,Nikita Krylov,Marcos Rogerio de Lima,Red,Light Heavyweight
+08/23/2015,Chris Kelades,Chris Beal,Red,Flyweight
+08/23/2015,Shane Campbell,Elias Silverio,Red,Lightweight
+08/23/2015,Misha Cirkunov,Daniel Jolly,Red,Light Heavyweight
+08/08/2015,Glover Teixeira,Ovince Saint Preux,Red,Light Heavyweight
+08/08/2015,Beneil Dariush,Michael Johnson,Red,Lightweight
+08/08/2015,Derek Brunson,Sam Alvey,Red,Middleweight
+08/08/2015,Jared Rosholt,Timothy Johnson,Red,Heavyweight
+08/08/2015,Amanda Nunes,Sara McMann,Red,Women's Bantamweight
+08/08/2015,Ray Borg,Geane Herrera,Red,Flyweight
+08/08/2015,Uriah Hall,Oluwale Bamgbose,Red,Middleweight
+08/08/2015,Chris Camozzi,Tom Watson,Red,Middleweight
+08/08/2015,Dustin Ortiz,Willie Gates,Red,Flyweight
+08/08/2015,Frankie Saenz,Sirwan Kakai,Red,Bantamweight
+08/08/2015,Jonathan Wilson,Chris Dempsey,Red,Light Heavyweight
+08/08/2015,Marlon Vera,Roman Salazar,Red,Bantamweight
+08/08/2015,Scott Holtzman,Anthony Christodoulou,Red,Lightweight
+08/01/2015,Ronda Rousey,Bethe Correia,Red,UFC Women's Bantamweight Title
+08/01/2015,Mauricio Rua,Rogerio Nogueira,Red,Light Heavyweight
+08/01/2015,Glaico Franca Moreira,Fernando Bruno,Red,Ultimate Fighter Brazil 4 Lightweight Tournament Title
+08/01/2015,Reginaldo Vieira,Dileno Lopes,Red,Ultimate Fighter Brazil 4 Bantamweight Tournament Title
+08/01/2015,Stefan Struve,Antonio Rodrigo Nogueira,Red,Heavyweight
+08/01/2015,Antonio Silva,Soa Palelei,Red,Heavyweight
+08/01/2015,Claudia Gadelha,Jessica Aguilar,Red,Women's Strawweight
+08/01/2015,Demian Maia,Neil Magny,Red,Welterweight
+08/01/2015,Patrick Cummins,Rafael Cavalcante,Red,Light Heavyweight
+08/01/2015,Warlley Alves,Nordine Taleb,Red,Welterweight
+08/01/2015,Iuri Alcantara,Leandro Issa,Red,Bantamweight
+08/01/2015,Vitor Miranda,Clint Hester,Red,Middleweight
+08/01/2015,Guido Cannetti,Hugo Viana,Red,Bantamweight
+07/25/2015,TJ Dillashaw,Renan Barao,Red,UFC Bantamweight Title
+07/25/2015,Miesha Tate,Jessica Eye,Red,Women's Bantamweight
+07/25/2015,Edson Barboza,Paul Felder,Red,Lightweight
+07/25/2015,Joe Lauzon,Takanori Gomi,Red,Lightweight
+07/25/2015,Tom Lawlor,Gian Villante,Red,Light Heavyweight
+07/25/2015,Jim Miller,Danny Castillo,Red,Lightweight
+07/25/2015,Ben Saunders,Kenny Robertson,Red,Welterweight
+07/25/2015,Bryan Caraway,Eddie Wineland,Red,Bantamweight
+07/25/2015,James Krause,Daron Cruickshank,Red,Lightweight
+07/25/2015,Andrew Holbrook,Ramsey Nijem,Red,Lightweight
+07/25/2015,Elizabeth Phillips,Jessamyn Duke,Red,Women's Bantamweight
+07/25/2015,Zak Cummings,Dominique Steele,Red,Middleweight
+07/18/2015,Michael Bisping,Thales Leites,Red,Middleweight
+07/18/2015,Evan Dunham,Ross Pearson,Red,Lightweight
+07/18/2015,Joe Duffy,Ivan Jorge,Red,Lightweight
+07/18/2015,Joanne Wood,Cortney Casey,Red,Women's Strawweight
+07/18/2015,Leon Edwards,Pawel Pawlak,Red,Welterweight
+07/18/2015,Stevie Ray,Leonardo Mafra,Red,Lightweight
+07/18/2015,Paddy Holohan,Vaughan Lee,Red,Flyweight
+07/18/2015,Ilir Latifi,Hans Stringer,Red,Light Heavyweight
+07/18/2015,Mickael Lebout,Teemu Packalen,Red,Lightweight
+07/18/2015,Robert Whiteford,Paul Redmond,Red,Featherweight
+07/18/2015,Jimmie Rivera,Marcus Brimage,Red,Bantamweight
+07/18/2015,Daniel Omielanczuk,Chris de la Rocha,Red,Heavyweight
+07/15/2015,Frank Mir,Todd Duffee,Red,Heavyweight
+07/15/2015,Tony Ferguson,Josh Thomson,Red,Lightweight
+07/15/2015,Holly Holm,Marion Reneau,Red,Women's Bantamweight
+07/15/2015,Manvel Gamburyan,Scott Jorgensen,Red,Bantamweight
+07/15/2015,Kevin Lee,James Moontasri,Red,Lightweight
+07/15/2015,Alan Jouban,Matt Dwyer,Red,Welterweight
+07/15/2015,Sam Sicilia,Yaotzin Meza,Red,Featherweight
+07/15/2015,Jessica Andrade,Sarah Moras,Red,Women's Bantamweight
+07/15/2015,Rani Yahya,Masanori Kanehara,Red,Bantamweight
+07/15/2015,Sean Strickland,Igor Araujo,Red,Welterweight
+07/15/2015,Kevin Casey,Ildemar Alcantara,Red,Middleweight
+07/15/2015,Lyman Good,Andrew Craig,Red,Welterweight
+07/12/2015,Stephen Thompson,Jake Ellenberger,Red,Welterweight
+07/12/2015,Kamaru Usman,Hayder Hassan,Red,Ultimate Fighter 21 Welterweight Tournament Title
+07/12/2015,Michael Graves,Vicente Luque,Red,Welterweight
+07/12/2015,Jorge Masvidal,Cezar Ferreira,Red,Welterweight
+07/12/2015,Michelle Waterson-Gomez,Angela Magana,Red,Women's Strawweight
+07/12/2015,Maximo Blanco,Mike de la Torre,Red,Featherweight
+07/12/2015,Josh Samman,Caio Magalhaes,Red,Middleweight
+07/12/2015,Jerrod Sanders,Russell Doane,Red,Bantamweight
+07/12/2015,Trevor Smith,Dan Miller,Red,Middleweight
+07/12/2015,George Sullivan,Dominic Waters,Red,Welterweight
+07/12/2015,Willie Gates,Darrell Montague,Red,Flyweight
+07/11/2015,Conor McGregor,Chad Mendes,Red,UFC Interim Featherweight Title
+07/11/2015,Robbie Lawler,Rory MacDonald,Red,UFC Welterweight Title
+07/11/2015,Jeremy Stephens,Dennis Bermudez,Red,Featherweight
+07/11/2015,Gunnar Nelson,Brandon Thatch,Red,Welterweight
+07/11/2015,Thomas Almeida,Brad Pickett,Red,Bantamweight
+07/11/2015,Matt Brown,Tim Means,Red,Welterweight
+07/11/2015,Alex Garcia,Mike Swick,Red,Welterweight
+07/11/2015,John Howard,Cathal Pendred,Red,Welterweight
+07/11/2015,Cody Garbrandt,Henry Briones,Red,Bantamweight
+07/11/2015,Louis Smolka,Neil Seery,Red,Flyweight
+07/11/2015,Cody Pfister,Yosdenis Cedeno,Red,Lightweight
+06/27/2015,Yoel Romero,Lyoto Machida,Red,Middleweight
+06/27/2015,Lorenz Larkin,Santiago Ponzinibbio,Red,Welterweight
+06/27/2015,Antonio Carlos Junior,Eddie Gordon,Red,Middleweight
+06/27/2015,Thiago Santos,Steve Bosse,Red,Middleweight
+06/27/2015,Hacran Dias,Levan Makashvili,Red,Featherweight
+06/27/2015,Alex Oliveira,Joe Merritt,Red,Welterweight
+06/27/2015,Leandro Silva,Lewis Gonzalez,Red,Welterweight
+06/27/2015,Tony Sims,Steve Montgomery,Red,Welterweight
+06/27/2015,Sirwan Kakai,Danny Martinez,Red,Bantamweight
+06/20/2015,Joanna Jedrzejczyk,Jessica Penne,Red,UFC Women's Strawweight Title
+06/20/2015,Tatsuya Kawajiri,Dennis Siver,Red,Featherweight
+06/20/2015,Peter Sobotta,Steve Kennedy,Red,Welterweight
+06/20/2015,Nick Hein,Lukasz Sajewski,Red,Lightweight
+06/20/2015,Makwan Amirkhani,Masio Fullen,Red,Featherweight
+06/20/2015,Mairbek Taisumov,Alan Patrick,Red,Lightweight
+06/20/2015,Arnold Allen,Alan Omer,Red,Featherweight
+06/20/2015,Noad Lahat,Niklas Backstrom,Red,Featherweight
+06/20/2015,Scott Askham,Antonio Dos Santos,Red,Middleweight
+06/20/2015,Magomed Mustafaev,Piotr Hallmann,Red,Lightweight
+06/20/2015,Taylor Lapilus,Yuta Sasaki,Red,Bantamweight
+06/13/2015,Fabricio Werdum,Cain Velasquez,Red,UFC Heavyweight Title
+06/13/2015,Eddie Alvarez,Gilbert Melendez,Red,Lightweight
+06/13/2015,Kelvin Gastelum,Nate Marquardt,Red,Middleweight
+06/13/2015,Yair Rodriguez,Charles Rosa,Red,Featherweight
+06/13/2015,Tecia Torres,Angela Hill,Red,Women's Strawweight
+06/13/2015,Henry Cejudo,Chico Camus,Red,Flyweight
+06/13/2015,Efrain Escudero,Drew Dober,Red,Lightweight
+06/13/2015,Patrick Williams,Alejandro Perez,Red,Bantamweight
+06/13/2015,Johnny Case,Francisco Trevino,Red,Lightweight
+06/13/2015,Cathal Pendred,Augusto Montano,Red,Welterweight
+06/13/2015,Gabriel Benitez,Clay Collard,Red,Featherweight
+06/06/2015,Dan Henderson,Tim Boetsch,Red,Middleweight
+06/06/2015,Ben Rothwell,Matt Mitrione,Red,Heavyweight
+06/06/2015,Dustin Poirier,Yancy Medeiros,Red,Lightweight
+06/06/2015,Brian Ortega,Thiago Tavares,Red,Featherweight
+06/06/2015,Anthony Birchak,Joe Soto,Red,Bantamweight
+06/06/2015,Francisco Rivera,Alex Caceres,Red,Bantamweight
+06/06/2015,Shawn Jordan,Derrick Lewis,Red,Heavyweight
+06/06/2015,Omari Akhmedov,Brian Ebersole,Red,Welterweight
+06/06/2015,Chris Wade,Christos Giagos,Red,Lightweight
+06/06/2015,Joe Proctor,Justin Edwards,Red,Lightweight
+06/06/2015,Jake Collier,Ricardo Abreu,Red,Middleweight
+06/06/2015,Jose Quinonez,Leonardo Morales,Red,Bantamweight
+05/30/2015,Carlos Condit,Thiago Alves,Red,Welterweight
+05/30/2015,Charles Oliveira,Nik Lentz,Red,Featherweight
+05/30/2015,Alex Oliveira,KJ Noons,Red,Welterweight
+05/30/2015,Francimar Barroso,Ryan Jimmo,Red,Light Heavyweight
+05/30/2015,Francisco Trinaldo,Norman Parke,Red,Lightweight
+05/30/2015,Darren Till,Wendell Oliveira Marques,Red,Welterweight
+05/30/2015,Jussier Formiga,Wilson Reis,Red,Flyweight
+05/30/2015,Nicolas Dalby,Elizeu Zaleski dos Santos,Red,Welterweight
+05/30/2015,Mirsad Bektic,Lucas Martins,Red,Featherweight
+05/30/2015,Juliana Lima,Ericka Almeida,Red,Women's Strawweight
+05/30/2015,Tom Breese,Luiz Dutra,Red,Welterweight
+05/23/2015,Daniel Cormier,Anthony Johnson,Red,UFC Light Heavyweight Title
+05/23/2015,Chris Weidman,Vitor Belfort,Red,UFC Middleweight Title
+05/23/2015,Donald Cerrone,John Makdessi,Red,Lightweight
+05/23/2015,Andrei Arlovski,Travis Browne,Red,Heavyweight
+05/23/2015,Joseph Benavidez,John Moraga,Red,Flyweight
+05/23/2015,John Dodson,Zach Makovsky,Red,Flyweight
+05/23/2015,Dong Hyun Kim,Joshua Burkman,Red,Welterweight
+05/23/2015,Rafael Natal,Uriah Hall,Red,Middleweight
+05/23/2015,Colby Covington,Mike Pyle,Red,Welterweight
+05/23/2015,Islam Makhachev,Leo Kuntz,Red,Lightweight
+05/23/2015,Justin Scoggins,Josh Sampo,Red,Flyweight
+05/16/2015,Frankie Edgar,Urijah Faber,Red,Featherweight
+05/16/2015,Gegard Mousasi,Constantinos Philippou,Red,Middleweight
+05/16/2015,Mark Munoz,Luke Barnatt,Red,Middleweight
+05/16/2015,Neil Magny,Hyun Gyu Lim,Red,Welterweight
+05/16/2015,Phillipe Nover,Yui Chul Nam,Red,Featherweight
+05/16/2015,Levan Makashvili,Mark Eddiva,Red,Featherweight
+05/16/2015,Jon Tuck,Tae Hyun Bang,Red,Lightweight
+05/16/2015,Kajan Johnson,Zhang Lipeng,Red,Lightweight
+05/16/2015,Li Jingliang,Dhiego Lima,Red,Welterweight
+05/16/2015,Guangyou Ning,Royston Wee,Red,Bantamweight
+05/16/2015,Jon Delos Reyes,Roldan Sangcha'an,Red,Flyweight
+05/16/2015,Yao Zhikui,Nolan Ticman,Red,Flyweight
+05/09/2015,Stipe Miocic,Mark Hunt,Red,Heavyweight
+05/09/2015,Robert Whittaker,Brad Tavares,Red,Middleweight
+05/09/2015,Sean O'Connell,Anthony Perosh,Red,Light Heavyweight
+05/09/2015,James Vick,Jake Matthews,Red,Lightweight
+05/09/2015,Dan Hooker,Hatsu Hioki,Red,Featherweight
+05/09/2015,Kyle Noke,Jonavin Webb,Red,Welterweight
+05/09/2015,Sam Alvey,Daniel Kelly,Red,Middleweight
+05/09/2015,Bec Rawlings,Lisa Ellis,Red,Women's Strawweight
+05/09/2015,Brad Scott,Dylan Andrews,Red,Middleweight
+05/09/2015,Alex Chambers,Kailin Curran,Red,Women's Strawweight
+05/09/2015,Brendan O'Reilly,Vik Grujic,Red,Welterweight
+05/09/2015,Ben Nguyen,Alptekin Ozkilic,Red,Flyweight
+04/25/2015,Demetrious Johnson,Kyoji Horiguchi,Red,UFC Flyweight Title
+04/25/2015,Quinton Jackson,Fabio Maldonado,Red,Catch Weight
+04/25/2015,Michael Bisping,CB Dollaway,Red,Middleweight
+04/25/2015,John Makdessi,Shane Campbell,Red,Catch Weight
+04/25/2015,Thomas Almeida,Yves Jabouin,Red,Bantamweight
+04/25/2015,Patrick Cote,Joe Riggs,Red,Welterweight
+04/25/2015,Alexis Davis,Sarah Kaufman,Red,Women's Bantamweight
+04/25/2015,Chad Laprise,Bryan Barberena,Red,Lightweight
+04/25/2015,Olivier Aubin-Mercier,David Michaud,Red,Lightweight
+04/25/2015,Nordine Taleb,Chris Clements,Red,Welterweight
+04/25/2015,Valerie Letourneau,Jessica Rakoczy,Red,Women's Strawweight
+04/25/2015,Randa Markos,Aisling Daly,Red,Women's Strawweight
+04/18/2015,Luke Rockhold,Lyoto Machida,Red,Middleweight
+04/18/2015,Jacare Souza,Chris Camozzi,Red,Middleweight
+04/18/2015,Max Holloway,Cub Swanson,Red,Featherweight
+04/18/2015,Paige VanZant,Felice Herrig,Red,Women's Strawweight
+04/18/2015,Beneil Dariush,Jim Miller,Red,Lightweight
+04/18/2015,Ovince Saint Preux,Patrick Cummins,Red,Light Heavyweight
+04/18/2015,Gian Villante,Corey Anderson,Red,Light Heavyweight
+04/18/2015,Aljamain Sterling,Takeya Mizugaki,Red,Bantamweight
+04/18/2015,Tim Means,George Sullivan,Red,Welterweight
+04/18/2015,Diego Brandao,Jimy Hettes,Red,Featherweight
+04/18/2015,Chris Dempsey,Eddie Gordon,Red,Middleweight
+04/11/2015,Mirko Filipovic,Gabriel Gonzaga,Red,Heavyweight
+04/11/2015,Jimi Manuwa,Jan Blachowicz,Red,Light Heavyweight
+04/11/2015,Pawel Pawlak,Sheldon Westcott,Red,Welterweight
+04/11/2015,Maryna Moroz,Joanne Wood,Red,Women's Strawweight
+04/11/2015,Leon Edwards,Seth Baczynski,Red,Welterweight
+04/11/2015,Bartosz Fabinski,Garreth McLellan,Red,Middleweight
+04/11/2015,Sergio Moraes,Mickael Lebout,Red,Welterweight
+04/11/2015,Yaotzin Meza,Damian Stasiak,Red,Featherweight
+04/11/2015,Anthony Hamilton,Daniel Omielanczuk,Red,Heavyweight
+04/11/2015,Aleksandra Albu,Izabela Badurek,Red,Women's Strawweight
+04/11/2015,Stevie Ray,Marcin Bandel,Red,Lightweight
+04/11/2015,Taylor Lapilus,Rocky Lee,Red,Featherweight
+04/04/2015,Chad Mendes,Ricardo Lamas,Red,Featherweight
+04/04/2015,Al Iaquinta,Jorge Masvidal,Red,Lightweight
+04/04/2015,Michael Chiesa,Mitch Clarke,Red,Lightweight
+04/04/2015,Julianna Pena,Milana Dudieva,Red,Women's Bantamweight
+04/04/2015,Clay Guida,Robert Peralta,Red,Featherweight
+04/04/2015,Dustin Poirier,Diego Ferreira,Red,Lightweight
+04/04/2015,Liz Carmouche,Lauren Murphy,Red,Women's Bantamweight
+04/04/2015,Alexander Yakovlev,Gray Maynard,Red,Lightweight
+04/04/2015,Timothy Johnson,Shamil Abdurakhimov,Red,Heavyweight
+04/04/2015,Ron Stallings,Justin Jones,Red,Middleweight
+03/21/2015,Demian Maia,Ryan LaFlare,Red,Welterweight
+03/21/2015,Erick Silva,Josh Koscheck,Red,Welterweight
+03/21/2015,Leonardo Santos,Anthony Rocco Martin,Red,Lightweight
+03/21/2015,Amanda Nunes,Shayna Baszler,Red,Women's Bantamweight
+03/21/2015,Gilbert Burns,Alex Oliveira,Red,Lightweight
+03/21/2015,Godofredo Pepey,Andre Fili,Red,Featherweight
+03/21/2015,Francisco Trinaldo,Akbarh Arreola,Red,Lightweight
+03/21/2015,Edimilson Souza,Katsunori Kikuno,Red,Featherweight
+03/21/2015,Leonardo Mafra,Cain Carrizosa,Red,Lightweight
+03/21/2015,Christos Giagos,Jorge de Oliveira,Red,Lightweight
+03/21/2015,Fredy Serrano,Bentley Syler,Red,Flyweight
+03/14/2015,Rafael Dos Anjos,Anthony Pettis,Red,UFC Lightweight Title
+03/14/2015,Joanna Jedrzejczyk,Carla Esparza,Red,UFC Women's Strawweight Title
+03/14/2015,Johny Hendricks,Matt Brown,Red,Welterweight
+03/14/2015,Alistair Overeem,Roy Nelson,Red,Heavyweight
+03/14/2015,Henry Cejudo,Chris Cariaso,Red,Flyweight
+03/14/2015,Ross Pearson,Sam Stout,Red,Lightweight
+03/14/2015,Elias Theodorou,Roger Narvaez,Red,Middleweight
+03/14/2015,Beneil Dariush,Daron Cruickshank,Red,Lightweight
+03/14/2015,Jared Rosholt,Josh Copeland,Red,Heavyweight
+03/14/2015,Ryan Benoit,Sergio Pettis,Red,Flyweight
+03/14/2015,Joe Duffy,Jake Lindsey,Red,Lightweight
+03/14/2015,Germaine de Randamie,Larissa Pacheco,Red,Women's Bantamweight
+02/28/2015,Ronda Rousey,Cat Zingano,Red,UFC Women's Bantamweight Title
+02/28/2015,Holly Holm,Raquel Pennington,Red,Women's Bantamweight
+02/28/2015,Jake Ellenberger,Josh Koscheck,Red,Welterweight
+02/28/2015,Alan Jouban,Richard Walsh,Red,Welterweight
+02/28/2015,Tony Ferguson,Gleison Tibau,Red,Lightweight
+02/28/2015,Roan Carneiro,Mark Munoz,Red,Middleweight
+02/28/2015,Tim Means,Dhiego Lima,Red,Welterweight
+02/28/2015,Derrick Lewis,Ruan Potts,Red,Heavyweight
+02/28/2015,Valmir Lazaro,James Krause,Red,Lightweight
+02/28/2015,Masio Fullen,Alex Torres,Red,Featherweight
+02/22/2015,Frank Mir,Antonio Silva,Red,Heavyweight
+02/22/2015,Michael Johnson,Edson Barboza,Red,Lightweight
+02/22/2015,Sam Alvey,Cezar Ferreira,Red,Middleweight
+02/22/2015,Adriano Martins,Rustam Khabilov,Red,Lightweight
+02/22/2015,Frankie Saenz,Iuri Alcantara,Red,Bantamweight
+02/22/2015,Santiago Ponzinibbio,Sean Strickland,Red,Welterweight
+02/22/2015,Marion Reneau,Jessica Andrade,Red,Women's Bantamweight
+02/22/2015,Matt Dwyer,William Macario,Red,Welterweight
+02/22/2015,Mike de la Torre,Tiago dos Santos e Silva,Red,Featherweight
+02/22/2015,Douglas Silva de Andrade,Cody Gibson,Red,Bantamweight
+02/22/2015,Ivan Jorge,Josh Shockley,Red,Lightweight
+02/14/2015,Benson Henderson,Brandon Thatch,Red,Welterweight
+02/14/2015,Max Holloway,Cole Miller,Red,Featherweight
+02/14/2015,Neil Magny,Kiichi Kunimoto,Red,Welterweight
+02/14/2015,Daniel Kelly,Patrick Walsh,Red,Middleweight
+02/14/2015,Kevin Lee,Michel Prazeres,Red,Lightweight
+02/14/2015,Ray Borg,Chris Kelades,Red,Flyweight
+02/14/2015,Efrain Escudero,Rodrigo de Lima,Red,Lightweight
+02/14/2015,Chas Skelly,Jim Alers,Red,Featherweight
+02/14/2015,Zach Makovsky,Tim Elliott,Red,Flyweight
+02/14/2015,James Moontasri,Cody Pfister,Red,Lightweight
+01/31/2015,Tyron Woodley,Kelvin Gastelum,Red,Welterweight
+01/31/2015,Al Iaquinta,Joe Lauzon,Red,Lightweight
+01/31/2015,Thales Leites,Tim Boetsch,Red,Middleweight
+01/31/2015,Thiago Alves,Jordan Mein,Red,Welterweight
+01/31/2015,Miesha Tate,Sara McMann,Red,Women's Bantamweight
+01/31/2015,Derek Brunson,Ed Herman,Red,Middleweight
+01/31/2015,John Lineker,Ian McCall,Red,Flyweight
+01/31/2015,Rafael Natal,Tom Watson,Red,Middleweight
+01/31/2015,Ildemar Alcantara,Richardson Moreira,Red,Middleweight
+01/31/2015,Thiago Santos,Andy Enz,Red,Middleweight
+01/24/2015,Anthony Johnson,Alexander Gustafsson,Red,Light Heavyweight
+01/24/2015,Gegard Mousasi,Dan Henderson,Red,Middleweight
+01/24/2015,Ryan Bader,Phil Davis,Red,Light Heavyweight
+01/24/2015,Sam Sicilia,Akira Corassani,Red,Featherweight
+01/24/2015,Albert Tumenov,Nicholas Musoke,Red,Welterweight
+01/24/2015,Kenny Robertson,Sultan Aliev,Red,Welterweight
+01/24/2015,Makwan Amirkhani,Andy Ogle,Red,Featherweight
+01/24/2015,Nikita Krylov,Stanislav Nedkov,Red,Light Heavyweight
+01/24/2015,Mairbek Taisumov,Anthony Christodoulou,Red,Lightweight
+01/24/2015,Mirsad Bektic,Paul Redmond,Red,Featherweight
+01/24/2015,Viktor Pesta,Konstantin Erokhin,Red,Heavyweight
+01/24/2015,Neil Seery,Chris Beal,Red,Flyweight
+01/18/2015,Conor McGregor,Dennis Siver,Red,Featherweight
+01/18/2015,Donald Cerrone,Benson Henderson,Red,Lightweight
+01/18/2015,Uriah Hall,Ron Stallings,Red,Middleweight
+01/18/2015,Gleison Tibau,Norman Parke,Red,Lightweight
+01/18/2015,Cathal Pendred,Sean Spencer,Red,Welterweight
+01/18/2015,Lorenz Larkin,John Howard,Red,Welterweight
+01/18/2015,Chris Wade,Zhang Lipeng,Red,Lightweight
+01/18/2015,Paddy Holohan,Shane Howell,Red,Flyweight
+01/18/2015,Johnny Case,Frankie Perez,Red,Lightweight
+01/18/2015,Charles Rosa,Sean Soriano,Red,Featherweight
+01/18/2015,Sean O'Connell,Matt Van Buren,Red,Light Heavyweight
+01/18/2015,Joby Sanchez,Tateki Matsuda,Red,Flyweight
+01/03/2015,Jon Jones,Daniel Cormier,Red,UFC Light Heavyweight Title
+01/03/2015,Donald Cerrone,Myles Jury,Red,Lightweight
+01/03/2015,Brad Tavares,Nate Marquardt,Red,Middleweight
+01/03/2015,Kyoji Horiguchi,Louis Gaudinot,Red,Flyweight
+01/03/2015,Paul Felder,Danny Castillo,Red,Lightweight
+01/03/2015,Cody Garbrandt,Marcus Brimage,Red,Bantamweight
+01/03/2015,Shawn Jordan,Jared Cannonier,Red,Heavyweight
+01/03/2015,Evan Dunham,Rodrigo Damm,Red,Lightweight
+01/03/2015,Omari Akhmedov,Mats Nilsson,Red,Welterweight
+01/03/2015,Marion Reneau,Alexis Dufresne,Red,Women's Bantamweight
+12/20/2014,Lyoto Machida,CB Dollaway,Red,Middleweight
+12/20/2014,Renan Barao,Mitch Gagnon,Red,Bantamweight
+12/20/2014,Patrick Cummins,Antonio Carlos Junior,Red,Light Heavyweight
+12/20/2014,Rashid Magomedov,Elias Silverio,Red,Lightweight
+12/20/2014,Erick Silva,Mike Rhodes,Red,Welterweight
+12/20/2014,Daniel Sarafian,Antonio Dos Santos,Red,Middleweight
+12/20/2014,Marcos Rogerio de Lima,Igor Pokrajac,Red,Light Heavyweight
+12/20/2014,Renato Moicano,Tom Niinimaki,Red,Featherweight
+12/20/2014,Hacran Dias,Darren Elkins,Red,Featherweight
+12/20/2014,Leandro Issa,Yuta Sasaki,Red,Bantamweight
+12/20/2014,Tim Means,Marcio Alexandre Junior,Red,Welterweight
+12/20/2014,Vitor Miranda,Jake Collier,Red,Middleweight
+12/13/2014,Junior Dos Santos,Stipe Miocic,Red,Heavyweight
+12/13/2014,Rafael Dos Anjos,Nate Diaz,Red,Lightweight
+12/13/2014,Alistair Overeem,Stefan Struve,Red,Heavyweight
+12/13/2014,Matt Mitrione,Gabriel Gonzaga,Red,Heavyweight
+12/13/2014,Joanna Jedrzejczyk,Claudia Gadelha,Red,Women's Strawweight
+12/13/2014,John Moraga,Willie Gates,Red,Flyweight
+12/13/2014,Ben Saunders,Joe Riggs,Red,Welterweight
+12/13/2014,Drew Dober,Jamie Varner,Red,Lightweight
+12/13/2014,Bryan Barberena,Joe Ellenberger,Red,Lightweight
+12/13/2014,David Michaud,Garett Whiteley,Red,Lightweight
+12/13/2014,Henry Cejudo,Dustin Kimura,Red,Bantamweight
+12/13/2014,Ian Entwistle,Anthony Birchak,Red,Bantamweight
+12/12/2014,Carla Esparza,Rose Namajunas,Red,UFC Women's Strawweight Title
+12/12/2014,Charles Oliveira,Jeremy Stephens,Red,Featherweight
+12/12/2014,Yancy Medeiros,Joe Proctor,Red,Lightweight
+12/12/2014,Jessica Penne,Randa Markos,Red,Women's Strawweight
+12/12/2014,Felice Herrig,Lisa Ellis,Red,Women's Strawweight
+12/12/2014,Heather Clark,Bec Rawlings,Red,Women's Strawweight
+12/12/2014,Joanne Wood,Seo Hee Ham,Red,Women's Strawweight
+12/12/2014,Tecia Torres,Angela Magana,Red,Women's Strawweight
+12/12/2014,Aisling Daly,Alex Chambers,Red,Women's Strawweight
+12/12/2014,Angela Hill,Emily Kagan,Red,Women's Strawweight
+12/06/2014,Robbie Lawler,Johny Hendricks,Red,UFC Welterweight Title
+12/06/2014,Anthony Pettis,Gilbert Melendez,Red,UFC Lightweight Title
+12/06/2014,Travis Browne,Brendan Schaub,Red,Heavyweight
+12/06/2014,Todd Duffee,Anthony Hamilton,Red,Heavyweight
+12/06/2014,Tony Ferguson,Abel Trujillo,Red,Lightweight
+12/06/2014,Urijah Faber,Francisco Rivera,Red,Bantamweight
+12/06/2014,Josh Samman,Eddie Gordon,Red,Middleweight
+12/06/2014,Corey Anderson,Justin Jones,Red,Light Heavyweight
+12/06/2014,Raquel Pennington,Ashlee Evans-Smith,Red,Women's Bantamweight
+12/06/2014,Sergio Pettis,Matt Hobar,Red,Bantamweight
+12/06/2014,Clay Collard,Alex White,Red,Featherweight
+11/22/2014,Frankie Edgar,Cub Swanson,Red,Featherweight
+11/22/2014,Edson Barboza,Bobby Green,Red,Lightweight
+11/22/2014,Chico Camus,Brad Pickett,Red,Flyweight
+11/22/2014,Aleksei Oleinik,Jared Rosholt,Red,Heavyweight
+11/22/2014,Joseph Benavidez,Dustin Ortiz,Red,Flyweight
+11/22/2014,Matt Wiman,Isaac Vallie-Flagg,Red,Lightweight
+11/22/2014,Ruslan Magomedov,Josh Copeland,Red,Heavyweight
+11/22/2014,Roger Narvaez,Luke Barnatt,Red,Middleweight
+11/22/2014,James Vick,Nick Hein,Red,Lightweight
+11/22/2014,Akbarh Arreola,Yves Edwards,Red,Lightweight
+11/22/2014,Paige VanZant,Kailin Curran,Red,Women's Strawweight
+11/22/2014,Dooho Choi,Juan Manuel Puig,Red,Featherweight
+11/15/2014,Fabricio Werdum,Mark Hunt,Red,UFC Interim Heavyweight Title
+11/15/2014,Kelvin Gastelum,Jake Ellenberger,Red,Welterweight
+11/15/2014,Ricardo Lamas,Dennis Bermudez,Red,Featherweight
+11/15/2014,Augusto Montano,Chris Heatherly,Red,Welterweight
+11/15/2014,Hector Urbina,Edgar Garcia,Red,Welterweight
+11/15/2014,Yair Rodriguez,Leonardo Morales,Red,Ultimate Fighter Latin America Featherweight Tournament Title
+11/15/2014,Alejandro Perez,Jose Quinonez,Red,Ultimate Fighter Latin America Bantamweight Tournament Title
+11/15/2014,Jessica Eye,Leslie Smith,Red,Women's Bantamweight
+11/15/2014,Gabriel Benitez,Humberto Brown Morrison,Red,Featherweight
+11/15/2014,Henry Briones,Guido Cannetti,Red,Bantamweight
+11/15/2014,Marco Beltran,Marlon Vera,Red,Bantamweight
+11/08/2014,Ovince Saint Preux,Mauricio Rua,Red,Light Heavyweight
+11/08/2014,Warlley Alves,Alan Jouban,Red,Welterweight
+11/08/2014,Claudio Silva,Leon Edwards,Red,Welterweight
+11/08/2014,Dhiego Lima,Jorge de Oliveira,Red,Welterweight
+11/08/2014,Juliana Lima,Nina Nunes,Red,Women's Strawweight
+11/08/2014,Diego Rivas,Rodolfo Rubio Perez,Red,Featherweight
+11/08/2014,Caio Magalhaes,Trevor Smith,Red,Middleweight
+11/08/2014,Leandro Silva,Charlie Brenneman,Red,Lightweight
+11/08/2014,Thomas Almeida,Tim Gorman,Red,Bantamweight
+11/08/2014,Colby Covington,Wagner Silva,Red,Welterweight
+11/07/2014,Luke Rockhold,Michael Bisping,Red,Middleweight
+11/07/2014,Al Iaquinta,Ross Pearson,Red,Lightweight
+11/07/2014,Robert Whittaker,Clint Hester,Red,Middleweight
+11/07/2014,Soa Palelei,Walt Harris,Red,Heavyweight
+11/07/2014,Jake Matthews,Vagner Rocha,Red,Lightweight
+11/07/2014,Anthony Perosh,Guto Inocente,Red,Light Heavyweight
+11/07/2014,Sam Alvey,Dylan Andrews,Red,Middleweight
+11/07/2014,Louis Smolka,Richie Vaculik,Red,Flyweight
+11/07/2014,Chris Clements,Vik Grujic,Red,Welterweight
+11/07/2014,Daniel Kelly,Luke Zachrich,Red,Middleweight
+11/07/2014,Marcus Brimage,Jumabieke Tuerxun,Red,Bantamweight
+10/25/2014,Jose Aldo,Chad Mendes,Red,UFC Featherweight Title
+10/25/2014,Phil Davis,Glover Teixeira,Red,Light Heavyweight
+10/25/2014,Fabio Maldonado,Hans Stringer,Red,Light Heavyweight
+10/25/2014,Darren Elkins,Lucas Martins,Red,Featherweight
+10/25/2014,Beneil Dariush,Diego Ferreira,Red,Lightweight
+10/25/2014,Neil Magny,William Macario,Red,Welterweight
+10/25/2014,Yan Cabral,Naoyuki Kotani,Red,Lightweight
+10/25/2014,Wilson Reis,Scott Jorgensen,Red,Flyweight
+10/25/2014,Andre Fili,Felipe Arantes,Red,Featherweight
+10/25/2014,Gilbert Burns,Christos Giagos,Red,Lightweight
+10/25/2014,Anthony Rocco Martin,Fabricio Camoes,Red,Lightweight
+10/04/2014,Rory MacDonald,Tarec Saffiedine,Red,Welterweight
+10/04/2014,Raphael Assuncao,Bryan Caraway,Red,Bantamweight
+10/04/2014,Chad Laprise,Yosdenis Cedeno,Red,Lightweight
+10/04/2014,Elias Theodorou,Bruno Santos,Red,Middleweight
+10/04/2014,Nordine Taleb,Li Jingliang,Red,Welterweight
+10/04/2014,Mitch Gagnon,Roman Salazar,Red,Bantamweight
+10/04/2014,Daron Cruickshank,Anthony Njokuani,Red,Lightweight
+10/04/2014,Olivier Aubin-Mercier,Jake Lindsey,Red,Lightweight
+10/04/2014,Paul Felder,Jason Saggo,Red,Lightweight
+10/04/2014,Chris Kelades,Paddy Holohan,Red,Flyweight
+10/04/2014,Albert Tumenov,Matt Dwyer,Red,Welterweight
+10/04/2014,Rick Story,Gunnar Nelson,Red,Welterweight
+10/04/2014,Max Holloway,Akira Corassani,Red,Featherweight
+10/04/2014,Jan Blachowicz,Ilir Latifi,Red,Light Heavyweight
+10/04/2014,Mike Wilkinson,Niklas Backstrom,Red,Featherweight
+10/04/2014,Magnus Cedenblad,Scott Askham,Red,Middleweight
+10/04/2014,Nicholas Musoke,Alexander Yakovlev,Red,Welterweight
+10/04/2014,Dennis Siver,Charles Rosa,Red,Featherweight
+10/04/2014,Cathal Pendred,Gasan Umalatov,Red,Welterweight
+10/04/2014,Krzysztof Jotko,Tor Troeng,Red,Middleweight
+10/04/2014,Mairbek Taisumov,Marcin Bandel,Red,Lightweight
+10/04/2014,Zubaira Tukhugov,Ernest Chavez,Red,Featherweight
+09/27/2014,Demetrious Johnson,Chris Cariaso,Red,UFC Flyweight Title
+09/27/2014,Donald Cerrone,Eddie Alvarez,Red,Lightweight
+09/27/2014,Conor McGregor,Dustin Poirier,Red,Featherweight
+09/27/2014,Yoel Romero,Tim Kennedy,Red,Middleweight
+09/27/2014,Cat Zingano,Amanda Nunes,Red,Women's Bantamweight
+09/27/2014,Dominick Cruz,Takeya Mizugaki,Red,Bantamweight
+09/27/2014,Jorge Masvidal,James Krause,Red,Lightweight
+09/27/2014,Stephen Thompson,Patrick Cote,Red,Welterweight
+09/27/2014,Brian Ebersole,John Howard,Red,Welterweight
+09/27/2014,Kevin Lee,Jon Tuck,Red,Lightweight
+09/27/2014,Manvel Gamburyan,Cody Gibson,Red,Bantamweight
+09/20/2014,Mark Hunt,Roy Nelson,Red,Heavyweight
+09/20/2014,Myles Jury,Takanori Gomi,Red,Lightweight
+09/20/2014,Yoshihiro Akiyama,Amir Sadollah,Red,Welterweight
+09/20/2014,Miesha Tate,Rin Nakai,Red,Women's Bantamweight
+09/20/2014,Kiichi Kunimoto,Richard Walsh,Red,Welterweight
+09/20/2014,Kyoji Horiguchi,Jon Delos Reyes,Red,Flyweight
+09/20/2014,Masanori Kanehara,Alex Caceres,Red,Bantamweight
+09/20/2014,Katsunori Kikuno,Sam Sicilia,Red,Featherweight
+09/20/2014,Hyun Gyu Lim,Takenori Sato,Red,Welterweight
+09/20/2014,Kyung Ho Kang,Michinori Tanaka,Red,Bantamweight
+09/20/2014,Johnny Case,Kazuki Tokudome,Red,Lightweight
+09/20/2014,Maximo Blanco,Dan Hooker,Red,Featherweight
+09/13/2014,Andrei Arlovski,Antonio Silva,Red,Heavyweight
+09/13/2014,Gleison Tibau,Piotr Hallmann,Red,Lightweight
+09/13/2014,Leonardo Santos,Efrain Escudero,Red,Lightweight
+09/13/2014,Santiago Ponzinibbio,Wendell Oliveira Marques,Red,Welterweight
+09/13/2014,Iuri Alcantara,Russell Doane,Red,Bantamweight
+09/13/2014,Jessica Andrade,Larissa Pacheco,Red,Women's Bantamweight
+09/13/2014,Godofredo Pepey,Dashon Johnson,Red,Featherweight
+09/13/2014,George Sullivan,Igor Araujo,Red,Welterweight
+09/13/2014,Francisco Trinaldo,Leandro Silva,Red,Lightweight
+09/13/2014,Sean Spencer,Paulo Thiago,Red,Welterweight
+09/13/2014,Rani Yahya,Johnny Bedford,Red,Bantamweight
+09/05/2014,Jacare Souza,Gegard Mousasi,Red,Middleweight
+09/05/2014,Ben Rothwell,Alistair Overeem,Red,Heavyweight
+09/05/2014,Matt Mitrione,Derrick Lewis,Red,Heavyweight
+09/05/2014,Joe Lauzon,Michael Chiesa,Red,Lightweight
+09/05/2014,John Moraga,Justin Scoggins,Red,Flyweight
+09/05/2014,Al Iaquinta,Rodrigo Damm,Red,Lightweight
+09/05/2014,Rafael Natal,Chris Camozzi,Red,Middleweight
+09/05/2014,Chris Beal,Tateki Matsuda,Red,Bantamweight
+09/05/2014,Chas Skelly,Sean Soriano,Red,Featherweight
+08/30/2014,TJ Dillashaw,Joe Soto,Red,UFC Bantamweight Title
+08/30/2014,Tony Ferguson,Danny Castillo,Red,Lightweight
+08/30/2014,Bethe Correia,Shayna Baszler,Red,Women's Bantamweight
+08/30/2014,Diego Ferreira,Ramsey Nijem,Red,Lightweight
+08/30/2014,Yancy Medeiros,Damon Jackson,Red,Lightweight
+08/30/2014,Derek Brunson,Lorenz Larkin,Red,Middleweight
+08/30/2014,Anthony Hamilton,Ruan Potts,Red,Heavyweight
+08/30/2014,Chris Wade,Cain Carrizosa,Red,Lightweight
+08/23/2014,Rafael Dos Anjos,Benson Henderson,Red,Lightweight
+08/23/2014,Jordan Mein,Mike Pyle,Red,Welterweight
+08/23/2014,Thales Leites,Francis Carmont,Red,Middleweight
+08/23/2014,Max Holloway,Clay Collard,Red,Catch Weight
+08/23/2014,James Vick,Valmir Lazaro,Red,Lightweight
+08/23/2014,Chas Skelly,Tom Niinimaki,Red,Featherweight
+08/23/2014,Neil Magny,Alex Garcia,Red,Welterweight
+08/23/2014,Beneil Dariush,Anthony Rocco Martin,Red,Lightweight
+08/23/2014,Matt Hobar,Aaron Phillips,Red,Bantamweight
+08/23/2014,Ben Saunders,Chris Heatherly,Red,Welterweight
+08/23/2014,Wilson Reis,Joby Sanchez,Red,Flyweight
+08/23/2014,Michael Bisping,Cung Le,Red,Middleweight
+08/23/2014,Tyron Woodley,Dong Hyun Kim,Red,Welterweight
+08/23/2014,Zhang Lipeng,Brendan O'Reilly,Red,Lightweight
+08/23/2014,Guangyou Ning,Jianping Yang,Red,Ultimate Fighter China Featherweight Tournament Title
+08/23/2014,Sai Wang,Danny Mitchell,Red,Welterweight
+08/23/2014,Alberto Mina,Shinsho Anzai,Red,Welterweight
+08/23/2014,Yuta Sasaki,Roland Delorme,Red,Bantamweight
+08/23/2014,Colby Covington,Anying Wang,Red,Welterweight
+08/23/2014,Royston Wee,Yao Zhikui,Red,Bantamweight
+08/23/2014,Milana Dudieva,Elizabeth Phillips,Red,Women's Bantamweight
+08/16/2014,Ryan Bader,Ovince Saint Preux,Red,Light Heavyweight
+08/16/2014,Ross Pearson,Gray Maynard,Red,Lightweight
+08/16/2014,Tim Boetsch,Brad Tavares,Red,Middleweight
+08/16/2014,Alan Jouban,Seth Baczynski,Red,Welterweight
+08/16/2014,Shawn Jordan,Jack May,Red,Heavyweight
+08/16/2014,Thiago Tavares,Robert Peralta,Red,Featherweight
+08/16/2014,Jussier Formiga,Zach Makovsky,Red,Flyweight
+08/16/2014,Sara McMann,Lauren Murphy,Red,Women's Bantamweight
+08/16/2014,Tom Watson,Sam Alvey,Red,Middleweight
+08/16/2014,Frankie Saenz,Nolan Ticman,Red,Bantamweight
+07/26/2014,Robbie Lawler,Matt Brown,Red,Welterweight
+07/26/2014,Anthony Johnson,Rogerio Nogueira,Red,Light Heavyweight
+07/26/2014,Dennis Bermudez,Clay Guida,Red,Featherweight
+07/26/2014,Bobby Green,Josh Thomson,Red,Lightweight
+07/26/2014,Jorge Masvidal,Daron Cruickshank,Red,Lightweight
+07/26/2014,Patrick Cummins,Kyle Kingsbury,Red,Light Heavyweight
+07/26/2014,Tim Means,Hernani Perpetuo,Red,Welterweight
+07/26/2014,Tiago dos Santos e Silva,Akbarh Arreola,Red,Lightweight
+07/26/2014,Gilbert Burns,Andreas Stahl,Red,Welterweight
+07/26/2014,Joanna Jedrzejczyk,Juliana Lima,Red,Women's Strawweight
+07/26/2014,Noad Lahat,Steven Siler,Red,Featherweight
+07/19/2014,Conor McGregor,Diego Brandao,Red,Featherweight
+07/19/2014,Gunnar Nelson,Zak Cummings,Red,Welterweight
+07/19/2014,Ian McCall,Brad Pickett,Red,Flyweight
+07/19/2014,Norman Parke,Naoyuki Kotani,Red,Lightweight
+07/19/2014,Ilir Latifi,Chris Dempsey,Red,Light Heavyweight
+07/19/2014,Neil Seery,Phil Harris,Red,Flyweight
+07/19/2014,Cathal Pendred,Mike King,Red,Middleweight
+07/19/2014,Trevor Smith,Tor Troeng,Red,Middleweight
+07/19/2014,Nikita Krylov,Cody Donovan,Red,Light Heavyweight
+07/19/2014,Paddy Holohan,Josh Sampo,Red,Flyweight
+07/16/2014,Donald Cerrone,Jim Miller,Red,Lightweight
+07/16/2014,Edson Barboza,Evan Dunham,Red,Lightweight
+07/16/2014,Rick Story,Leonardo Mafra,Red,Welterweight
+07/16/2014,Joe Proctor,Justin Salas,Red,Lightweight
+07/16/2014,John Lineker,Alptekin Ozkilic,Red,Flyweight
+07/16/2014,Lucas Martins,Alex White,Red,Featherweight
+07/16/2014,Gleison Tibau,Pat Healy,Red,Lightweight
+07/16/2014,Leslie Smith,Jessamyn Duke,Red,Women's Bantamweight
+07/16/2014,Aljamain Sterling,Hugo Viana,Red,Bantamweight
+07/16/2014,Yosdenis Cedeno,Jerrod Sanders,Red,Lightweight
+07/16/2014,Claudia Gadelha,Tina Lahdemaki,Red,Women's Strawweight
+07/06/2014,Frankie Edgar,BJ Penn,Red,Featherweight
+07/06/2014,Corey Anderson,Matt Van Buren,Red,Ultimate Fighter 19 Light Heavyweight Tournament Title
+07/06/2014,Eddie Gordon,Dhiego Lima,Red,Ultimate Fighter 19 Middleweight Tournament Title
+07/06/2014,Derrick Lewis,Guto Inocente,Red,Heavyweight
+07/06/2014,Dustin Ortiz,Justin Scoggins,Red,Flyweight
+07/06/2014,Kevin Lee,Jesse Ronson,Red,Lightweight
+07/06/2014,Leandro Issa,Jumabieke Tuerxun,Red,Bantamweight
+07/06/2014,Adriano Martins,Juan Manuel Puig,Red,Lightweight
+07/06/2014,Patrick Walsh,Daniel Spohn,Red,Light Heavyweight
+07/06/2014,Sarah Moras,Alexis Dufresne,Red,Catch Weight
+07/05/2014,Chris Weidman,Lyoto Machida,Red,UFC Middleweight Title
+07/05/2014,Ronda Rousey,Alexis Davis,Red,UFC Women's Bantamweight Title
+07/05/2014,Uriah Hall,Thiago Santos,Red,Middleweight
+07/05/2014,Russell Doane,Marcus Brimage,Red,Bantamweight
+07/05/2014,Urijah Faber,Alex Caceres,Red,Bantamweight
+07/05/2014,Kenny Robertson,Ildemar Alcantara,Red,Welterweight
+07/05/2014,Bruno Santos,Chris Camozzi,Red,Middleweight
+07/05/2014,Rob Font,George Roop,Red,Bantamweight
+07/05/2014,Luke Zachrich,Guilherme Vasconcelos,Red,Middleweight
+06/28/2014,Cub Swanson,Jeremy Stephens,Red,Featherweight
+06/28/2014,Kelvin Gastelum,Nicholas Musoke,Red,Welterweight
+06/28/2014,Cezar Ferreira,Andrew Craig,Red,Middleweight
+06/28/2014,Ricardo Lamas,Hacran Dias,Red,Featherweight
+06/28/2014,Clint Hester,Antonio Braga Neto,Red,Middleweight
+06/28/2014,Joe Ellenberger,James Moontasri,Red,Lightweight
+06/28/2014,Diego Ferreira,Colton Smith,Red,Lightweight
+06/28/2014,Cody Gibson,Johnny Bedford,Red,Bantamweight
+06/28/2014,Marcelo Guimaraes,Andy Enz,Red,Middleweight
+06/28/2014,Ray Borg,Shane Howell,Red,Flyweight
+06/28/2014,Aleksei Oleinik,Anthony Hamilton,Red,Heavyweight
+06/28/2014,Nate Marquardt,James Te Huna,Red,Middleweight
+06/28/2014,Jared Rosholt,Soa Palelei,Red,Heavyweight
+06/28/2014,Charles Oliveira,Hatsu Hioki,Red,Featherweight
+06/28/2014,Robert Whittaker,Mike Rhodes,Red,Welterweight
+06/28/2014,Jake Matthews,Dashon Johnson,Red,Lightweight
+06/28/2014,Richie Vaculik,Roldan Sangcha'an,Red,Flyweight
+06/28/2014,Vik Grujic,Chris Indich,Red,Welterweight
+06/28/2014,Neil Magny,Rodrigo de Lima,Red,Welterweight
+06/28/2014,Dan Hooker,Ian Entwistle,Red,Featherweight
+06/28/2014,Gian Villante,Sean O'Connell,Red,Light Heavyweight
+06/14/2014,Demetrious Johnson,Ali Bagautinov,Red,UFC Flyweight Title
+06/14/2014,Rory MacDonald,Tyron Woodley,Red,Welterweight
+06/14/2014,Ryan Bader,Rafael Cavalcante,Red,Light Heavyweight
+06/14/2014,Andrei Arlovski,Brendan Schaub,Red,Heavyweight
+06/14/2014,Ovince Saint Preux,Ryan Jimmo,Red,Light Heavyweight
+06/14/2014,Kiichi Kunimoto,Daniel Sarafian,Red,Welterweight
+06/14/2014,Valerie Letourneau,Elizabeth Phillips,Red,Women's Bantamweight
+06/14/2014,Yves Jabouin,Mike Easton,Red,Bantamweight
+06/14/2014,Tae Hyun Bang,Kajan Johnson,Red,Lightweight
+06/14/2014,Michinori Tanaka,Roland Delorme,Red,Bantamweight
+06/14/2014,Jason Saggo,Josh Shockley,Red,Lightweight
+06/07/2014,Benson Henderson,Rustam Khabilov,Red,Lightweight
+06/07/2014,Diego Sanchez,Ross Pearson,Red,Lightweight
+06/07/2014,John Dodson,John Moraga,Red,Flyweight
+06/07/2014,Rafael Dos Anjos,Jason High,Red,Lightweight
+06/07/2014,Piotr Hallmann,Yves Edwards,Red,Lightweight
+06/07/2014,Bryan Caraway,Erik Perez,Red,Bantamweight
+06/07/2014,Sergio Pettis,Yaotzin Meza,Red,Bantamweight
+06/07/2014,Lance Benoist,Bobby Voelker,Red,Welterweight
+06/07/2014,Scott Jorgensen,Danny Martinez,Red,Flyweight
+06/07/2014,Jon Tuck,Jake Lindsey,Red,Lightweight
+06/07/2014,Patrick Cummins,Roger Narvaez,Red,Light Heavyweight
+05/31/2014,Stipe Miocic,Fabio Maldonado,Red,Heavyweight
+05/31/2014,Antonio Carlos Junior,Vitor Miranda,Red,Ultimate Fighter Brazil 3 Heavyweight Tournament Title
+05/31/2014,Warlley Alves,Marcio Alexandre Junior,Red,Ultimate Fighter Brazil 3 Middleweight Tournament Title
+05/31/2014,Demian Maia,Alexander Yakovlev,Red,Welterweight
+05/31/2014,Robert Peralta,Rony Jason,Red,Featherweight
+05/31/2014,Rashid Magomedov,Rodrigo Damm,Red,Lightweight
+05/31/2014,Elias Silverio,Ernest Chavez,Red,Lightweight
+05/31/2014,Gasan Umalatov,Paulo Thiago,Red,Welterweight
+05/31/2014,Edimilson Souza,Mark Eddiva,Red,Featherweight
+05/31/2014,Ricardo Abreu,Wagner Silva,Red,Middleweight
+05/31/2014,Marcos Rogerio de Lima,Richardson Moreira,Red,Heavyweight
+05/31/2014,Pedro Munhoz,Matt Hobar,Red,Bantamweight
+05/31/2014,Gegard Mousasi,Mark Munoz,Red,Middleweight
+05/31/2014,CB Dollaway,Francis Carmont,Red,Middleweight
+05/31/2014,Sean Strickland,Luke Barnatt,Red,Middleweight
+05/31/2014,Niklas Backstrom,Tom Niinimaki,Red,Featherweight
+05/31/2014,Nick Hein,Drew Dober,Red,Lightweight
+05/31/2014,Magnus Cedenblad,Krzysztof Jotko,Red,Middleweight
+05/31/2014,Iuri Alcantara,Vaughan Lee,Red,Bantamweight
+05/31/2014,Peter Sobotta,Pawel Pawlak,Red,Welterweight
+05/31/2014,Maximo Blanco,Andy Ogle,Red,Featherweight
+05/31/2014,Ruslan Magomedov,Viktor Pesta,Red,Heavyweight
+05/24/2014,TJ Dillashaw,Renan Barao,Red,UFC Bantamweight Title
+05/24/2014,Daniel Cormier,Dan Henderson,Red,Light Heavyweight
+05/24/2014,Robbie Lawler,Jake Ellenberger,Red,Welterweight
+05/24/2014,Takeya Mizugaki,Francisco Rivera,Red,Bantamweight
+05/24/2014,James Krause,Jamie Varner,Red,Lightweight
+05/24/2014,Michael Chiesa,Francisco Trinaldo,Red,Lightweight
+05/24/2014,Tony Ferguson,Katsunori Kikuno,Red,Lightweight
+05/24/2014,Chris Holdsworth,Chico Camus,Red,Bantamweight
+05/24/2014,Mitch Clarke,Al Iaquinta,Red,Lightweight
+05/24/2014,Vinc Pichel,Anthony Njokuani,Red,Lightweight
+05/24/2014,Sam Sicilia,Aaron Phillips,Red,Featherweight
+05/24/2014,Li Jingliang,David Michaud,Red,Welterweight
+05/10/2014,Matt Brown,Erick Silva,Red,Welterweight
+05/10/2014,Constantinos Philippou,Lorenz Larkin,Red,Middleweight
+05/10/2014,Daron Cruickshank,Erik Koch,Red,Lightweight
+05/10/2014,Neil Magny,Tim Means,Red,Welterweight
+05/10/2014,Soa Palelei,Ruan Potts,Red,Heavyweight
+05/10/2014,Chris Cariaso,Louis Smolka,Red,Flyweight
+05/10/2014,Ed Herman,Rafael Natal,Red,Middleweight
+05/10/2014,Kyoji Horiguchi,Darrell Montague,Red,Flyweight
+05/10/2014,Zak Cummings,Yan Cabral,Red,Welterweight
+05/10/2014,Johnny Eduardo,Eddie Wineland,Red,Bantamweight
+05/10/2014,Nik Lentz,Manvel Gamburyan,Red,Featherweight
+05/10/2014,Justin Salas,Ben Wall,Red,Lightweight
+05/10/2014,Albert Tumenov,Anthony Lapsley,Red,Welterweight
+04/26/2014,Jon Jones,Glover Teixeira,Red,UFC Light Heavyweight Title
+04/26/2014,Anthony Johnson,Phil Davis,Red,Light Heavyweight
+04/26/2014,Luke Rockhold,Tim Boetsch,Red,Middleweight
+04/26/2014,Jim Miller,Yancy Medeiros,Red,Lightweight
+04/26/2014,Max Holloway,Andre Fili,Red,Featherweight
+04/26/2014,Joseph Benavidez,Tim Elliott,Red,Flyweight
+04/26/2014,Takanori Gomi,Isaac Vallie-Flagg,Red,Lightweight
+04/26/2014,Bethe Correia,Jessamyn Duke,Red,Women's Bantamweight
+04/26/2014,Danny Castillo,Charlie Brenneman,Red,Lightweight
+04/26/2014,Chris Beal,Patrick Williams,Red,Bantamweight
+04/19/2014,Fabricio Werdum,Travis Browne,Red,Heavyweight
+04/19/2014,Miesha Tate,Liz Carmouche,Red,Women's Bantamweight
+04/19/2014,Donald Cerrone,Edson Barboza,Red,Lightweight
+04/19/2014,Yoel Romero,Brad Tavares,Red,Middleweight
+04/19/2014,Khabib Nurmagomedov,Rafael Dos Anjos,Red,Lightweight
+04/19/2014,Thiago Alves,Seth Baczynski,Red,Welterweight
+04/19/2014,Jorge Masvidal,Pat Healy,Red,Lightweight
+04/19/2014,Alex White,Estevan Payan,Red,Featherweight
+04/19/2014,Caio Magalhaes,Luke Zachrich,Red,Middleweight
+04/19/2014,Jordan Mein,Hernani Perpetuo,Red,Welterweight
+04/19/2014,Dustin Ortiz,Ray Borg,Red,Flyweight
+04/19/2014,Mirsad Bektic,Chas Skelly,Red,Featherweight
+04/19/2014,Derrick Lewis,Jack May,Red,Heavyweight
+04/16/2014,Tim Kennedy,Michael Bisping,Red,Middleweight
+04/16/2014,Patrick Cote,Kyle Noke,Red,Welterweight
+04/16/2014,Elias Theodorou,Sheldon Westcott,Red,TUF Nations Canada vs. Australia Middleweight Tournament Title
+04/16/2014,Chad Laprise,Olivier Aubin-Mercier,Red,TUF Nations Canada vs. Australia Welterweight Tournament Title
+04/16/2014,Dustin Poirier,Akira Corassani,Red,Featherweight
+04/16/2014,KJ Noons,Sam Stout,Red,Welterweight
+04/16/2014,Sarah Kaufman,Leslie Smith,Red,Women's Bantamweight
+04/16/2014,Ryan Jimmo,Sean O'Connell,Red,Light Heavyweight
+04/16/2014,George Roop,Dustin Kimura,Red,Bantamweight
+04/16/2014,Mark Bocek,Mike de la Torre,Red,Lightweight
+04/16/2014,Nordine Taleb,Vik Grujic,Red,Middleweight
+04/16/2014,Richard Walsh,Chris Indich,Red,Welterweight
+04/16/2014,Mitch Gagnon,Tim Gorman,Red,Bantamweight
+04/11/2014,Roy Nelson,Antonio Rodrigo Nogueira,Red,Heavyweight
+04/11/2014,Clay Guida,Tatsuya Kawajiri,Red,Featherweight
+04/11/2014,Ryan LaFlare,John Howard,Red,Welterweight
+04/11/2014,Ramsey Nijem,Beneil Dariush,Red,Lightweight
+04/11/2014,Jared Rosholt,Daniel Omielanczuk,Red,Heavyweight
+04/11/2014,Thales Leites,Trevor Smith,Red,Middleweight
+04/11/2014,Jim Alers,Alan Omer,Red,Featherweight
+03/23/2014,Dan Henderson,Mauricio Rua,Red,Light Heavyweight
+03/23/2014,CB Dollaway,Cezar Ferreira,Red,Middleweight
+03/23/2014,Fabio Maldonado,Gian Villante,Red,Light Heavyweight
+03/23/2014,Michel Prazeres,Mairbek Taisumov,Red,Lightweight
+03/23/2014,Rony Jason,Steven Siler,Red,Featherweight
+03/23/2014,Thiago Santos,Ronny Markes,Red,Middleweight
+03/23/2014,Jussier Formiga,Scott Jorgensen,Red,Flyweight
+03/23/2014,Kenny Robertson,Thiago Perpetuo,Red,Welterweight
+03/23/2014,Hans Stringer,Francimar Barroso,Red,Light Heavyweight
+03/23/2014,Godofredo Pepey,Noad Lahat,Red,Featherweight
+03/15/2014,Johny Hendricks,Robbie Lawler,Red,UFC Welterweight Title
+03/15/2014,Tyron Woodley,Carlos Condit,Red,Welterweight
+03/15/2014,Myles Jury,Diego Sanchez,Red,Lightweight
+03/15/2014,Hector Lombard,Jake Shields,Red,Welterweight
+03/15/2014,Ovince Saint Preux,Nikita Krylov,Red,Light Heavyweight
+03/15/2014,Kelvin Gastelum,Rick Story,Red,Welterweight
+03/15/2014,Jessica Andrade,Raquel Pennington,Red,Women's Bantamweight
+03/15/2014,Dennis Bermudez,Jimy Hettes,Red,Featherweight
+03/15/2014,Alex Garcia,Sean Spencer,Red,Welterweight
+03/15/2014,Francisco Trevino,Renee Forte,Red,Lightweight
+03/15/2014,Justin Scoggins,Will Campuzano,Red,Flyweight
+03/15/2014,Sean Strickland,Robert McDaniel,Red,Middleweight
+03/15/2014,Robert Whiteford,Daniel Pineda,Red,Featherweight
+03/08/2014,Alexander Gustafsson,Jimi Manuwa,Red,Light Heavyweight
+03/08/2014,Michael Johnson,Melvin Guillard,Red,Lightweight
+03/08/2014,Brad Pickett,Neil Seery,Red,Flyweight
+03/08/2014,Gunnar Nelson,Omari Akhmedov,Red,Welterweight
+03/08/2014,Ilir Latifi,Cyrille Diabate,Red,Light Heavyweight
+03/08/2014,Luke Barnatt,Mats Nilsson,Red,Middleweight
+03/08/2014,Claudio Silva,Brad Scott,Red,Middleweight
+03/08/2014,Igor Araujo,Danny Mitchell,Red,Welterweight
+03/01/2014,Dong Hyun Kim,John Hathaway,Red,Welterweight
+03/01/2014,Zhang Lipeng,Sai Wang,Red,Ultimate Fighter China Welterweight Tournament Title
+03/01/2014,Matt Mitrione,Shawn Jordan,Red,Heavyweight
+03/01/2014,Hatsu Hioki,Ivan Menjivar,Red,Featherweight
+03/01/2014,Yui Chul Nam,Kazuki Tokudome,Red,Lightweight
+03/01/2014,Vaughan Lee,Nam Phan,Red,Bantamweight
+03/01/2014,Anying Wang,Albert Cheng,Red,Welterweight
+03/01/2014,Mark Eddiva,Jumabieke Tuerxun,Red,Featherweight
+02/22/2014,Ronda Rousey,Sara McMann,Red,UFC Women's Bantamweight Title
+02/22/2014,Daniel Cormier,Patrick Cummins,Red,Light Heavyweight
+02/22/2014,Rory MacDonald,Demian Maia,Red,Welterweight
+02/22/2014,Mike Pyle,TJ Waldburger,Red,Welterweight
+02/22/2014,Stephen Thompson,Robert Whittaker,Red,Welterweight
+02/22/2014,Alexis Davis,Jessica Eye,Red,Women's Bantamweight
+02/22/2014,Raphael Assuncao,Pedro Munhoz,Red,Bantamweight
+02/22/2014,Aljamain Sterling,Cody Gibson,Red,Bantamweight
+02/22/2014,Zach Makovsky,Josh Sampo,Red,Flyweight
+02/22/2014,Erik Koch,Rafaello Oliveira,Red,Lightweight
+02/22/2014,Ernest Chavez,Yosdenis Cedeno,Red,Lightweight
+02/15/2014,Lyoto Machida,Gegard Mousasi,Red,Middleweight
+02/15/2014,Jacare Souza,Francis Carmont,Red,Middleweight
+02/15/2014,Erick Silva,Takenori Sato,Red,Welterweight
+02/15/2014,Nicholas Musoke,Viscardi Andrade,Red,Welterweight
+02/15/2014,Charles Oliveira,Andy Ogle,Red,Featherweight
+02/15/2014,Joe Proctor,Cristiano Marcello,Red,Lightweight
+02/15/2014,Rodrigo Damm,Ivan Jorge,Red,Lightweight
+02/15/2014,Francisco Trinaldo,Jesse Ronson,Red,Lightweight
+02/15/2014,Iuri Alcantara,Wilson Reis,Red,Bantamweight
+02/15/2014,Felipe Arantes,Maximo Blanco,Red,Featherweight
+02/15/2014,Ildemar Alcantara,Albert Tumenov,Red,Welterweight
+02/15/2014,Zubaira Tukhugov,Douglas Silva de Andrade,Red,Featherweight
+02/01/2014,Renan Barao,Urijah Faber,Red,UFC Bantamweight Title
+02/01/2014,Jose Aldo,Ricardo Lamas,Red,UFC Featherweight Title
+02/01/2014,Alistair Overeem,Frank Mir,Red,Heavyweight
+02/01/2014,Ali Bagautinov,John Lineker,Red,Flyweight
+02/01/2014,Abel Trujillo,Jamie Varner,Red,Lightweight
+02/01/2014,Alan Patrick,John Makdessi,Red,Lightweight
+02/01/2014,Chris Cariaso,Danny Martinez,Red,Flyweight
+02/01/2014,Nick Catone,Tom Watson,Red,Middleweight
+02/01/2014,Al Iaquinta,Kevin Lee,Red,Lightweight
+02/01/2014,Clint Hester,Andy Enz,Red,Middleweight
+02/01/2014,Rashid Magomedov,Anthony Rocco Martin,Red,Lightweight
+02/01/2014,Neil Magny,Gasan Umalatov,Red,Welterweight
+01/25/2014,Benson Henderson,Josh Thomson,Red,Lightweight
+01/25/2014,Stipe Miocic,Gabriel Gonzaga,Red,Heavyweight
+01/25/2014,Donald Cerrone,Adriano Martins,Red,Lightweight
+01/25/2014,Jeremy Stephens,Darren Elkins,Red,Featherweight
+01/25/2014,Alex Caceres,Sergio Pettis,Red,Bantamweight
+01/25/2014,Eddie Wineland,Yves Jabouin,Red,Bantamweight
+01/25/2014,Hugo Viana,Ramiro Hernandez,Red,Bantamweight
+01/25/2014,Daron Cruickshank,Mike Rio,Red,Lightweight
+01/25/2014,George Sullivan,Mike Rhodes,Red,Welterweight
+01/25/2014,Nikita Krylov,Walt Harris,Red,Heavyweight
+01/15/2014,Luke Rockhold,Constantinos Philippou,Red,Middleweight
+01/15/2014,Brad Tavares,Lorenz Larkin,Red,Middleweight
+01/15/2014,TJ Dillashaw,Mike Easton,Red,Bantamweight
+01/15/2014,Yoel Romero,Derek Brunson,Red,Middleweight
+01/15/2014,John Moraga,Dustin Ortiz,Red,Flyweight
+01/15/2014,Cole Miller,Sam Sicilia,Red,Featherweight
+01/15/2014,Ramsey Nijem,Justin Edwards,Red,Lightweight
+01/15/2014,Elias Silverio,Isaac Vallie-Flagg,Red,Lightweight
+01/15/2014,Trevor Smith,Brian Houston,Red,Middleweight
+01/15/2014,Louis Smolka,Alptekin Ozkilic,Red,Flyweight
+01/15/2014,Vinc Pichel,Garett Whiteley,Red,Lightweight
+01/15/2014,Beneil Dariush,Charlie Brenneman,Red,Lightweight
+01/04/2014,Tarec Saffiedine,Hyun Gyu Lim,Red,Welterweight
+01/04/2014,Tatsuya Kawajiri,Sean Soriano,Red,Featherweight
+01/04/2014,Kiichi Kunimoto,Luiz Dutra,Red,Welterweight
+01/04/2014,Kyung Ho Kang,Shunichi Shimizu,Red,Bantamweight
+01/04/2014,Max Holloway,Will Chope,Red,Featherweight
+01/04/2014,Katsunori Kikuno,Quinn Mulhern,Red,Lightweight
+01/04/2014,Royston Wee,Dave Galera,Red,Bantamweight
+01/04/2014,Mairbek Taisumov,Tae Hyun Bang,Red,Lightweight
+01/04/2014,Dustin Kimura,Jon Delos Reyes,Red,Bantamweight
+01/04/2014,Russell Doane,Leandro Issa,Red,Bantamweight
+12/28/2013,Chris Weidman,Anderson Silva,Red,UFC Middleweight Title
+12/28/2013,Ronda Rousey,Miesha Tate,Red,UFC Women's Bantamweight Title
+12/28/2013,Travis Browne,Josh Barnett,Red,Heavyweight
+12/28/2013,Jim Miller,Fabricio Camoes,Red,Lightweight
+12/28/2013,Dustin Poirier,Diego Brandao,Red,Featherweight
+12/28/2013,Uriah Hall,Chris Leben,Red,Middleweight
+12/28/2013,Michael Johnson,Gleison Tibau,Red,Lightweight
+12/28/2013,John Howard,Siyar Bahadurzada,Red,Welterweight
+12/28/2013,William Macario,Bobby Voelker,Red,Welterweight
+12/28/2013,Robert Peralta,Estevan Payan,Red,Featherweight
+12/14/2013,Demetrious Johnson,Joseph Benavidez,Red,UFC Flyweight Title
+12/14/2013,Urijah Faber,Michael McDonald,Red,Bantamweight
+12/14/2013,Chad Mendes,Nik Lentz,Red,Featherweight
+12/14/2013,Joe Lauzon,Mac Danzig,Red,Lightweight
+12/14/2013,Ryan LaFlare,Court McGee,Red,Welterweight
+12/14/2013,Edson Barboza,Danny Castillo,Red,Lightweight
+12/14/2013,Bobby Green,Pat Healy,Red,Lightweight
+12/14/2013,Zach Makovsky,Scott Jorgensen,Red,Flyweight
+12/14/2013,Sam Stout,Cody McKenzie,Red,Lightweight
+12/14/2013,Abel Trujillo,Roger Bowling,Red,Lightweight
+12/14/2013,Alptekin Ozkilic,Darren Uyenoyama,Red,Flyweight
+12/06/2013,Mauricio Rua,James Te Huna,Red,Light Heavyweight
+12/06/2013,Ryan Bader,Anthony Perosh,Red,Light Heavyweight
+12/06/2013,Soa Palelei,Pat Barry,Red,Heavyweight
+12/06/2013,Clint Hester,Dylan Andrews,Red,Middleweight
+12/06/2013,Bethe Correia,Julie Kedzie,Red,Women's Bantamweight
+12/06/2013,Takeya Mizugaki,Nam Phan,Red,Bantamweight
+12/06/2013,Caio Magalhaes,Nick Ring,Red,Middleweight
+12/06/2013,Justin Scoggins,Richie Vaculik,Red,Flyweight
+12/06/2013,Krzysztof Jotko,Bruno Santos,Red,Middleweight
+12/06/2013,Alex Garcia,Ben Wall,Red,Welterweight
+11/30/2013,Nate Diaz,Gray Maynard,Red,Lightweight
+11/30/2013,Julianna Pena,Jessica Rakoczy,Red,Ultimate Fighter 18 Women's Bantamweight Tournament Title
+11/30/2013,Chris Holdsworth,Davey Grant,Red,Ultimate Fighter 18 Bantamweight Tournament Title
+11/30/2013,Jessamyn Duke,Peggy Morgan,Red,Women's Bantamweight
+11/30/2013,Raquel Pennington,Roxanne Modafferi,Red,Women's Bantamweight
+11/30/2013,Akira Corassani,Maximo Blanco,Red,Featherweight
+11/30/2013,Tom Niinimaki,Rani Yahya,Red,Featherweight
+11/30/2013,Jared Rosholt,Walt Harris,Red,Heavyweight
+11/30/2013,Sean Spencer,Drew Dober,Red,Welterweight
+11/30/2013,Josh Sampo,Ryan Benoit,Red,Flyweight
+11/16/2013,Georges St-Pierre,Johny Hendricks,Red,UFC Welterweight Title
+11/16/2013,Rashad Evans,Chael Sonnen,Red,Light Heavyweight
+11/16/2013,Robbie Lawler,Rory MacDonald,Red,Welterweight
+11/16/2013,Tyron Woodley,Josh Koscheck,Red,Welterweight
+11/16/2013,Ali Bagautinov,Tim Elliott,Red,Flyweight
+11/16/2013,Donald Cerrone,Evan Dunham,Red,Lightweight
+11/16/2013,Thales Leites,Ed Herman,Red,Middleweight
+11/16/2013,Rick Story,Brian Ebersole,Red,Welterweight
+11/16/2013,Erik Perez,Edwin Figueroa,Red,Bantamweight
+11/16/2013,Jason High,Anthony Lapsley,Red,Welterweight
+11/16/2013,Sergio Pettis,Will Campuzano,Red,Bantamweight
+11/16/2013,Gian Villante,Cody Donovan,Red,Light Heavyweight
+11/09/2013,Vitor Belfort,Dan Henderson,Red,Light Heavyweight
+11/09/2013,Cezar Ferreira,Daniel Sarafian,Red,Middleweight
+11/09/2013,Rafael Cavalcante,Igor Pokrajac,Red,Light Heavyweight
+11/09/2013,Brandon Thatch,Paulo Thiago,Red,Welterweight
+11/09/2013,Ryan LaFlare,Santiago Ponzinibbio,Red,Welterweight
+11/09/2013,Jeremy Stephens,Rony Jason,Red,Featherweight
+11/09/2013,Sam Sicilia,Godofredo Pepey,Red,Featherweight
+11/09/2013,Omari Akhmedov,Thiago Perpetuo,Red,Middleweight
+11/09/2013,Thiago Tavares,Justin Salas,Red,Lightweight
+11/09/2013,Adriano Martins,Daron Cruickshank,Red,Lightweight
+11/09/2013,Dustin Ortiz,Jose Maria,Red,Flyweight
+11/06/2013,Tim Kennedy,Rafael Natal,Red,Middleweight
+11/06/2013,Alexis Davis,Liz Carmouche,Red,Women's Bantamweight
+11/06/2013,Yoel Romero,Ronny Markes,Red,Middleweight
+11/06/2013,Rustam Khabilov,Jorge Masvidal,Red,Lightweight
+11/06/2013,Michael Chiesa,Colton Smith,Red,Lightweight
+11/06/2013,Bobby Green,James Krause,Red,Lightweight
+11/06/2013,Francisco Rivera,George Roop,Red,Bantamweight
+11/06/2013,Dennis Bermudez,Steven Siler,Red,Featherweight
+11/06/2013,Amanda Nunes,Germaine de Randamie,Red,Women's Bantamweight
+11/06/2013,Lorenz Larkin,Chris Camozzi,Red,Middleweight
+11/06/2013,Seth Baczynski,Neil Magny,Red,Welterweight
+11/06/2013,Derek Brunson,Brian Houston,Red,Middleweight
+10/26/2013,Lyoto Machida,Mark Munoz,Red,Middleweight
+10/26/2013,Jimi Manuwa,Ryan Jimmo,Red,Light Heavyweight
+10/26/2013,Norman Parke,Jon Tuck,Red,Lightweight
+10/26/2013,Nicholas Musoke,Alessio Sakara,Red,Middleweight
+10/26/2013,John Lineker,Phil Harris,Red,Flyweight
+10/26/2013,Al Iaquinta,Piotr Hallmann,Red,Lightweight
+10/26/2013,Luke Barnatt,Andrew Craig,Red,Middleweight
+10/26/2013,Jessica Andrade,Rosi Sexton,Red,Women's Bantamweight
+10/26/2013,Cole Miller,Andy Ogle,Red,Featherweight
+10/26/2013,Jimy Hettes,Robert Whiteford,Red,Featherweight
+10/26/2013,Brad Scott,Michael Kuiper,Red,Middleweight
+10/19/2013,Cain Velasquez,Junior Dos Santos,Red,UFC Heavyweight Title
+10/19/2013,Daniel Cormier,Roy Nelson,Red,Heavyweight
+10/19/2013,Gilbert Melendez,Diego Sanchez,Red,Lightweight
+10/19/2013,Gabriel Gonzaga,Shawn Jordan,Red,Heavyweight
+10/19/2013,John Dodson,Darrell Montague,Red,Flyweight
+10/19/2013,Tim Boetsch,CB Dollaway,Red,Middleweight
+10/19/2013,Hector Lombard,Nate Marquardt,Red,Welterweight
+10/19/2013,KJ Noons,George Sotiropoulos,Red,Lightweight
+10/19/2013,Adlan Amagov,TJ Waldburger,Red,Welterweight
+10/19/2013,Tony Ferguson,Mike Rio,Red,Lightweight
+10/19/2013,Andre Fili,Jeremy Larsen,Red,Featherweight
+10/19/2013,Kyoji Horiguchi,Dustin Pague,Red,Bantamweight
+10/09/2013,Jake Shields,Demian Maia,Red,Welterweight
+10/09/2013,Dong Hyun Kim,Erick Silva,Red,Welterweight
+10/09/2013,Thiago Silva,Matt Hamill,Red,Light Heavyweight
+10/09/2013,Fabio Maldonado,Joey Beltran,Red,Light Heavyweight
+10/09/2013,Rousimar Palhares,Mike Pierce,Red,Welterweight
+10/09/2013,Raphael Assuncao,TJ Dillashaw,Red,Bantamweight
+10/09/2013,Igor Araujo,Ildemar Alcantara,Red,Welterweight
+10/09/2013,Yan Cabral,David Mitchell,Red,Welterweight
+10/09/2013,Chris Cariaso,Iliarde Santos,Red,Flyweight
+10/09/2013,Alan Patrick,Garett Whiteley,Red,Lightweight
+09/21/2013,Jon Jones,Alexander Gustafsson,Red,UFC Light Heavyweight Title
+09/21/2013,Renan Barao,Eddie Wineland,Red,UFC Interim Bantamweight Title
+09/21/2013,Brendan Schaub,Matt Mitrione,Red,Heavyweight
+09/21/2013,Francis Carmont,Constantinos Philippou,Red,Middleweight
+09/21/2013,Khabib Nurmagomedov,Pat Healy,Red,Lightweight
+09/21/2013,Myles Jury,Mike Ricci,Red,Lightweight
+09/21/2013,Wilson Reis,Ivan Menjivar,Red,Bantamweight
+09/21/2013,Stephen Thompson,Chris Clements,Red,Welterweight
+09/21/2013,Mitch Gagnon,Dustin Kimura,Red,Bantamweight
+09/21/2013,John Makdessi,Renee Forte,Red,Lightweight
+09/21/2013,Michel Prazeres,Jesse Ronson,Red,Lightweight
+09/21/2013,Alex Caceres,Roland Delorme,Red,Bantamweight
+09/21/2013,Daniel Omielanczuk,Nandor Guelmino,Red,Heavyweight
+09/04/2013,Glover Teixeira,Ryan Bader,Red,Light Heavyweight
+09/04/2013,Jacare Souza,Yushin Okami,Red,Middleweight
+09/04/2013,Joseph Benavidez,Jussier Formiga,Red,Flyweight
+09/04/2013,Piotr Hallmann,Francisco Trinaldo,Red,Lightweight
+09/04/2013,Rafael Natal,Tor Troeng,Red,Middleweight
+09/04/2013,Ali Bagautinov,Marcos Vinicius,Red,Flyweight
+09/04/2013,Edimilson Souza,Felipe Arantes,Red,Featherweight
+09/04/2013,Lucas Martins,Ramiro Hernandez,Red,Bantamweight
+09/04/2013,Elias Silverio,Joao Zeferino,Red,Welterweight
+09/04/2013,Ivan Jorge,Keith Wisniewski,Red,Welterweight
+09/04/2013,Sean Spencer,Yuri Villefort,Red,Welterweight
+08/31/2013,Anthony Pettis,Benson Henderson,Red,UFC Lightweight Title
+08/31/2013,Josh Barnett,Frank Mir,Red,Heavyweight
+08/31/2013,Chad Mendes,Clay Guida,Red,Featherweight
+08/31/2013,Ben Rothwell,Brandon Vera,Red,Heavyweight
+08/31/2013,Dustin Poirier,Erik Koch,Red,Featherweight
+08/31/2013,Gleison Tibau,Jamie Varner,Red,Lightweight
+08/31/2013,Tim Elliott,Louis Gaudinot,Red,Flyweight
+08/31/2013,Hyun Gyu Lim,Pascal Krauss,Red,Welterweight
+08/31/2013,Chico Camus,Kyung Ho Kang,Red,Bantamweight
+08/31/2013,Soa Palelei,Nikita Krylov,Red,Heavyweight
+08/31/2013,Al Iaquinta,Ryan Couture,Red,Lightweight
+08/31/2013,Magnus Cedenblad,Jared Hamman,Red,Middleweight
+08/28/2013,Carlos Condit,Martin Kampmann,Red,Welterweight
+08/28/2013,Rafael Dos Anjos,Donald Cerrone,Red,Lightweight
+08/28/2013,Kelvin Gastelum,Brian Melancon,Red,Welterweight
+08/28/2013,Court McGee,Robert Whittaker,Red,Welterweight
+08/28/2013,Takeya Mizugaki,Erik Perez,Red,Bantamweight
+08/28/2013,Brad Tavares,Robert McDaniel,Red,Middleweight
+08/28/2013,Dylan Andrews,Papy Abedi,Red,Middleweight
+08/28/2013,Brandon Thatch,Justin Edwards,Red,Welterweight
+08/28/2013,Darren Elkins,Hatsu Hioki,Red,Featherweight
+08/28/2013,Jason High,James Head,Red,Welterweight
+08/28/2013,Zak Cummings,Ben Alloway,Red,Welterweight
+08/17/2013,Chael Sonnen,Mauricio Rua,Red,Light Heavyweight
+08/17/2013,Travis Browne,Alistair Overeem,Red,Heavyweight
+08/17/2013,Urijah Faber,Iuri Alcantara,Red,Bantamweight
+08/17/2013,Matt Brown,Mike Pyle,Red,Welterweight
+08/17/2013,John Howard,Uriah Hall,Red,Middleweight
+08/17/2013,Michael Johnson,Joe Lauzon,Red,Lightweight
+08/17/2013,Michael McDonald,Brad Pickett,Red,Bantamweight
+08/17/2013,Conor McGregor,Max Holloway,Red,Featherweight
+08/17/2013,Steven Siler,Mike Brown,Red,Featherweight
+08/17/2013,Diego Brandao,Daniel Pineda,Red,Featherweight
+08/17/2013,Manvel Gamburyan,Cole Miller,Red,Featherweight
+08/17/2013,Ovince Saint Preux,Cody Donovan,Red,Light Heavyweight
+08/17/2013,James Vick,Ramsey Nijem,Red,Lightweight
+08/03/2013,Jose Aldo,Chan Sung Jung,Red,UFC Featherweight Title
+08/03/2013,Phil Davis,Lyoto Machida,Red,Light Heavyweight
+08/03/2013,Cezar Ferreira,Thiago Santos,Red,Middleweight
+08/03/2013,Thales Leites,Tom Watson,Red,Middleweight
+08/03/2013,John Lineker,Jose Maria,Red,Flyweight
+08/03/2013,Anthony Perosh,Vinny Magalhaes,Red,Light Heavyweight
+08/03/2013,Amanda Nunes,Sheila Gaff,Red,Women's Bantamweight
+08/03/2013,Sergio Moraes,Neil Magny,Red,Welterweight
+08/03/2013,Ian McCall,Iliarde Santos,Red,Flyweight
+08/03/2013,Rani Yahya,Josh Clopton,Red,Featherweight
+08/03/2013,Francimar Barroso,Ednaldo Oliveira,Red,Light Heavyweight
+08/03/2013,Viscardi Andrade,Bristol Marunde,Red,Welterweight
+07/27/2013,Demetrious Johnson,John Moraga,Red,UFC Flyweight Title
+07/27/2013,Rory MacDonald,Jake Ellenberger,Red,Welterweight
+07/27/2013,Robbie Lawler,Bobby Voelker,Red,Welterweight
+07/27/2013,Liz Carmouche,Jessica Andrade,Red,Women's Bantamweight
+07/27/2013,Jorge Masvidal,Michael Chiesa,Red,Lightweight
+07/27/2013,Danny Castillo,Tim Means,Red,Lightweight
+07/27/2013,Melvin Guillard,Mac Danzig,Red,Lightweight
+07/27/2013,Daron Cruickshank,Yves Edwards,Red,Lightweight
+07/27/2013,Ed Herman,Trevor Smith,Red,Middleweight
+07/27/2013,Germaine de Randamie,Julie Kedzie,Red,Women's Bantamweight
+07/27/2013,Justin Salas,Aaron Riley,Red,Lightweight
+07/27/2013,Yaotzin Meza,John Albert,Red,Bantamweight
+07/06/2013,Chris Weidman,Anderson Silva,Red,UFC Middleweight Title
+07/06/2013,Frankie Edgar,Charles Oliveira,Red,Featherweight
+07/06/2013,Tim Kennedy,Roger Gracie,Red,Middleweight
+07/06/2013,Mark Munoz,Tim Boetsch,Red,Middleweight
+07/06/2013,Cub Swanson,Dennis Siver,Red,Featherweight
+07/06/2013,Andrew Craig,Chris Leben,Red,Middleweight
+07/06/2013,Norman Parke,Kazuki Tokudome,Red,Lightweight
+07/06/2013,Gabriel Gonzaga,Dave Herman,Red,Heavyweight
+07/06/2013,Edson Barboza,Rafaello Oliveira,Red,Lightweight
+07/06/2013,Brian Melancon,Seth Baczynski,Red,Welterweight
+07/06/2013,Mike Pierce,David Mitchell,Red,Welterweight
+06/15/2013,Rashad Evans,Dan Henderson,Red,Light Heavyweight
+06/15/2013,Stipe Miocic,Roy Nelson,Red,Heavyweight
+06/15/2013,Ryan Jimmo,Igor Pokrajac,Red,Light Heavyweight
+06/15/2013,Alexis Davis,Rosi Sexton,Red,Women's Bantamweight
+06/15/2013,Shawn Jordan,Pat Barry,Red,Heavyweight
+06/15/2013,Jake Shields,Tyron Woodley,Red,Welterweight
+06/15/2013,James Krause,Sam Stout,Red,Lightweight
+06/15/2013,Sean Pierson,Kenny Robertson,Red,Welterweight
+06/15/2013,Roland Delorme,Edwin Figueroa,Red,Bantamweight
+06/15/2013,Mitch Clarke,John Maguire,Red,Lightweight
+06/15/2013,Yves Jabouin,Dustin Pague,Red,Bantamweight
+06/08/2013,Fabricio Werdum,Antonio Rodrigo Nogueira,Red,Heavyweight
+06/08/2013,Leonardo Santos,William Macario,Red,Ultimate Fighter Brazil 2 Welterweight Tournament Title
+06/08/2013,Thiago Silva,Rafael Cavalcante,Red,Light Heavyweight
+06/08/2013,Erick Silva,Jason High,Red,Welterweight
+06/08/2013,Daniel Sarafian,Eddie Mendez,Red,Middleweight
+06/08/2013,Rony Jason,Mike Wilkinson,Red,Featherweight
+06/08/2013,Raphael Assuncao,Vaughan Lee,Red,Bantamweight
+06/08/2013,Felipe Arantes,Godofredo Pepey,Red,Featherweight
+06/08/2013,Ildemar Alcantara,Leandro Silva,Red,Welterweight
+06/08/2013,Rodrigo Damm,Mizuto Hirota,Red,Featherweight
+06/08/2013,Caio Magalhaes,Karlos Vemola,Red,Middleweight
+06/08/2013,Antonio Braga Neto,Anthony Smith,Red,Middleweight
+05/25/2013,Cain Velasquez,Antonio Silva,Red,UFC Heavyweight Title
+05/25/2013,Junior Dos Santos,Mark Hunt,Red,Heavyweight
+05/25/2013,Glover Teixeira,James Te Huna,Red,Light Heavyweight
+05/25/2013,TJ Grant,Gray Maynard,Red,Lightweight
+05/25/2013,Donald Cerrone,KJ Noons,Red,Lightweight
+05/25/2013,Mike Pyle,Rick Story,Red,Welterweight
+05/25/2013,Dennis Bermudez,Max Holloway,Red,Featherweight
+05/25/2013,Robert Whittaker,Colton Smith,Red,Welterweight
+05/25/2013,Khabib Nurmagomedov,Abel Trujillo,Red,Lightweight
+05/25/2013,Stephen Thompson,Nah-Shon Burrell,Red,Welterweight
+05/25/2013,George Roop,Brian Bowles,Red,Bantamweight
+05/25/2013,Jeremy Stephens,Estevan Payan,Red,Featherweight
+05/18/2013,Vitor Belfort,Luke Rockhold,Red,Middleweight
+05/18/2013,Jacare Souza,Chris Camozzi,Red,Middleweight
+05/18/2013,Rafael Dos Anjos,Evan Dunham,Red,Lightweight
+05/18/2013,Rafael Natal,Joao Zeferino,Red,Middleweight
+05/18/2013,Nik Lentz,Hacran Dias,Red,Featherweight
+05/18/2013,Francisco Trinaldo,Mike Rio,Red,Lightweight
+05/18/2013,Gleison Tibau,John Cholish,Red,Lightweight
+05/18/2013,Paulo Thiago,Michel Prazeres,Red,Welterweight
+05/18/2013,Iuri Alcantara,Iliarde Santos,Red,Bantamweight
+05/18/2013,Fabio Maldonado,Roger Hollett,Red,Light Heavyweight
+05/18/2013,John Lineker,Azamat Gashimov,Red,Flyweight
+05/18/2013,Jussier Formiga,Chris Cariaso,Red,Flyweight
+05/18/2013,Lucas Martins,Jeremy Larsen,Red,Lightweight
+04/27/2013,Jon Jones,Chael Sonnen,Red,UFC Light Heavyweight Title
+04/27/2013,Michael Bisping,Alan Belcher,Red,Middleweight
+04/27/2013,Roy Nelson,Cheick Kongo,Red,Heavyweight
+04/27/2013,Phil Davis,Vinny Magalhaes,Red,Light Heavyweight
+04/27/2013,Rustam Khabilov,Yancy Medeiros,Red,Lightweight
+04/27/2013,Ovince Saint Preux,Gian Villante,Red,Light Heavyweight
+04/27/2013,Sara McMann,Sheila Gaff,Red,Women's Bantamweight
+04/27/2013,Bryan Caraway,Johnny Bedford,Red,Bantamweight
+04/27/2013,Cody McKenzie,Leonard Garcia,Red,Featherweight
+04/27/2013,Steven Siler,Kurt Holobaugh,Red,Featherweight
+04/20/2013,Benson Henderson,Gilbert Melendez,Red,UFC Lightweight Title
+04/20/2013,Daniel Cormier,Frank Mir,Red,Heavyweight
+04/20/2013,Josh Thomson,Nate Diaz,Red,Lightweight
+04/20/2013,Matt Brown,Jordan Mein,Red,Welterweight
+04/20/2013,Chad Mendes,Darren Elkins,Red,Featherweight
+04/20/2013,Francis Carmont,Lorenz Larkin,Red,Middleweight
+04/20/2013,Myles Jury,Ramsey Nijem,Red,Lightweight
+04/20/2013,Joseph Benavidez,Darren Uyenoyama,Red,Flyweight
+04/20/2013,Jorge Masvidal,Tim Means,Red,Lightweight
+04/20/2013,TJ Dillashaw,Hugo Viana,Red,Bantamweight
+04/20/2013,Anthony Njokuani,Roger Bowling,Red,Lightweight
+04/20/2013,Yoel Romero,Clifford Starks,Red,Middleweight
+04/13/2013,Urijah Faber,Scott Jorgensen,Red,Bantamweight
+04/13/2013,Kelvin Gastelum,Uriah Hall,Red,Ultimate Fighter 17 Middleweight Tournament Title
+04/13/2013,Cat Zingano,Miesha Tate,Red,Women's Bantamweight
+04/13/2013,Travis Browne,Gabriel Gonzaga,Red,Heavyweight
+04/13/2013,Robert McDaniel,Gilbert Smith,Red,Middleweight
+04/13/2013,Josh Samman,Kevin Casey,Red,Middleweight
+04/13/2013,Luke Barnatt,Collin Hart,Red,Middleweight
+04/13/2013,Dylan Andrews,Jimmy Quinlan,Red,Middleweight
+04/13/2013,Clint Hester,Bristol Marunde,Red,Middleweight
+04/13/2013,Cole Miller,Bart Palaszewski,Red,Featherweight
+04/13/2013,Maximo Blanco,Sam Sicilia,Red,Featherweight
+04/13/2013,Daniel Pineda,Justin Lawrence,Red,Featherweight
+04/06/2013,Gegard Mousasi,Ilir Latifi,Red,Light Heavyweight
+04/06/2013,Ross Pearson,Ryan Couture,Red,Lightweight
+04/06/2013,Matt Mitrione,Philip De Fries,Red,Heavyweight
+04/06/2013,Brad Pickett,Mike Easton,Red,Bantamweight
+04/06/2013,Diego Brandao,Pablo Garza,Red,Featherweight
+04/06/2013,Akira Corassani,Robert Peralta,Red,Featherweight
+04/06/2013,Reza Madadi,Michael Johnson,Red,Lightweight
+04/06/2013,Tor Troeng,Adam Cella,Red,Middleweight
+04/06/2013,Adlan Amagov,Chris Spang,Red,Welterweight
+04/06/2013,Conor McGregor,Marcus Brimage,Red,Featherweight
+04/06/2013,Ryan LaFlare,Ben Alloway,Red,Welterweight
+04/06/2013,Tom Lawlor,Michael Kuiper,Red,Middleweight
+04/06/2013,Papy Abedi,Besam Yousef,Red,Welterweight
+03/16/2013,Georges St-Pierre,Nick Diaz,Red,UFC Welterweight Title
+03/16/2013,Johny Hendricks,Carlos Condit,Red,Welterweight
+03/16/2013,Jake Ellenberger,Nate Marquardt,Red,Welterweight
+03/16/2013,Chris Camozzi,Nick Ring,Red,Middleweight
+03/16/2013,Mike Ricci,Colin Fletcher,Red,Lightweight
+03/16/2013,Patrick Cote,Bobby Voelker,Red,Welterweight
+03/16/2013,Darren Elkins,Antonio Carvalho,Red,Featherweight
+03/16/2013,Jordan Mein,Dan Miller,Red,Welterweight
+03/16/2013,John Makdessi,Daron Cruickshank,Red,Lightweight
+03/16/2013,Rick Story,Quinn Mulhern,Red,Welterweight
+03/16/2013,TJ Dillashaw,Issei Tamura,Red,Bantamweight
+03/16/2013,George Roop,Reuben Duran,Red,Bantamweight
+03/02/2013,Wanderlei Silva,Brian Stann,Red,Light Heavyweight
+03/02/2013,Mark Hunt,Stefan Struve,Red,Heavyweight
+03/02/2013,Diego Sanchez,Takanori Gomi,Red,Lightweight
+03/02/2013,Yushin Okami,Hector Lombard,Red,Middleweight
+03/02/2013,Rani Yahya,Mizuto Hirota,Red,Featherweight
+03/02/2013,Dong Hyun Kim,Siyar Bahadurzada,Red,Welterweight
+03/02/2013,Brad Tavares,Riki Fukuda,Red,Middleweight
+03/02/2013,Takeya Mizugaki,Bryan Caraway,Red,Bantamweight
+03/02/2013,Kazuki Tokudome,Cristiano Marcello,Red,Lightweight
+03/02/2013,Hyun Gyu Lim,Marcelo Guimaraes,Red,Welterweight
+02/23/2013,Ronda Rousey,Liz Carmouche,Red,UFC Women's Bantamweight Title
+02/23/2013,Lyoto Machida,Dan Henderson,Red,Light Heavyweight
+02/23/2013,Urijah Faber,Ivan Menjivar,Red,Bantamweight
+02/23/2013,Court McGee,Josh Neer,Red,Welterweight
+02/23/2013,Robbie Lawler,Josh Koscheck,Red,Welterweight
+02/23/2013,Brendan Schaub,Lavar Johnson,Red,Heavyweight
+02/23/2013,Michael Chiesa,Anton Kuivanen,Red,Lightweight
+02/23/2013,Dennis Bermudez,Matt Grice,Red,Featherweight
+02/23/2013,Sam Stout,Caros Fodor,Red,Lightweight
+02/23/2013,Kenny Robertson,Brock Jardine,Red,Welterweight
+02/23/2013,Neil Magny,Jon Manley,Red,Welterweight
+02/23/2013,Nah-Shon Burrell,Yuri Villefort,Red,Welterweight
+02/16/2013,Renan Barao,Michael McDonald,Red,UFC Interim Bantamweight Title
+02/16/2013,Cub Swanson,Dustin Poirier,Red,Featherweight
+02/16/2013,Jimi Manuwa,Cyrille Diabate,Red,Light Heavyweight
+02/16/2013,Gunnar Nelson,Jorge Santiago,Red,Welterweight
+02/16/2013,James Te Huna,Ryan Jimmo,Red,Light Heavyweight
+02/16/2013,Renee Forte,Terry Etim,Red,Lightweight
+02/16/2013,Danny Castillo,Paul Sass,Red,Lightweight
+02/16/2013,Andy Ogle,Josh Grispi,Red,Featherweight
+02/16/2013,Tom Watson,Stanislav Nedkov,Red,Middleweight
+02/16/2013,Vaughan Lee,Motonobu Tezuka,Red,Bantamweight
+02/16/2013,Phil Harris,Ulysses Gomez,Red,Flyweight
+02/02/2013,Jose Aldo,Frankie Edgar,Red,UFC Featherweight Title
+02/02/2013,Rogerio Nogueira,Rashad Evans,Red,Light Heavyweight
+02/02/2013,Antonio Silva,Alistair Overeem,Red,Heavyweight
+02/02/2013,Demian Maia,Jon Fitch,Red,Welterweight
+02/02/2013,Joseph Benavidez,Ian McCall,Red,Flyweight
+02/02/2013,Evan Dunham,Gleison Tibau,Red,Lightweight
+02/02/2013,Tyron Woodley,Jay Hieron,Red,Welterweight
+02/02/2013,Bobby Green,Jacob Volkmann,Red,Lightweight
+02/02/2013,Isaac Vallie-Flagg,Yves Edwards,Red,Lightweight
+02/02/2013,Dustin Kimura,Chico Camus,Red,Bantamweight
+02/02/2013,Francisco Rivera,Edwin Figueroa,Red,Bantamweight
+01/26/2013,Demetrious Johnson,John Dodson,Red,UFC Flyweight Title
+01/26/2013,Glover Teixeira,Quinton Jackson,Red,Light Heavyweight
+01/26/2013,Anthony Pettis,Donald Cerrone,Red,Lightweight
+01/26/2013,Ricardo Lamas,Erik Koch,Red,Featherweight
+01/26/2013,TJ Grant,Matt Wiman,Red,Lightweight
+01/26/2013,Clay Guida,Hatsu Hioki,Red,Featherweight
+01/26/2013,Pascal Krauss,Mike Stumpf,Red,Welterweight
+01/26/2013,Ryan Bader,Vladimir Matyushenko,Red,Light Heavyweight
+01/26/2013,Shawn Jordan,Mike Russow,Red,Heavyweight
+01/26/2013,Rafael Natal,Sean Spencer,Red,Middleweight
+01/26/2013,David Mitchell,Simeon Thoresen,Red,Welterweight
+01/19/2013,Vitor Belfort,Michael Bisping,Red,Middleweight
+01/19/2013,CB Dollaway,Daniel Sarafian,Red,Middleweight
+01/19/2013,Gabriel Gonzaga,Ben Rothwell,Red,Heavyweight
+01/19/2013,Khabib Nurmagomedov,Thiago Tavares,Red,Lightweight
+01/19/2013,Godofredo Pepey,Milton Vieira,Red,Featherweight
+01/19/2013,Ronny Markes,Andrew Craig,Red,Middleweight
+01/19/2013,Nik Lentz,Diego Nunes,Red,Featherweight
+01/19/2013,Edson Barboza,Lucas Martins,Red,Lightweight
+01/19/2013,Ildemar Alcantara,Wagner Prado,Red,Light Heavyweight
+01/19/2013,Francisco Trinaldo,CJ Keith,Red,Lightweight
+12/29/2012,Cain Velasquez,Junior Dos Santos,Red,UFC Heavyweight Title
+12/29/2012,Jim Miller,Joe Lauzon,Red,Lightweight
+12/29/2012,Constantinos Philippou,Tim Boetsch,Red,Middleweight
+12/29/2012,Yushin Okami,Alan Belcher,Red,Middleweight
+12/29/2012,Derek Brunson,Chris Leben,Red,Middleweight
+12/29/2012,Eddie Wineland,Brad Pickett,Red,Bantamweight
+12/29/2012,Erik Perez,Byron Bloodworth,Red,Bantamweight
+12/29/2012,Jamie Varner,Melvin Guillard,Red,Lightweight
+12/29/2012,Myles Jury,Michael Johnson,Red,Lightweight
+12/29/2012,Todd Duffee,Philip De Fries,Red,Heavyweight
+12/29/2012,Max Holloway,Leonard Garcia,Red,Featherweight
+12/29/2012,John Moraga,Chris Cariaso,Red,Flyweight
+12/15/2012,Roy Nelson,Matt Mitrione,Red,Heavyweight
+12/15/2012,Colton Smith,Mike Ricci,Red,Ultimate Fighter 16 Welterweight Tournament Title
+12/15/2012,Pat Barry,Shane del Rosario,Red,Heavyweight
+12/15/2012,Dustin Poirier,Jonathan Brookins,Red,Featherweight
+12/15/2012,Mike Pyle,James Head,Red,Welterweight
+12/15/2012,Johnny Bedford,Marcos Vinicius,Red,Bantamweight
+12/15/2012,Rustam Khabilov,Vinc Pichel,Red,Lightweight
+12/15/2012,TJ Waldburger,Nick Catone,Red,Welterweight
+12/15/2012,Hugo Viana,Reuben Duran,Red,Bantamweight
+12/15/2012,Mike Rio,John Cofer,Red,Lightweight
+12/15/2012,Tim Elliott,Jared Papazian,Red,Flyweight
+12/14/2012,Ross Pearson,George Sotiropoulos,Red,Lightweight
+12/14/2012,Robert Whittaker,Brad Scott,Red,Ultimate Fighter Australia vs. UK Welterweight Tournament Title
+12/14/2012,Norman Parke,Colin Fletcher,Red,Ultimate Fighter Australia vs. UK Lightweight Tournament Title
+12/14/2012,Hector Lombard,Rousimar Palhares,Red,Middleweight
+12/14/2012,Chad Mendes,Yaotzin Meza,Red,Featherweight
+12/14/2012,Mike Pierce,Seth Baczynski,Red,Welterweight
+12/14/2012,Ben Alloway,Manuel Rodriguez,Red,Welterweight
+12/14/2012,Mike Wilkinson,Brendan Loughnane,Red,Lightweight
+12/14/2012,Cody Donovan,Nick Penner,Red,Light Heavyweight
+12/08/2012,Benson Henderson,Nate Diaz,Red,UFC Lightweight Title
+12/08/2012,Alexander Gustafsson,Mauricio Rua,Red,Light Heavyweight
+12/08/2012,Rory MacDonald,BJ Penn,Red,Welterweight
+12/08/2012,Matt Brown,Mike Swick,Red,Welterweight
+12/08/2012,Yves Edwards,Jeremy Stephens,Red,Lightweight
+12/08/2012,Raphael Assuncao,Mike Easton,Red,Bantamweight
+12/08/2012,Ramsey Nijem,Joe Proctor,Red,Lightweight
+12/08/2012,Daron Cruickshank,Henry Martinez,Red,Lightweight
+12/08/2012,Abel Trujillo,Marcus LeVesseur,Red,Lightweight
+12/08/2012,Dennis Siver,Nam Phan,Red,Featherweight
+12/08/2012,Scott Jorgensen,John Albert,Red,Bantamweight
+11/17/2012,Georges St-Pierre,Carlos Condit,Red,UFC Welterweight Title
+11/17/2012,Johny Hendricks,Martin Kampmann,Red,Welterweight
+11/17/2012,Francis Carmont,Tom Lawlor,Red,Middleweight
+11/17/2012,Rafael Dos Anjos,Mark Bocek,Red,Lightweight
+11/17/2012,Pablo Garza,Mark Hominick,Red,Featherweight
+11/17/2012,Patrick Cote,Alessio Sakara,Red,Middleweight
+11/17/2012,Cyrille Diabate,Chad Griggs,Red,Light Heavyweight
+11/17/2012,John Makdessi,Sam Stout,Red,Lightweight
+11/17/2012,Antonio Carvalho,Rodrigo Damm,Red,Featherweight
+11/17/2012,Matthew Riddle,John Maguire,Red,Welterweight
+11/17/2012,Ivan Menjivar,Azamat Gashimov,Red,Bantamweight
+11/17/2012,Darren Elkins,Steven Siler,Red,Featherweight
+11/10/2012,Cung Le,Rich Franklin,Red,Middleweight
+11/10/2012,Dong Hyun Kim,Paulo Thiago,Red,Welterweight
+11/10/2012,Takanori Gomi,Mac Danzig,Red,Lightweight
+11/10/2012,Jon Tuck,Zhang Tiequan,Red,Lightweight
+11/10/2012,Takeya Mizugaki,Jeff Hougland,Red,Bantamweight
+11/10/2012,Alex Caceres,Motonobu Tezuka,Red,Bantamweight
+11/10/2012,John Lineker,Yasuhiro Urushitani,Red,Flyweight
+11/10/2012,Riki Fukuda,Tom DeBlass,Red,Middleweight
+10/13/2012,Anderson Silva,Stephan Bonnar,Red,Light Heavyweight
+10/13/2012,Antonio Rodrigo Nogueira,Dave Herman,Red,Heavyweight
+10/13/2012,Glover Teixeira,Fabio Maldonado,Red,Light Heavyweight
+10/13/2012,Jon Fitch,Erick Silva,Red,Welterweight
+10/13/2012,Phil Davis,Wagner Prado,Red,Light Heavyweight
+10/13/2012,Demian Maia,Rick Story,Red,Welterweight
+10/13/2012,Rony Jason,Sam Sicilia,Red,Featherweight
+10/13/2012,Gleison Tibau,Francisco Trinaldo,Red,Lightweight
+10/13/2012,Diego Brandao,Joey Gambino,Red,Featherweight
+10/13/2012,Sergio Moraes,Renee Forte,Red,Welterweight
+10/13/2012,Chris Camozzi,Luiz Cane,Red,Middleweight
+10/13/2012,Cristiano Marcello,Reza Madadi,Red,Lightweight
+10/05/2012,Antonio Silva,Travis Browne,Red,Heavyweight
+10/05/2012,Jake Ellenberger,Jay Hieron,Red,Welterweight
+10/05/2012,John Dodson,Jussier Formiga,Red,Flyweight
+10/05/2012,Justin Edwards,Josh Neer,Red,Welterweight
+10/05/2012,Michael Johnson,Danny Castillo,Red,Lightweight
+10/05/2012,Mike Pierce,Aaron Simpson,Red,Welterweight
+10/05/2012,Marcus LeVesseur,Carlo Prater,Red,Lightweight
+10/05/2012,Jacob Volkmann,Shane Roller,Red,Lightweight
+10/05/2012,Diego Nunes,Bart Palaszewski,Red,Featherweight
+10/05/2012,Darren Uyenoyama,Phil Harris,Red,Flyweight
+09/29/2012,Stefan Struve,Stipe Miocic,Red,Heavyweight
+09/29/2012,Dan Hardy,Amir Sadollah,Red,Welterweight
+09/29/2012,Brad Pickett,Yves Jabouin,Red,Bantamweight
+09/29/2012,Matt Wiman,Paul Sass,Red,Lightweight
+09/29/2012,John Hathaway,John Maguire,Red,Welterweight
+09/29/2012,Che Mills,Duane Ludwig,Red,Welterweight
+09/29/2012,Jimi Manuwa,Kyle Kingsbury,Red,Light Heavyweight
+09/29/2012,Akira Corassani,Andy Ogle,Red,Featherweight
+09/29/2012,Brad Tavares,Tom Watson,Red,Middleweight
+09/29/2012,Gunnar Nelson,DaMarques Johnson,Red,Catch Weight
+09/29/2012,Robert Peralta,Jason Young,Red,Featherweight
+09/22/2012,Jon Jones,Vitor Belfort,Red,UFC Light Heavyweight Title
+09/22/2012,Demetrious Johnson,Joseph Benavidez,Red,UFC Flyweight Title
+09/22/2012,Michael Bisping,Brian Stann,Red,Middleweight
+09/22/2012,Matt Hamill,Roger Hollett,Red,Light Heavyweight
+09/22/2012,Cub Swanson,Charles Oliveira,Red,Featherweight
+09/22/2012,Vinny Magalhaes,Igor Pokrajac,Red,Light Heavyweight
+09/22/2012,TJ Grant,Evan Dunham,Red,Lightweight
+09/22/2012,Sean Pierson,Lance Benoist,Red,Welterweight
+09/22/2012,Marcus Brimage,Jimy Hettes,Red,Featherweight
+09/22/2012,Seth Baczynski,Simeon Thoresen,Red,Welterweight
+09/22/2012,Mitch Gagnon,Walel Watson,Red,Bantamweight
+09/22/2012,Kyle Noke,Charlie Brenneman,Red,Welterweight
+08/11/2012,Benson Henderson,Frankie Edgar,Red,UFC Lightweight Title
+08/11/2012,Donald Cerrone,Melvin Guillard,Red,Lightweight
+08/11/2012,Yushin Okami,Buddy Roberts,Red,Middleweight
+08/11/2012,Max Holloway,Justin Lawrence,Red,Featherweight
+08/11/2012,Dennis Bermudez,Tommy Hayden,Red,Featherweight
+08/11/2012,Michael Kuiper,Jared Hamman,Red,Middleweight
+08/11/2012,Erik Perez,Ken Stone,Red,Bantamweight
+08/11/2012,Chico Camus,Dustin Pague,Red,Bantamweight
+08/11/2012,Nik Lentz,Eiji Mitsuoka,Red,Featherweight
+08/04/2012,Mauricio Rua,Brandon Vera,Red,Light Heavyweight
+08/04/2012,Lyoto Machida,Ryan Bader,Red,Light Heavyweight
+08/04/2012,Joe Lauzon,Jamie Varner,Red,Lightweight
+08/04/2012,Mike Swick,DaMarques Johnson,Red,Welterweight
+08/04/2012,Nam Phan,Cole Miller,Red,Featherweight
+08/04/2012,Rani Yahya,Josh Grispi,Red,Featherweight
+08/04/2012,Philip De Fries,Oli Thompson,Red,Heavyweight
+08/04/2012,Manvel Gamburyan,Michihiro Omigawa,Red,Featherweight
+08/04/2012,John Moraga,Ulysses Gomez,Red,Flyweight
+07/21/2012,Renan Barao,Urijah Faber,Red,UFC Interim Bantamweight Title
+07/21/2012,Tim Boetsch,Hector Lombard,Red,Middleweight
+07/21/2012,Cheick Kongo,Shawn Jordan,Red,Heavyweight
+07/21/2012,James Head,Brian Ebersole,Red,Welterweight
+07/21/2012,Nick Ring,Court McGee,Red,Middleweight
+07/21/2012,Ryan Jimmo,Anthony Perosh,Red,Light Heavyweight
+07/21/2012,Bryan Caraway,Mitch Gagnon,Red,Bantamweight
+07/21/2012,Antonio Carvalho,Daniel Pineda,Red,Featherweight
+07/21/2012,Anton Kuivanen,Mitch Clarke,Red,Lightweight
+07/11/2012,Chris Weidman,Mark Munoz,Red,Middleweight
+07/11/2012,James Te Huna,Joey Beltran,Red,Light Heavyweight
+07/11/2012,Aaron Simpson,Kenny Robertson,Red,Welterweight
+07/11/2012,Francis Carmont,Karlos Vemola,Red,Middleweight
+07/11/2012,TJ Dillashaw,Vaughan Lee,Red,Bantamweight
+07/11/2012,Rafael Dos Anjos,Anthony Njokuani,Red,Lightweight
+07/11/2012,Alex Caceres,Damacio Page,Red,Bantamweight
+07/11/2012,Chris Cariaso,Josh Ferguson,Red,Flyweight
+07/11/2012,Andrew Craig,Rafael Natal,Red,Middleweight
+07/11/2012,Marcelo Guimaraes,Dan Stittgen,Red,Welterweight
+07/11/2012,Raphael Assuncao,Issei Tamura,Red,Bantamweight
+07/07/2012,Anderson Silva,Chael Sonnen,Red,UFC Middleweight Title
+07/07/2012,Forrest Griffin,Tito Ortiz,Red,Light Heavyweight
+07/07/2012,Cung Le,Patrick Cote,Red,Middleweight
+07/07/2012,Demian Maia,Dong Hyun Kim,Red,Welterweight
+07/07/2012,Chad Mendes,Cody McKenzie,Red,Featherweight
+07/07/2012,Mike Easton,Ivan Menjivar,Red,Bantamweight
+07/07/2012,Melvin Guillard,Fabricio Camoes,Red,Lightweight
+07/07/2012,Khabib Nurmagomedov,Gleison Tibau,Red,Lightweight
+07/07/2012,Constantinos Philippou,Riki Fukuda,Red,Middleweight
+07/07/2012,Shane Roller,John Alessio,Red,Lightweight
+07/07/2012,Rafaello Oliveira,Yoislandy Izquierdo,Red,Lightweight
+06/23/2012,Rich Franklin,Wanderlei Silva,Red,Catch Weight
+06/23/2012,Cezar Ferreira,Sergio Moraes,Red,Ultimate Fighter Brazil 1 Middleweight Tournament Title
+06/23/2012,Rony Jason,Godofredo Pepey,Red,Ultimate Fighter Brazil 1 Featherweight Tournament Title
+06/23/2012,Fabricio Werdum,Mike Russow,Red,Heavyweight
+06/23/2012,Hacran Dias,Iuri Alcantara,Red,Featherweight
+06/23/2012,Rodrigo Damm,Anistavio Medeiros,Red,Featherweight
+06/23/2012,Francisco Trinaldo,Delson Heleno,Red,Middleweight
+06/23/2012,Hugo Viana,John Teixeira,Red,Featherweight
+06/23/2012,Thiago Perpetuo,Leonardo Mafra,Red,Middleweight
+06/23/2012,Marcos Vinicius,Wagner Campos,Red,Featherweight
+06/22/2012,Gray Maynard,Clay Guida,Red,Lightweight
+06/22/2012,Sam Stout,Spencer Fisher,Red,Lightweight
+06/22/2012,Brian Ebersole,TJ Waldburger,Red,Welterweight
+06/22/2012,Cub Swanson,Ross Pearson,Red,Featherweight
+06/22/2012,Ricardo Lamas,Hatsu Hioki,Red,Featherweight
+06/22/2012,Ramsey Nijem,CJ Keith,Red,Lightweight
+06/22/2012,Rick Story,Brock Jardine,Red,Welterweight
+06/22/2012,Steven Siler,Joey Gambino,Red,Featherweight
+06/22/2012,Chris Camozzi,Nick Catone,Red,Middleweight
+06/22/2012,Matt Brown,Luis Ramos,Red,Welterweight
+06/22/2012,Dan Miller,Ricardo Funch,Red,Welterweight
+06/22/2012,Ken Stone,Dustin Pague,Red,Bantamweight
+06/08/2012,Demetrious Johnson,Ian McCall,Red,Flyweight
+06/08/2012,Erick Silva,Charlie Brenneman,Red,Welterweight
+06/08/2012,Mike Pyle,Josh Neer,Red,Welterweight
+06/08/2012,Eddie Wineland,Scott Jorgensen,Red,Bantamweight
+06/08/2012,Mike Pierce,Carlos Eduardo Rocha,Red,Welterweight
+06/08/2012,Seth Baczynski,Lance Benoist,Red,Welterweight
+06/08/2012,Matt Grice,Leonard Garcia,Red,Featherweight
+06/08/2012,Dustin Pague,Jared Papazian,Red,Bantamweight
+06/08/2012,Tim Means,Justin Salas,Red,Lightweight
+06/08/2012,Buddy Roberts,Caio Magalhaes,Red,Middleweight
+06/08/2012,Henry Martinez,Bernardo Magalhaes,Red,Lightweight
+06/08/2012,Sean Pierson,Jake Hecht,Red,Welterweight
+06/01/2012,Martin Kampmann,Jake Ellenberger,Red,Welterweight
+06/01/2012,Michael Chiesa,Al Iaquinta,Red,Ultimate Fighter 15 Lightweight Tournament Title
+06/01/2012,Charles Oliveira,Jonathan Brookins,Red,Featherweight
+06/01/2012,Max Holloway,Pat Schilling,Red,Featherweight
+06/01/2012,Justin Lawrence,John Cofer,Red,Lightweight
+06/01/2012,Daron Cruickshank,Chris Tickle,Red,Lightweight
+06/01/2012,Myles Jury,Chris Saunders,Red,Lightweight
+06/01/2012,Sam Sicilia,Cristiano Marcello,Red,Lightweight
+06/01/2012,Joe Proctor,Jeremy Larsen,Red,Lightweight
+06/01/2012,Erik Perez,John Albert,Red,Bantamweight
+05/26/2012,Junior Dos Santos,Frank Mir,Red,UFC Heavyweight Title
+05/26/2012,Cain Velasquez,Antonio Silva,Red,Heavyweight
+05/26/2012,Roy Nelson,Dave Herman,Red,Heavyweight
+05/26/2012,Stipe Miocic,Shane del Rosario,Red,Heavyweight
+05/26/2012,Stefan Struve,Lavar Johnson,Red,Heavyweight
+05/26/2012,Darren Elkins,Diego Brandao,Red,Featherweight
+05/26/2012,Jamie Varner,Edson Barboza,Red,Lightweight
+05/26/2012,CB Dollaway,Jason Miller,Red,Middleweight
+05/26/2012,Dan Hardy,Duane Ludwig,Red,Welterweight
+05/26/2012,Paul Sass,Jacob Volkmann,Red,Lightweight
+05/26/2012,Glover Teixeira,Kyle Kingsbury,Red,Light Heavyweight
+05/26/2012,Mike Brown,Daniel Pineda,Red,Featherweight
+05/15/2012,Chan Sung Jung,Dustin Poirier,Red,Featherweight
+05/15/2012,Amir Sadollah,Jorge Lopez,Red,Welterweight
+05/15/2012,Donald Cerrone,Jeremy Stephens,Red,Lightweight
+05/15/2012,Yves Jabouin,Jeff Hougland,Red,Bantamweight
+05/15/2012,Igor Pokrajac,Fabio Maldonado,Red,Light Heavyweight
+05/15/2012,Tom Lawlor,Jason MacDonald,Red,Middleweight
+05/15/2012,Brad Tavares,Dongi Yang,Red,Middleweight
+05/15/2012,Cody McKenzie,Marcus LeVesseur,Red,Lightweight
+05/15/2012,TJ Grant,Carlo Prater,Red,Lightweight
+05/15/2012,Rafael Dos Anjos,Kamal Shalorus,Red,Lightweight
+05/15/2012,Johnny Eduardo,Jeff Curran,Red,Bantamweight
+05/15/2012,Francisco Rivera,Alex Soto,Red,Bantamweight
+05/05/2012,Nate Diaz,Jim Miller,Red,Lightweight
+05/05/2012,Johny Hendricks,Josh Koscheck,Red,Welterweight
+05/05/2012,Alan Belcher,Rousimar Palhares,Red,Middleweight
+05/05/2012,Lavar Johnson,Pat Barry,Red,Heavyweight
+05/05/2012,Michael Johnson,Tony Ferguson,Red,Lightweight
+05/05/2012,John Dodson,Tim Elliott,Red,Flyweight
+05/05/2012,John Hathaway,Pascal Krauss,Red,Welterweight
+05/05/2012,Louis Gaudinot,John Lineker,Red,Flyweight
+05/05/2012,Danny Castillo,John Cholish,Red,Lightweight
+05/05/2012,Dennis Bermudez,Pablo Garza,Red,Featherweight
+05/05/2012,Roland Delorme,Nick Denis,Red,Bantamweight
+05/05/2012,Karlos Vemola,Mike Massenzio,Red,Middleweight
+04/21/2012,Jon Jones,Rashad Evans,Red,UFC Light Heavyweight Title
+04/21/2012,Rory MacDonald,Che Mills,Red,Welterweight
+04/21/2012,Ben Rothwell,Brendan Schaub,Red,Heavyweight
+04/21/2012,Michael McDonald,Miguel Torres,Red,Bantamweight
+04/21/2012,Eddie Yagin,Mark Hominick,Red,Featherweight
+04/21/2012,Mark Bocek,John Alessio,Red,Lightweight
+04/21/2012,Travis Browne,Chad Griggs,Red,Heavyweight
+04/21/2012,Matt Brown,Stephen Thompson,Red,Welterweight
+04/21/2012,Anthony Njokuani,John Makdessi,Red,Lightweight
+04/21/2012,Mac Danzig,Efrain Escudero,Red,Lightweight
+04/21/2012,Chris Clements,Keith Wisniewski,Red,Welterweight
+04/21/2012,Marcus Brimage,Maximo Blanco,Red,Featherweight
+04/14/2012,Alexander Gustafsson,Thiago Silva,Red,Light Heavyweight
+04/14/2012,Brian Stann,Alessio Sakara,Red,Middleweight
+04/14/2012,Siyar Bahadurzada,Paulo Thiago,Red,Welterweight
+04/14/2012,Dennis Siver,Diego Nunes,Red,Featherweight
+04/14/2012,John Maguire,DaMarques Johnson,Red,Welterweight
+04/14/2012,Brad Pickett,Damacio Page,Red,Bantamweight
+04/14/2012,James Head,Papy Abedi,Red,Welterweight
+04/14/2012,Cyrille Diabate,Tom DeBlass,Red,Light Heavyweight
+04/14/2012,Francis Carmont,Magnus Cedenblad,Red,Middleweight
+04/14/2012,Reza Madadi,Yoislandy Izquierdo,Red,Lightweight
+04/14/2012,Simeon Thoresen,Besam Yousef,Red,Welterweight
+04/14/2012,Jason Young,Eric Wisely,Red,Featherweight
+03/02/2012,Martin Kampmann,Thiago Alves,Red,Welterweight
+03/02/2012,Joseph Benavidez,Yasuhiro Urushitani,Red,Flyweight
+03/02/2012,Constantinos Philippou,Court McGee,Red,Middleweight
+03/02/2012,James Te Huna,Aaron Rosa,Red,Light Heavyweight
+03/02/2012,Anthony Perosh,Nick Penner,Red,Light Heavyweight
+03/02/2012,Steven Siler,Cole Miller,Red,Featherweight
+03/02/2012,Andrew Craig,Kyle Noke,Red,Middleweight
+03/02/2012,TJ Waldburger,Jake Hecht,Red,Welterweight
+03/02/2012,Daniel Pineda,Mackens Semerzier,Red,Featherweight
+03/02/2012,Shawn Jordan,Oli Thompson,Red,Heavyweight
+02/25/2012,Benson Henderson,Frankie Edgar,Red,UFC Lightweight Title
+02/25/2012,Ryan Bader,Quinton Jackson,Red,Light Heavyweight
+02/25/2012,Mark Hunt,Cheick Kongo,Red,Heavyweight
+02/25/2012,Jake Shields,Yoshihiro Akiyama,Red,Welterweight
+02/25/2012,Tim Boetsch,Yushin Okami,Red,Middleweight
+02/25/2012,Hatsu Hioki,Bart Palaszewski,Red,Featherweight
+02/25/2012,Anthony Pettis,Joe Lauzon,Red,Lightweight
+02/25/2012,Takanori Gomi,Eiji Mitsuoka,Red,Lightweight
+02/25/2012,Vaughan Lee,Norifumi Yamamoto,Red,Bantamweight
+02/25/2012,Riki Fukuda,Steve Cantwell,Red,Middleweight
+02/25/2012,Chris Cariaso,Takeya Mizugaki,Red,Bantamweight
+02/25/2012,Issei Tamura,Zhang Tiequan,Red,Featherweight
+02/15/2012,Jake Ellenberger,Diego Sanchez,Red,Welterweight
+02/15/2012,Stefan Struve,Dave Herman,Red,Heavyweight
+02/15/2012,Ronny Markes,Aaron Simpson,Red,Middleweight
+02/15/2012,Stipe Miocic,Philip De Fries,Red,Heavyweight
+02/15/2012,TJ Dillashaw,Walel Watson,Red,Bantamweight
+02/15/2012,Ivan Menjivar,John Albert,Red,Bantamweight
+02/15/2012,Jonathan Brookins,Vagner Rocha,Red,Featherweight
+02/15/2012,Justin Salas,Anton Kuivanen,Red,Lightweight
+02/15/2012,Tim Means,Bernardo Magalhaes,Red,Lightweight
+02/04/2012,Carlos Condit,Nick Diaz,Red,UFC Interim Welterweight Title
+02/04/2012,Fabricio Werdum,Roy Nelson,Red,Heavyweight
+02/04/2012,Josh Koscheck,Mike Pierce,Red,Welterweight
+02/04/2012,Renan Barao,Scott Jorgensen,Red,Bantamweight
+02/04/2012,Ed Herman,Clifford Starks,Red,Middleweight
+02/04/2012,Dustin Poirier,Max Holloway,Red,Featherweight
+02/04/2012,Edwin Figueroa,Alex Caceres,Red,Bantamweight
+02/04/2012,Matt Brown,Chris Cope,Red,Welterweight
+02/04/2012,Matthew Riddle,Henry Martinez,Red,Welterweight
+02/04/2012,Rafael Natal,Michael Kuiper,Red,Middleweight
+02/04/2012,Stephen Thompson,Dan Stittgen,Red,Welterweight
+01/28/2012,Rashad Evans,Phil Davis,Red,Light Heavyweight
+01/28/2012,Chael Sonnen,Michael Bisping,Red,Middleweight
+01/28/2012,Chris Weidman,Demian Maia,Red,Middleweight
+01/28/2012,Evan Dunham,Nik Lentz,Red,Lightweight
+01/28/2012,Mike Russow,Jon Olav Einemo,Red,Heavyweight
+01/28/2012,Cub Swanson,George Roop,Red,Featherweight
+01/28/2012,Charles Oliveira,Eric Wisely,Red,Featherweight
+01/28/2012,Michael Johnson,Shane Roller,Red,Lightweight
+01/28/2012,Lavar Johnson,Joey Beltran,Red,Heavyweight
+01/28/2012,Chris Camozzi,Dustin Jacoby,Red,Middleweight
+01/20/2012,Jim Miller,Melvin Guillard,Red,Lightweight
+01/20/2012,Josh Neer,Duane Ludwig,Red,Welterweight
+01/20/2012,Mike Easton,Jared Papazian,Red,Bantamweight
+01/20/2012,Pat Barry,Christian Morecraft,Red,Heavyweight
+01/20/2012,Jorge Rivera,Eric Schafer,Red,Middleweight
+01/20/2012,Khabib Nurmagomedov,Kamal Shalorus,Red,Lightweight
+01/20/2012,Charlie Brenneman,Daniel Roberts,Red,Welterweight
+01/20/2012,Fabricio Camoes,Tommy Hayden,Red,Lightweight
+01/20/2012,Daniel Pineda,Pat Schilling,Red,Featherweight
+01/20/2012,Nick Denis,Joseph Sandoval,Red,Bantamweight
+01/14/2012,Jose Aldo,Chad Mendes,Red,UFC Featherweight Title
+01/14/2012,Vitor Belfort,Anthony Johnson,Red,Middleweight
+01/14/2012,Rousimar Palhares,Mike Massenzio,Red,Middleweight
+01/14/2012,Carlo Prater,Erick Silva,Red,Welterweight
+01/14/2012,Edson Barboza,Terry Etim,Red,Lightweight
+01/14/2012,Thiago Tavares,Sam Stout,Red,Lightweight
+01/14/2012,Gabriel Gonzaga,Ednaldo Oliveira,Red,Heavyweight
+01/14/2012,Iuri Alcantara,Michihiro Omigawa,Red,Featherweight
+01/14/2012,Mike Pyle,Ricardo Funch,Red,Welterweight
+01/14/2012,Felipe Arantes,Antonio Carvalho,Red,Featherweight
+12/30/2011,Alistair Overeem,Brock Lesnar,Red,Heavyweight
+12/30/2011,Nate Diaz,Donald Cerrone,Red,Lightweight
+12/30/2011,Johny Hendricks,Jon Fitch,Red,Welterweight
+12/30/2011,Alexander Gustafsson,Vladimir Matyushenko,Red,Light Heavyweight
+12/30/2011,Jimy Hettes,Nam Phan,Red,Featherweight
+12/30/2011,Ross Pearson,Junior Assuncao,Red,Featherweight
+12/30/2011,Danny Castillo,Anthony Njokuani,Red,Lightweight
+12/30/2011,Dong Hyun Kim,Sean Pierson,Red,Welterweight
+12/30/2011,Jacob Volkmann,Efrain Escudero,Red,Lightweight
+12/30/2011,Diego Nunes,Manvel Gamburyan,Red,Featherweight
+12/10/2011,Jon Jones,Lyoto Machida,Red,UFC Light Heavyweight Title
+12/10/2011,Frank Mir,Antonio Rodrigo Nogueira,Red,Heavyweight
+12/10/2011,Rogerio Nogueira,Tito Ortiz,Red,Light Heavyweight
+12/10/2011,Brian Ebersole,Claude Patrick,Red,Welterweight
+12/10/2011,Chan Sung Jung,Mark Hominick,Red,Featherweight
+12/10/2011,Igor Pokrajac,Krzysztof Soszynski,Red,Light Heavyweight
+12/10/2011,Constantinos Philippou,Jared Hamman,Red,Middleweight
+12/10/2011,Dennis Hallman,John Makdessi,Red,Lightweight
+12/10/2011,Yves Jabouin,Walel Watson,Red,Bantamweight
+12/10/2011,Mark Bocek,Nik Lentz,Red,Lightweight
+12/10/2011,Jake Hecht,Rich Attonito,Red,Welterweight
+12/10/2011,John Cholish,Mitch Clarke,Red,Lightweight
+12/03/2011,Michael Bisping,Jason Miller,Red,Middleweight
+12/03/2011,Diego Brandao,Dennis Bermudez,Red,Ultimate Fighter 14 Featherweight Tournament Title
+12/03/2011,John Dodson,TJ Dillashaw,Red,Ultimate Fighter 14 Bantamweight Tournament Title
+12/03/2011,Tony Ferguson,Yves Edwards,Red,Lightweight
+12/03/2011,Johnny Bedford,Louis Gaudinot,Red,Bantamweight
+12/03/2011,Marcus Brimage,Stephen Bass,Red,Featherweight
+12/03/2011,John Albert,Dustin Pague,Red,Bantamweight
+12/03/2011,Roland Delorme,Josh Ferguson,Red,Bantamweight
+12/03/2011,Steven Siler,Josh Clopton,Red,Featherweight
+12/03/2011,Bryan Caraway,Dustin Neace,Red,Featherweight
+11/19/2011,Dan Henderson,Mauricio Rua,Red,Light Heavyweight
+11/19/2011,Wanderlei Silva,Cung Le,Red,Middleweight
+11/19/2011,Urijah Faber,Brian Bowles,Red,Bantamweight
+11/19/2011,Martin Kampmann,Rick Story,Red,Welterweight
+11/19/2011,Stephan Bonnar,Kyle Kingsbury,Red,Light Heavyweight
+11/19/2011,Ryan Bader,Jason Brilz,Red,Light Heavyweight
+11/19/2011,Michael McDonald,Alex Soto,Red,Bantamweight
+11/19/2011,Chris Weidman,Tom Lawlor,Red,Middleweight
+11/19/2011,Gleison Tibau,Rafael Dos Anjos,Red,Lightweight
+11/19/2011,Miguel Torres,Nick Pace,Red,Bantamweight
+11/19/2011,Seth Baczynski,Matt Brown,Red,Welterweight
+11/19/2011,Danny Castillo,Shamar Bailey,Red,Lightweight
+11/12/2011,Junior Dos Santos,Cain Velasquez,Red,UFC Heavyweight Title
+11/12/2011,Benson Henderson,Clay Guida,Red,Lightweight
+11/12/2011,Dustin Poirier,Pablo Garza,Red,Featherweight
+11/12/2011,Ricardo Lamas,Cub Swanson,Red,Featherweight
+11/12/2011,DaMarques Johnson,Clay Harvison,Red,Welterweight
+11/12/2011,Darren Uyenoyama,Norifumi Yamamoto,Red,Bantamweight
+11/12/2011,Alex Caceres,Cole Escovedo,Red,Bantamweight
+11/12/2011,Mike Pierce,Paul Bradley,Red,Welterweight
+11/12/2011,Aaron Rosa,Matt Lucas,Red,Light Heavyweight
+11/05/2011,Mark Munoz,Chris Leben,Red,Middleweight
+11/05/2011,Renan Barao,Brad Pickett,Red,Bantamweight
+11/05/2011,Thiago Alves,Papy Abedi,Red,Welterweight
+11/05/2011,Anthony Perosh,Cyrille Diabate,Red,Light Heavyweight
+11/05/2011,Terry Etim,Edward Faaloloto,Red,Lightweight
+11/05/2011,John Maguire,Justin Edwards,Red,Welterweight
+11/05/2011,Philip De Fries,Rob Broughton,Red,Heavyweight
+11/05/2011,Michihiro Omigawa,Jason Young,Red,Featherweight
+11/05/2011,Che Mills,Chris Cope,Red,Welterweight
+11/05/2011,Chris Cariaso,Vaughan Lee,Red,Bantamweight
+10/29/2011,Nick Diaz,BJ Penn,Red,Welterweight
+10/29/2011,Cheick Kongo,Matt Mitrione,Red,Heavyweight
+10/29/2011,Roy Nelson,Mirko Filipovic,Red,Heavyweight
+10/29/2011,Scott Jorgensen,Jeff Curran,Red,Bantamweight
+10/29/2011,Hatsu Hioki,George Roop,Red,Featherweight
+10/29/2011,Donald Cerrone,Dennis Siver,Red,Lightweight
+10/29/2011,Bart Palaszewski,Tyson Griffin,Red,Featherweight
+10/29/2011,Brandon Vera,Eliot Marshall,Red,Light Heavyweight
+10/29/2011,Ramsey Nijem,Danny Downes,Red,Lightweight
+10/29/2011,Francis Carmont,Chris Camozzi,Red,Middleweight
+10/29/2011,Clifford Starks,Dustin Jacoby,Red,Middleweight
+10/08/2011,Frankie Edgar,Gray Maynard,Red,UFC Lightweight Title
+10/08/2011,Jose Aldo,Kenny Florian,Red,UFC Featherweight Title
+10/08/2011,Chael Sonnen,Brian Stann,Red,Middleweight
+10/08/2011,Nam Phan,Leonard Garcia,Red,Featherweight
+10/08/2011,Joe Lauzon,Melvin Guillard,Red,Lightweight
+10/08/2011,Demian Maia,Jorge Santiago,Red,Middleweight
+10/08/2011,Anthony Pettis,Jeremy Stephens,Red,Lightweight
+10/08/2011,Stipe Miocic,Joey Beltran,Red,Heavyweight
+10/08/2011,Darren Elkins,Zhang Tiequan,Red,Featherweight
+10/08/2011,Aaron Simpson,Eric Schafer,Red,Middleweight
+10/08/2011,Mike Massenzio,Steve Cantwell,Red,Middleweight
+10/01/2011,Dominick Cruz,Demetrious Johnson,Red,UFC Bantamweight Title
+10/01/2011,Stefan Struve,Pat Barry,Red,Heavyweight
+10/01/2011,Anthony Johnson,Charlie Brenneman,Red,Welterweight
+10/01/2011,Matt Wiman,Mac Danzig,Red,Lightweight
+10/01/2011,Yves Edwards,Rafaello Oliveira,Red,Lightweight
+10/01/2011,Paul Sass,Michael Johnson,Red,Lightweight
+10/01/2011,Mike Easton,Byron Bloodworth,Red,Bantamweight
+10/01/2011,TJ Grant,Shane Roller,Red,Lightweight
+10/01/2011,Josh Neer,Keith Wisniewski,Red,Welterweight
+10/01/2011,Walel Watson,Joseph Sandoval,Red,Bantamweight
+09/24/2011,Jon Jones,Quinton Jackson,Red,UFC Light Heavyweight Title
+09/24/2011,Josh Koscheck,Matt Hughes,Red,Welterweight
+09/24/2011,Mark Hunt,Ben Rothwell,Red,Heavyweight
+09/24/2011,Travis Browne,Rob Broughton,Red,Heavyweight
+09/24/2011,Nate Diaz,Takanori Gomi,Red,Lightweight
+09/24/2011,Tony Ferguson,Aaron Riley,Red,Lightweight
+09/24/2011,Tim Boetsch,Nick Ring,Red,Middleweight
+09/24/2011,Junior Assuncao,Eddie Yagin,Red,Featherweight
+09/24/2011,Takeya Mizugaki,Cole Escovedo,Red,Bantamweight
+09/24/2011,James Te Huna,Ricardo Romero,Red,Light Heavyweight
+09/17/2011,Jake Ellenberger,Jake Shields,Red,Welterweight
+09/17/2011,Court McGee,Dongi Yang,Red,Middleweight
+09/17/2011,Erik Koch,Jonathan Brookins,Red,Featherweight
+09/17/2011,Alan Belcher,Jason MacDonald,Red,Middleweight
+09/17/2011,Vagner Rocha,Cody McKenzie,Red,Lightweight
+09/17/2011,Evan Dunham,Shamar Bailey,Red,Lightweight
+09/17/2011,Lance Benoist,Matthew Riddle,Red,Welterweight
+09/17/2011,Ken Stone,Donny Walker,Red,Bantamweight
+09/17/2011,Seth Baczynski,Clay Harvison,Red,Welterweight
+09/17/2011,TJ Waldburger,Mike Stumpf,Red,Welterweight
+09/17/2011,Robert Peralta,Mike Lullo,Red,Featherweight
+09/17/2011,Justin Edwards,Jorge Lopez,Red,Welterweight
+08/27/2011,Anderson Silva,Yushin Okami,Red,UFC Middleweight Title
+08/27/2011,Mauricio Rua,Forrest Griffin,Red,Light Heavyweight
+08/27/2011,Edson Barboza,Ross Pearson,Red,Lightweight
+08/27/2011,Antonio Rodrigo Nogueira,Brendan Schaub,Red,Heavyweight
+08/27/2011,Stanislav Nedkov,Luiz Cane,Red,Light Heavyweight
+08/27/2011,Thiago Tavares,Spencer Fisher,Red,Lightweight
+08/27/2011,Rousimar Palhares,Dan Miller,Red,Middleweight
+08/27/2011,Paulo Thiago,David Mitchell,Red,Welterweight
+08/27/2011,Raphael Assuncao,Johnny Eduardo,Red,Bantamweight
+08/27/2011,Erick Silva,Luis Ramos,Red,Welterweight
+08/27/2011,Iuri Alcantara,Felipe Arantes,Red,Featherweight
+08/27/2011,Yves Jabouin,Ian Loveland,Red,Bantamweight
+08/14/2011,Chris Lytle,Dan Hardy,Red,Welterweight
+08/14/2011,Benson Henderson,Jim Miller,Red,Lightweight
+08/14/2011,Donald Cerrone,Charles Oliveira,Red,Lightweight
+08/14/2011,Duane Ludwig,Amir Sadollah,Red,Welterweight
+08/14/2011,Jared Hamman,CB Dollaway,Red,Middleweight
+08/14/2011,Joseph Benavidez,Eddie Wineland,Red,Bantamweight
+08/14/2011,Ed Herman,Kyle Noke,Red,Middleweight
+08/14/2011,Ronny Markes,Karlos Vemola,Red,Light Heavyweight
+08/14/2011,Jimy Hettes,Alex Caceres,Red,Featherweight
+08/14/2011,Cole Miller,TJ O'Brien,Red,Lightweight
+08/14/2011,Jacob Volkmann,Danny Castillo,Red,Lightweight
+08/14/2011,Edwin Figueroa,Jason Reinhardt,Red,Bantamweight
+08/06/2011,Rashad Evans,Tito Ortiz,Red,Light Heavyweight
+08/06/2011,Vitor Belfort,Yoshihiro Akiyama,Red,Middleweight
+08/06/2011,Brian Ebersole,Dennis Hallman,Red,Welterweight
+08/06/2011,Constantinos Philippou,Jorge Rivera,Red,Middleweight
+08/06/2011,Rory MacDonald,Mike Pyle,Red,Welterweight
+08/06/2011,Alexander Gustafsson,Matt Hamill,Red,Light Heavyweight
+08/06/2011,Chad Mendes,Rani Yahya,Red,Featherweight
+08/06/2011,Ivan Menjivar,Nick Pace,Red,Bantamweight
+08/06/2011,Johny Hendricks,Mike Pierce,Red,Welterweight
+08/06/2011,Mike Brown,Nam Phan,Red,Featherweight
+08/06/2011,Rafael Natal,Paul Bradley,Red,Middleweight
+07/02/2011,Dominick Cruz,Urijah Faber,Red,UFC Bantamweight Title
+07/02/2011,Chris Leben,Wanderlei Silva,Red,Middleweight
+07/02/2011,Dennis Siver,Matt Wiman,Red,Lightweight
+07/02/2011,Tito Ortiz,Ryan Bader,Red,Light Heavyweight
+07/02/2011,Carlos Condit,Dong Hyun Kim,Red,Welterweight
+07/02/2011,Melvin Guillard,Shane Roller,Red,Lightweight
+07/02/2011,Rafael Dos Anjos,George Sotiropoulos,Red,Lightweight
+07/02/2011,Brian Bowles,Takeya Mizugaki,Red,Bantamweight
+07/02/2011,Aaron Simpson,Brad Tavares,Red,Middleweight
+07/02/2011,Anthony Njokuani,Andre Winner,Red,Lightweight
+07/02/2011,Jeff Hougland,Donny Walker,Red,Bantamweight
+06/26/2011,Cheick Kongo,Pat Barry,Red,Heavyweight
+06/26/2011,Charlie Brenneman,Rick Story,Red,Welterweight
+06/26/2011,Matt Brown,John Howard,Red,Welterweight
+06/26/2011,Matt Mitrione,Christian Morecraft,Red,Heavyweight
+06/26/2011,Tyson Griffin,Manvel Gamburyan,Red,Featherweight
+06/26/2011,Javier Vazquez,Joe Stevenson,Red,Featherweight
+06/26/2011,Joe Lauzon,Curt Warburton,Red,Lightweight
+06/26/2011,Rich Attonito,Daniel Roberts,Red,Welterweight
+06/26/2011,Ricardo Lamas,Matt Grice,Red,Featherweight
+06/26/2011,Michael Johnson,Edward Faaloloto,Red,Lightweight
+06/11/2011,Junior Dos Santos,Shane Carwin,Red,Heavyweight
+06/11/2011,Kenny Florian,Diego Nunes,Red,Featherweight
+06/11/2011,Mark Munoz,Demian Maia,Red,Middleweight
+06/11/2011,Dave Herman,Jon Olav Einemo,Red,Heavyweight
+06/11/2011,Donald Cerrone,Vagner Rocha,Red,Lightweight
+06/11/2011,Sam Stout,Yves Edwards,Red,Lightweight
+06/11/2011,Chris Weidman,Jesse Bongfeldt,Red,Middleweight
+06/11/2011,Krzysztof Soszynski,Mike Massenzio,Red,Light Heavyweight
+06/11/2011,Nick Ring,James Head,Red,Middleweight
+06/11/2011,Dustin Poirier,Jason Young,Red,Featherweight
+06/11/2011,Joey Beltran,Aaron Rosa,Red,Heavyweight
+06/11/2011,Darren Elkins,Michihiro Omigawa,Red,Featherweight
+06/04/2011,Tony Ferguson,Ramsey Nijem,Red,Ultimate Fighter 13 Welterweight Tournament Title
+06/04/2011,Clay Guida,Anthony Pettis,Red,Lightweight
+06/04/2011,Ed Herman,Tim Credeur,Red,Middleweight
+06/04/2011,Kyle Kingsbury,Fabio Maldonado,Red,Light Heavyweight
+06/04/2011,Chris Cope,Chuck O'Neil,Red,Welterweight
+06/04/2011,Jeremy Stephens,Danny Downes,Red,Lightweight
+06/04/2011,George Roop,Josh Grispi,Red,Featherweight
+06/04/2011,Shamar Bailey,Ryan McGillivray,Red,Welterweight
+06/04/2011,Clay Harvison,Justin Edwards,Red,Welterweight
+06/04/2011,Scott Jorgensen,Ken Stone,Red,Bantamweight
+06/04/2011,Reuben Duran,Francisco Rivera,Red,Bantamweight
+05/28/2011,Quinton Jackson,Matt Hamill,Red,Light Heavyweight
+05/28/2011,Frank Mir,Roy Nelson,Red,Heavyweight
+05/28/2011,Travis Browne,Stefan Struve,Red,Heavyweight
+05/28/2011,Rick Story,Thiago Alves,Red,Welterweight
+05/28/2011,Brian Stann,Jorge Santiago,Red,Middleweight
+05/28/2011,Demetrious Johnson,Miguel Torres,Red,Bantamweight
+05/28/2011,Tim Boetsch,Kendall Grove,Red,Middleweight
+05/28/2011,Gleison Tibau,Rafaello Oliveira,Red,Lightweight
+05/28/2011,Michael McDonald,Chris Cariaso,Red,Bantamweight
+05/28/2011,Renan Barao,Cole Escovedo,Red,Bantamweight
+04/30/2011,Georges St-Pierre,Jake Shields,Red,UFC Welterweight Title
+04/30/2011,Jose Aldo,Mark Hominick,Red,UFC Featherweight Title
+04/30/2011,Lyoto Machida,Randy Couture,Red,Light Heavyweight
+04/30/2011,Vladimir Matyushenko,Jason Brilz,Red,Light Heavyweight
+04/30/2011,Benson Henderson,Mark Bocek,Red,Lightweight
+04/30/2011,Rory MacDonald,Nate Diaz,Red,Welterweight
+04/30/2011,Jake Ellenberger,Sean Pierson,Red,Welterweight
+04/30/2011,Claude Patrick,Daniel Roberts,Red,Welterweight
+04/30/2011,Ivan Menjivar,Charlie Valencia,Red,Bantamweight
+04/30/2011,Jason MacDonald,Ryan Jensen,Red,Middleweight
+04/30/2011,John Makdessi,Kyle Watson,Red,Lightweight
+04/30/2011,Pablo Garza,Yves Jabouin,Red,Featherweight
+03/26/2011,Phil Davis,Rogerio Nogueira,Red,Light Heavyweight
+03/26/2011,Anthony Johnson,Dan Hardy,Red,Welterweight
+03/26/2011,Amir Sadollah,DaMarques Johnson,Red,Welterweight
+03/26/2011,Chan Sung Jung,Leonard Garcia,Red,Featherweight
+03/26/2011,Mike Russow,Jon Madsen,Red,Heavyweight
+03/26/2011,Mackens Semerzier,Alex Caceres,Red,Featherweight
+03/26/2011,John Hathaway,Kris McCray,Red,Welterweight
+03/26/2011,Michael McDonald,Edwin Figueroa,Red,Bantamweight
+03/26/2011,Christian Morecraft,Sean McCorkle,Red,Heavyweight
+03/26/2011,Johny Hendricks,TJ Waldburger,Red,Welterweight
+03/26/2011,Aaron Simpson,Mario Miranda,Red,Middleweight
+03/26/2011,Nik Lentz,Waylon Lowe,Red,Lightweight
+03/19/2011,Jon Jones,Mauricio Rua,Red,UFC Light Heavyweight Title
+03/19/2011,Urijah Faber,Eddie Wineland,Red,Bantamweight
+03/19/2011,Jim Miller,Kamal Shalorus,Red,Lightweight
+03/19/2011,Nate Marquardt,Dan Miller,Red,Middleweight
+03/19/2011,Brendan Schaub,Mirko Filipovic,Red,Heavyweight
+03/19/2011,Luiz Cane,Eliot Marshall,Red,Light Heavyweight
+03/19/2011,Edson Barboza,Anthony Njokuani,Red,Lightweight
+03/19/2011,Mike Pyle,Ricardo Almeida,Red,Welterweight
+03/19/2011,Gleison Tibau,Kurt Pellegrino,Red,Lightweight
+03/19/2011,Joseph Benavidez,Ian Loveland,Red,Bantamweight
+03/19/2011,Nick Catone,Constantinos Philippou,Red,Catch Weight
+03/19/2011,Erik Koch,Raphael Assuncao,Red,Featherweight
+03/03/2011,Diego Sanchez,Martin Kampmann,Red,Welterweight
+03/03/2011,Mark Munoz,CB Dollaway,Red,Middleweight
+03/03/2011,Chris Weidman,Alessio Sakara,Red,Middleweight
+03/03/2011,Brian Bowles,Damacio Page,Red,Bantamweight
+03/03/2011,Cyrille Diabate,Steve Cantwell,Red,Light Heavyweight
+03/03/2011,Danny Castillo,Joe Stevenson,Red,Lightweight
+03/03/2011,Shane Roller,Thiago Tavares,Red,Lightweight
+03/03/2011,Takeya Mizugaki,Reuben Duran,Red,Bantamweight
+03/03/2011,Dongi Yang,Rob Kimmons,Red,Middleweight
+03/03/2011,Rousimar Palhares,David Branch,Red,Middleweight
+03/03/2011,Igor Pokrajac,Todd Brown,Red,Light Heavyweight
+02/26/2011,Michael Bisping,Jorge Rivera,Red,Middleweight
+02/26/2011,Dennis Siver,George Sotiropoulos,Red,Lightweight
+02/26/2011,Brian Ebersole,Chris Lytle,Red,Welterweight
+02/26/2011,Kyle Noke,Chris Camozzi,Red,Middleweight
+02/26/2011,Ross Pearson,Spencer Fisher,Red,Lightweight
+02/26/2011,Alexander Gustafsson,James Te Huna,Red,Light Heavyweight
+02/26/2011,Nick Ring,Riki Fukuda,Red,Middleweight
+02/26/2011,Anthony Perosh,Tom Blackledge,Red,Light Heavyweight
+02/26/2011,Zhang Tiequan,Jason Reinhardt,Red,Featherweight
+02/26/2011,Mark Hunt,Chris Tuchscherer,Red,Heavyweight
+02/26/2011,Curt Warburton,Maciej Jewtuszko,Red,Lightweight
+02/05/2011,Anderson Silva,Vitor Belfort,Red,UFC Middleweight Title
+02/05/2011,Forrest Griffin,Rich Franklin,Red,Light Heavyweight
+02/05/2011,Jon Jones,Ryan Bader,Red,Light Heavyweight
+02/05/2011,Jake Ellenberger,Carlos Eduardo Rocha,Red,Welterweight
+02/05/2011,Miguel Torres,Antonio Banuelos,Red,Bantamweight
+02/05/2011,Donald Cerrone,Paul Kelly,Red,Lightweight
+02/05/2011,Chad Mendes,Michihiro Omigawa,Red,Featherweight
+02/05/2011,Demetrious Johnson,Norifumi Yamamoto,Red,Bantamweight
+02/05/2011,Paul Taylor,Gabe Ruediger,Red,Lightweight
+02/05/2011,Kyle Kingsbury,Ricardo Romero,Red,Light Heavyweight
+02/05/2011,Mike Pierce,Kenny Robertson,Red,Welterweight
+01/22/2011,Melvin Guillard,Evan Dunham,Red,Lightweight
+01/22/2011,Matt Mitrione,Tim Hague,Red,Heavyweight
+01/22/2011,Mark Hominick,George Roop,Red,Featherweight
+01/22/2011,Pat Barry,Joey Beltran,Red,Heavyweight
+01/22/2011,Matt Wiman,Cole Miller,Red,Lightweight
+01/22/2011,Yves Edwards,Cody McKenzie,Red,Lightweight
+01/22/2011,DaMarques Johnson,Mike Guymon,Red,Welterweight
+01/22/2011,Rani Yahya,Mike Brown,Red,Featherweight
+01/22/2011,Waylon Lowe,Willamy Freire,Red,Lightweight
+01/22/2011,Charlie Brenneman,Amilcar Alves,Red,Welterweight
+01/22/2011,Chris Cariaso,Will Campuzano,Red,Bantamweight
+01/01/2011,Brian Stann,Chris Leben,Red,Middleweight
+01/01/2011,Dong Hyun Kim,Nate Diaz,Red,Welterweight
+01/01/2011,Clay Guida,Takanori Gomi,Red,Lightweight
+01/01/2011,Jeremy Stephens,Marcus Davis,Red,Lightweight
+01/01/2011,Dustin Poirier,Josh Grispi,Red,Featherweight
+01/01/2011,Brad Tavares,Phil Baroni,Red,Middleweight
+01/01/2011,Diego Nunes,Mike Brown,Red,Featherweight
+01/01/2011,Daniel Roberts,Greg Soto,Red,Welterweight
+01/01/2011,Jacob Volkmann,Antonio McKee,Red,Lightweight
+12/11/2010,Georges St-Pierre,Josh Koscheck,Red,UFC Welterweight Title
+12/11/2010,Stefan Struve,Sean McCorkle,Red,Heavyweight
+12/11/2010,Jim Miller,Charles Oliveira,Red,Lightweight
+12/11/2010,Mac Danzig,Joe Stevenson,Red,Lightweight
+12/11/2010,Thiago Alves,John Howard,Red,Welterweight
+12/11/2010,Dan Miller,Joe Doerksen,Red,Middleweight
+12/11/2010,Mark Bocek,Dustin Hazelett,Red,Lightweight
+12/11/2010,Sean Pierson,Matthew Riddle,Red,Welterweight
+12/11/2010,Ricardo Almeida,TJ Grant,Red,Welterweight
+12/11/2010,John Makdessi,Pat Audinwood,Red,Lightweight
+12/04/2010,Jonathan Brookins,Michael Johnson,Red,Ultimate Fighter 12 Lightweight Tournament Title
+12/04/2010,Stephan Bonnar,Igor Pokrajac,Red,Light Heavyweight
+12/04/2010,Demian Maia,Kendall Grove,Red,Middleweight
+12/04/2010,Rick Story,Johny Hendricks,Red,Welterweight
+12/04/2010,Leonard Garcia,Nam Phan,Red,Featherweight
+12/04/2010,Cody McKenzie,Aaron Wilkinson,Red,Lightweight
+12/04/2010,Ian Loveland,Tyler Toner,Red,Featherweight
+12/04/2010,Kyle Watson,Sako Chivitchian,Red,Lightweight
+12/04/2010,Nick Pace,Will Campuzano,Red,Bantamweight
+12/04/2010,Pablo Garza,Fredson Paixao,Red,Featherweight
+12/04/2010,David Branch,Rich Attonito,Red,Middleweight
+11/20/2010,Quinton Jackson,Lyoto Machida,Red,Light Heavyweight
+11/20/2010,BJ Penn,Matt Hughes,Red,Welterweight
+11/20/2010,Maiquel Falcao,Gerald Harris,Red,Middleweight
+11/20/2010,Phil Davis,Tim Boetsch,Red,Light Heavyweight
+11/20/2010,George Sotiropoulos,Joe Lauzon,Red,Lightweight
+11/20/2010,Brian Foster,Matt Brown,Red,Welterweight
+11/20/2010,Mark Munoz,Aaron Simpson,Red,Middleweight
+11/20/2010,Dennis Hallman,Karo Parisyan,Red,Welterweight
+11/20/2010,Edson Barboza,Mike Lullo,Red,Lightweight
+11/20/2010,Paul Kelly,TJ O'Brien,Red,Lightweight
+11/20/2010,Nik Lentz,Tyson Griffin,Red,Lightweight
+11/13/2010,Yushin Okami,Nate Marquardt,Red,Middleweight
+11/13/2010,Dennis Siver,Andre Winner,Red,Lightweight
+11/13/2010,Amir Sadollah,Peter Sobotta,Red,Welterweight
+11/13/2010,Krzysztof Soszynski,Goran Reljic,Red,Light Heavyweight
+11/13/2010,Duane Ludwig,Nick Osipczak,Red,Welterweight
+11/13/2010,Vladimir Matyushenko,Alexandre Ferreira,Red,Light Heavyweight
+11/13/2010,Pascal Krauss,Mark Scanlon,Red,Welterweight
+11/13/2010,Kyle Noke,Rob Kimmons,Red,Middleweight
+11/13/2010,Karlos Vemola,Seth Petruzelli,Red,Light Heavyweight
+11/13/2010,Carlos Eduardo Rocha,Kris McCray,Red,Welterweight
+10/23/2010,Cain Velasquez,Brock Lesnar,Red,UFC Heavyweight Title
+10/23/2010,Jake Shields,Martin Kampmann,Red,Welterweight
+10/23/2010,Diego Sanchez,Paulo Thiago,Red,Welterweight
+10/23/2010,Matt Hamill,Tito Ortiz,Red,Light Heavyweight
+10/23/2010,Brendan Schaub,Gabriel Gonzaga,Red,Heavyweight
+10/23/2010,Court McGee,Ryan Jensen,Red,Middleweight
+10/23/2010,Tom Lawlor,Patrick Cote,Red,Middleweight
+10/23/2010,Daniel Roberts,Mike Guymon,Red,Welterweight
+10/23/2010,Sam Stout,Paul Taylor,Red,Lightweight
+10/23/2010,Chris Camozzi,Dongi Yang,Red,Middleweight
+10/23/2010,Jon Madsen,Gilbert Yvel,Red,Heavyweight
+10/16/2010,Michael Bisping,Yoshihiro Akiyama,Red,Middleweight
+10/16/2010,Carlos Condit,Dan Hardy,Red,Welterweight
+10/16/2010,Mike Pyle,John Hathaway,Red,Welterweight
+10/16/2010,Claude Patrick,James Wilks,Red,Welterweight
+10/16/2010,Alexander Gustafsson,Cyrille Diabate,Red,Light Heavyweight
+10/16/2010,Rob Broughton,Vinicius Queiroz,Red,Heavyweight
+10/16/2010,Paul Sass,Mark Holst,Red,Lightweight
+10/16/2010,Spencer Fisher,Curt Warburton,Red,Lightweight
+10/16/2010,Fabio Maldonado,James McSweeney,Red,Light Heavyweight
+09/25/2010,Frank Mir,Mirko Filipovic,Red,Heavyweight
+09/25/2010,Ryan Bader,Rogerio Nogueira,Red,Light Heavyweight
+09/25/2010,Chris Lytle,Matt Serra,Red,Welterweight
+09/25/2010,Sean Sherk,Evan Dunham,Red,Lightweight
+09/25/2010,Melvin Guillard,Jeremy Stephens,Red,Lightweight
+09/25/2010,CB Dollaway,Joe Doerksen,Red,Middleweight
+09/25/2010,Matt Mitrione,Joey Beltran,Red,Heavyweight
+09/25/2010,Thiago Tavares,Pat Audinwood,Red,Lightweight
+09/25/2010,Waylon Lowe,Steve Lopez,Red,Lightweight
+09/25/2010,TJ Grant,Julio Paulino,Red,Welterweight
+09/25/2010,Sean McCorkle,Mark Hunt,Red,Heavyweight
+09/15/2010,Nate Marquardt,Rousimar Palhares,Red,Middleweight
+09/15/2010,Charles Oliveira,Efrain Escudero,Red,Lightweight
+09/15/2010,Jim Miller,Gleison Tibau,Red,Lightweight
+09/15/2010,Cole Miller,Ross Pearson,Red,Lightweight
+09/15/2010,Yves Edwards,John Gunderson,Red,Lightweight
+09/15/2010,Kyle Kingsbury,Jared Hamman,Red,Light Heavyweight
+09/15/2010,David Branch,Tomasz Drwal,Red,Middleweight
+09/15/2010,Rich Attonito,Rafael Natal,Red,Middleweight
+09/15/2010,TJ Waldburger,David Mitchell,Red,Welterweight
+09/15/2010,Brian Foster,Forrest Petz,Red,Welterweight
+08/28/2010,Frankie Edgar,BJ Penn,Red,UFC Lightweight Title
+08/28/2010,Randy Couture,James Toney,Red,Heavyweight
+08/28/2010,Demian Maia,Mario Miranda,Red,Middleweight
+08/28/2010,Gray Maynard,Kenny Florian,Red,Lightweight
+08/28/2010,Nate Diaz,Marcus Davis,Red,Welterweight
+08/28/2010,Joe Lauzon,Gabe Ruediger,Red,Lightweight
+08/28/2010,Nik Lentz,Andre Winner,Red,Lightweight
+08/28/2010,Dan Miller,John Salter,Red,Middleweight
+08/28/2010,Greg Soto,Nick Osipczak,Red,Welterweight
+08/28/2010,Mike Pierce,Amilcar Alves,Red,Welterweight
+08/07/2010,Anderson Silva,Chael Sonnen,Red,UFC Middleweight Title
+08/07/2010,Jon Fitch,Thiago Alves,Red,Welterweight
+08/07/2010,Clay Guida,Rafael Dos Anjos,Red,Lightweight
+08/07/2010,Matt Hughes,Ricardo Almeida,Red,Welterweight
+08/07/2010,Junior Dos Santos,Roy Nelson,Red,Heavyweight
+08/07/2010,Rick Story,Dustin Hazelett,Red,Welterweight
+08/07/2010,Phil Davis,Rodney Wallace,Red,Light Heavyweight
+08/07/2010,Johny Hendricks,Charlie Brenneman,Red,Welterweight
+08/07/2010,Tim Boetsch,Todd Brown,Red,Light Heavyweight
+08/07/2010,Stefan Struve,Christian Morecraft,Red,Heavyweight
+08/07/2010,Dennis Hallman,Ben Saunders,Red,Welterweight
+08/01/2010,Jon Jones,Vladimir Matyushenko,Red,Light Heavyweight
+08/01/2010,Yushin Okami,Mark Munoz,Red,Middleweight
+08/01/2010,Jake Ellenberger,John Howard,Red,Welterweight
+08/01/2010,Takanori Gomi,Tyson Griffin,Red,Lightweight
+08/01/2010,Jacob Volkmann,Paul Kelly,Red,Lightweight
+08/01/2010,Matthew Riddle,DaMarques Johnson,Red,Welterweight
+08/01/2010,Igor Pokrajac,James Irvin,Red,Light Heavyweight
+08/01/2010,Brian Stann,Mike Massenzio,Red,Middleweight
+08/01/2010,Charles Oliveira,Darren Elkins,Red,Lightweight
+08/01/2010,Rob Kimmons,Steve Steinbeiss,Red,Middleweight
+07/03/2010,Brock Lesnar,Shane Carwin,Red,UFC Heavyweight Title
+07/03/2010,Chris Leben,Yoshihiro Akiyama,Red,Middleweight
+07/03/2010,Chris Lytle,Matt Brown,Red,Welterweight
+07/03/2010,Stephan Bonnar,Krzysztof Soszynski,Red,Light Heavyweight
+07/03/2010,George Sotiropoulos,Kurt Pellegrino,Red,Lightweight
+07/03/2010,Brendan Schaub,Chris Tuchscherer,Red,Heavyweight
+07/03/2010,Ricardo Romero,Seth Petruzelli,Red,Light Heavyweight
+07/03/2010,Kendall Grove,Goran Reljic,Red,Middleweight
+07/03/2010,Gerald Harris,David Branch,Red,Middleweight
+07/03/2010,Daniel Roberts,Forrest Petz,Red,Welterweight
+07/03/2010,Jon Madsen,Karlos Vemola,Red,Heavyweight
+06/19/2010,Court McGee,Kris McCray,Red,Ultimate Fighter 11 Middleweight Tournament Title
+06/19/2010,Matt Hamill,Keith Jardine,Red,Light Heavyweight
+06/19/2010,Chris Leben,Aaron Simpson,Red,Middleweight
+06/19/2010,Dennis Siver,Spencer Fisher,Red,Lightweight
+06/19/2010,Rich Attonito,Jamie Yager,Red,Middleweight
+06/19/2010,John Gunderson,Mark Holst,Red,Lightweight
+06/19/2010,Brad Tavares,Seth Baczynski,Red,Middleweight
+06/19/2010,Kyle Noke,Josh Bryant,Red,Middleweight
+06/19/2010,Chris Camozzi,James Hammortree,Red,Middleweight
+06/19/2010,Travis Browne,James McSweeney,Red,Heavyweight
+06/12/2010,Rich Franklin,Chuck Liddell,Red,Light Heavyweight
+06/12/2010,Mirko Filipovic,Pat Barry,Red,Heavyweight
+06/12/2010,Martin Kampmann,Paulo Thiago,Red,Welterweight
+06/12/2010,Ben Rothwell,Gilbert Yvel,Red,Heavyweight
+06/12/2010,Carlos Condit,Rory MacDonald,Red,Welterweight
+06/12/2010,Evan Dunham,Tyson Griffin,Red,Lightweight
+06/12/2010,Matt Wiman,Mac Danzig,Red,Lightweight
+06/12/2010,Mario Miranda,David Loiseau,Red,Middleweight
+06/12/2010,James Wilks,Peter Sobotta,Red,Welterweight
+06/12/2010,Claude Patrick,Ricardo Funch,Red,Welterweight
+06/12/2010,Mike Pyle,Jesse Lennox,Red,Welterweight
+05/29/2010,Rashad Evans,Quinton Jackson,Red,Light Heavyweight
+05/29/2010,Michael Bisping,Dan Miller,Red,Middleweight
+05/29/2010,Mike Russow,Todd Duffee,Red,Heavyweight
+05/29/2010,Rogerio Nogueira,Jason Brilz,Red,Light Heavyweight
+05/29/2010,John Hathaway,Diego Sanchez,Red,Welterweight
+05/29/2010,Dong Hyun Kim,Amir Sadollah,Red,Welterweight
+05/29/2010,Efrain Escudero,Dan Lauzon,Red,Lightweight
+05/29/2010,Melvin Guillard,Waylon Lowe,Red,Lightweight
+05/29/2010,Cyrille Diabate,Luiz Cane,Red,Light Heavyweight
+05/29/2010,Aaron Riley,Joe Brammer,Red,Lightweight
+05/29/2010,Ryan Jensen,Jesse Forbes,Red,Middleweight
+05/08/2010,Mauricio Rua,Lyoto Machida,Red,UFC Light Heavyweight Title
+05/08/2010,Josh Koscheck,Paul Daley,Red,Welterweight
+05/08/2010,Jeremy Stephens,Sam Stout,Red,Lightweight
+05/08/2010,Matt Mitrione,Kevin Ferguson,Red,Heavyweight
+05/08/2010,Alan Belcher,Patrick Cote,Red,Middleweight
+05/08/2010,Joe Doerksen,Tom Lawlor,Red,Middleweight
+05/08/2010,Marcus Davis,Jonathan Goulet,Red,Welterweight
+05/08/2010,Johny Hendricks,TJ Grant,Red,Welterweight
+05/08/2010,Joey Beltran,Tim Hague,Red,Heavyweight
+05/08/2010,Mike Guymon,Yoshiyuki Yoshida,Red,Welterweight
+05/08/2010,John Salter,Jason MacDonald,Red,Middleweight
+04/10/2010,Anderson Silva,Demian Maia,Red,UFC Middleweight Title
+04/10/2010,Frankie Edgar,BJ Penn,Red,UFC Lightweight Title
+04/10/2010,Matt Hughes,Renzo Gracie,Red,Welterweight
+04/10/2010,Rafael Dos Anjos,Terry Etim,Red,Lightweight
+04/10/2010,Mark Munoz,Kendall Grove,Red,Middleweight
+04/10/2010,Phil Davis,Alexander Gustafsson,Red,Light Heavyweight
+04/10/2010,Rick Story,Nick Osipczak,Red,Welterweight
+04/10/2010,DaMarques Johnson,Brad Blackburn,Red,Welterweight
+04/10/2010,Paul Kelly,Matt Veach,Red,Lightweight
+04/10/2010,Jon Madsen,Mostapha Al-Turk,Red,Heavyweight
+03/31/2010,Kenny Florian,Takanori Gomi,Red,Lightweight
+03/31/2010,Roy Nelson,Stefan Struve,Red,Heavyweight
+03/31/2010,Jorge Rivera,Nate Quarry,Red,Middleweight
+03/31/2010,Ross Pearson,Dennis Siver,Red,Lightweight
+03/31/2010,Andre Winner,Rafaello Oliveira,Red,Lightweight
+03/31/2010,Jacob Volkmann,Ronys Torres,Red,Lightweight
+03/31/2010,Nik Lentz,Rob Emerson,Red,Lightweight
+03/31/2010,Gleison Tibau,Caol Uno,Red,Lightweight
+03/31/2010,Yushin Okami,Lucio Linhares,Red,Middleweight
+03/31/2010,Gerald Harris,Mario Miranda,Red,Middleweight
+03/31/2010,Charlie Brenneman,Jason High,Red,Welterweight
+03/27/2010,Georges St-Pierre,Dan Hardy,Red,UFC Welterweight Title
+03/27/2010,Shane Carwin,Frank Mir,Red,UFC Interim Heavyweight Title
+03/27/2010,Kurt Pellegrino,Fabricio Camoes,Red,Lightweight
+03/27/2010,Jon Fitch,Ben Saunders,Red,Welterweight
+03/27/2010,Jim Miller,Mark Bocek,Red,Lightweight
+03/27/2010,Nate Diaz,Rory Markham,Red,Welterweight
+03/27/2010,Ricardo Almeida,Matt Brown,Red,Welterweight
+03/27/2010,Rousimar Palhares,Tomasz Drwal,Red,Middleweight
+03/27/2010,Jared Hamman,Rodney Wallace,Red,Light Heavyweight
+03/27/2010,Matthew Riddle,Greg Soto,Red,Welterweight
+03/21/2010,Jon Jones,Brandon Vera,Red,Light Heavyweight
+03/21/2010,Junior Dos Santos,Gabriel Gonzaga,Red,Heavyweight
+03/21/2010,Cheick Kongo,Paul Buentello,Red,Heavyweight
+03/21/2010,Alessio Sakara,James Irvin,Red,Middleweight
+03/21/2010,Clay Guida,Shannon Gugerty,Red,Lightweight
+03/21/2010,Vladimir Matyushenko,Eliot Marshall,Red,Light Heavyweight
+03/21/2010,Darren Elkins,Duane Ludwig,Red,Lightweight
+03/21/2010,John Howard,Daniel Roberts,Red,Welterweight
+03/21/2010,Brendan Schaub,Chase Gormley,Red,Heavyweight
+03/21/2010,Mike Pierce,Julio Paulino,Red,Welterweight
+03/21/2010,Jason Brilz,Eric Schafer,Red,Light Heavyweight
+02/20/2010,Cain Velasquez,Antonio Rodrigo Nogueira,Red,Heavyweight
+02/20/2010,Wanderlei Silva,Michael Bisping,Red,Middleweight
+02/20/2010,George Sotiropoulos,Joe Stevenson,Red,Lightweight
+02/20/2010,Ryan Bader,Keith Jardine,Red,Light Heavyweight
+02/20/2010,Mirko Filipovic,Anthony Perosh,Red,Heavyweight
+02/20/2010,Krzysztof Soszynski,Stephan Bonnar,Red,Light Heavyweight
+02/20/2010,Chris Lytle,Brian Foster,Red,Welterweight
+02/20/2010,CB Dollaway,Goran Reljic,Red,Middleweight
+02/20/2010,James Te Huna,Igor Pokrajac,Red,Light Heavyweight
+02/06/2010,Randy Couture,Mark Coleman,Red,Light Heavyweight
+02/06/2010,Chael Sonnen,Nate Marquardt,Red,Middleweight
+02/06/2010,Paulo Thiago,Mike Swick,Red,Welterweight
+02/06/2010,Demian Maia,Dan Miller,Red,Middleweight
+02/06/2010,Matt Serra,Frank Trigg,Red,Welterweight
+02/06/2010,Mac Danzig,Justin Buchholz,Red,Lightweight
+02/06/2010,Melvin Guillard,Ronys Torres,Red,Lightweight
+02/06/2010,Rob Emerson,Phillipe Nover,Red,Lightweight
+02/06/2010,Phil Davis,Brian Stann,Red,Light Heavyweight
+02/06/2010,Chris Tuchscherer,Tim Hague,Red,Heavyweight
+02/06/2010,Joey Beltran,Rolles Gracie,Red,Heavyweight
+01/11/2010,Gray Maynard,Nate Diaz,Red,Lightweight
+01/11/2010,Evan Dunham,Efrain Escudero,Red,Lightweight
+01/11/2010,Aaron Simpson,Tom Lawlor,Red,Middleweight
+01/11/2010,Amir Sadollah,Brad Blackburn,Red,Welterweight
+01/11/2010,Chris Leben,Jay Silva,Red,Middleweight
+01/11/2010,Rick Story,Jesse Lennox,Red,Welterweight
+01/11/2010,Rory MacDonald,Mike Guymon,Red,Welterweight
+01/11/2010,Rafael Dos Anjos,Kyle Bradley,Red,Lightweight
+01/11/2010,Gerald Harris,John Salter,Red,Middleweight
+01/11/2010,Nick Catone,Jesse Forbes,Red,Middleweight
+01/02/2010,Rashad Evans,Thiago Silva,Red,Light Heavyweight
+01/02/2010,Paul Daley,Dustin Hazelett,Red,Welterweight
+01/02/2010,Sam Stout,Joe Lauzon,Red,Lightweight
+01/02/2010,Jim Miller,Duane Ludwig,Red,Lightweight
+01/02/2010,Junior Dos Santos,Gilbert Yvel,Red,Heavyweight
+01/02/2010,Martin Kampmann,Jacob Volkmann,Red,Welterweight
+01/02/2010,Cole Miller,Dan Lauzon,Red,Lightweight
+01/02/2010,Mark Munoz,Ryan Jensen,Red,Middleweight
+01/02/2010,Jake Ellenberger,Mike Pyle,Red,Welterweight
+01/02/2010,Rafaello Oliveira,John Gunderson,Red,Lightweight
+12/12/2009,BJ Penn,Diego Sanchez,Red,UFC Lightweight Title
+12/12/2009,Frank Mir,Cheick Kongo,Red,Heavyweight
+12/12/2009,Jon Fitch,Mike Pierce,Red,Welterweight
+12/12/2009,Kenny Florian,Clay Guida,Red,Lightweight
+12/12/2009,Stefan Struve,Paul Buentello,Red,Heavyweight
+12/12/2009,Alan Belcher,Wilson Gouveia,Red,Catch Weight
+12/12/2009,Matt Wiman,Shane Nelson,Red,Lightweight
+12/12/2009,Johny Hendricks,Ricardo Funch,Red,Welterweight
+12/12/2009,Rousimar Palhares,Lucio Linhares,Red,Middleweight
+12/12/2009,DaMarques Johnson,Edgar Garcia,Red,Welterweight
+12/12/2009,TJ Grant,Kevin Burns,Red,Welterweight
+12/05/2009,Roy Nelson,Brendan Schaub,Red,Ultimate Fighter 10 Heavyweight Tournament Title
+12/05/2009,Matt Hamill,Jon Jones,Red,Light Heavyweight
+12/05/2009,Kevin Ferguson,Houston Alexander,Red,Catch Weight
+12/05/2009,Frankie Edgar,Matt Veach,Red,Lightweight
+12/05/2009,Matt Mitrione,Marcus Jones,Red,Heavyweight
+12/05/2009,James McSweeney,Darrill Schoonover,Red,Heavyweight
+12/05/2009,Jon Madsen,Justin Wren,Red,Heavyweight
+12/05/2009,Brian Stann,Rodney Wallace,Red,Light Heavyweight
+12/05/2009,John Howard,Dennis Hallman,Red,Welterweight
+12/05/2009,Mark Bocek,Joe Brammer,Red,Lightweight
+11/21/2009,Forrest Griffin,Tito Ortiz,Red,Light Heavyweight
+11/21/2009,Josh Koscheck,Anthony Johnson,Red,Welterweight
+11/21/2009,Paulo Thiago,Jacob Volkmann,Red,Welterweight
+11/21/2009,Rogerio Nogueira,Luiz Cane,Red,Light Heavyweight
+11/21/2009,Amir Sadollah,Phil Baroni,Red,Welterweight
+11/21/2009,Ben Saunders,Marcus Davis,Red,Welterweight
+11/21/2009,Kendall Grove,Jake Rosholt,Red,Middleweight
+11/21/2009,Brian Foster,Brock Larson,Red,Welterweight
+11/21/2009,George Sotiropoulos,Jason Dent,Red,Lightweight
+11/14/2009,Randy Couture,Brandon Vera,Red,Light Heavyweight
+11/14/2009,Dan Hardy,Mike Swick,Red,Welterweight
+11/14/2009,Michael Bisping,Denis Kang,Red,Middleweight
+11/14/2009,Matt Brown,James Wilks,Red,Welterweight
+11/14/2009,Ross Pearson,Aaron Riley,Red,Lightweight
+11/14/2009,John Hathaway,Paul Taylor,Red,Welterweight
+11/14/2009,Terry Etim,Shannon Gugerty,Red,Lightweight
+11/14/2009,Nick Osipczak,Matthew Riddle,Red,Welterweight
+11/14/2009,Dennis Siver,Paul Kelly,Red,Lightweight
+11/14/2009,Alexander Gustafsson,Jared Hamman,Red,Light Heavyweight
+11/14/2009,Andre Winner,Rolando Delgado,Red,Lightweight
+10/24/2009,Lyoto Machida,Mauricio Rua,Red,UFC Light Heavyweight Title
+10/24/2009,Cain Velasquez,Ben Rothwell,Red,Heavyweight
+10/24/2009,Gleison Tibau,Josh Neer,Red,Lightweight
+10/24/2009,Joe Stevenson,Spencer Fisher,Red,Lightweight
+10/24/2009,Anthony Johnson,Yoshiyuki Yoshida,Red,Welterweight
+10/24/2009,Ryan Bader,Eric Schafer,Red,Light Heavyweight
+10/24/2009,Pat Barry,Antoni Hardonk,Red,Heavyweight
+10/24/2009,Chael Sonnen,Yushin Okami,Red,Middleweight
+10/24/2009,Jorge Rivera,Rob Kimmons,Red,Middleweight
+10/24/2009,Kyle Kingsbury,Razak Al-Hassan,Red,Light Heavyweight
+10/24/2009,Stefan Struve,Chase Gormley,Red,Heavyweight
+09/19/2009,Vitor Belfort,Rich Franklin,Red,Catch Weight
+09/19/2009,Junior Dos Santos,Mirko Filipovic,Red,Heavyweight
+09/19/2009,Paul Daley,Martin Kampmann,Red,Welterweight
+09/19/2009,Josh Koscheck,Frank Trigg,Red,Welterweight
+09/19/2009,Tyson Griffin,Hermes Franca,Red,Lightweight
+09/19/2009,Efrain Escudero,Cole Miller,Red,Lightweight
+09/19/2009,Tomasz Drwal,Drew McFedries,Red,Middleweight
+09/19/2009,Jim Miller,Steve Lopez,Red,Lightweight
+09/19/2009,Nik Lentz,Rafaello Oliveira,Red,Lightweight
+09/19/2009,Rick Story,Brian Foster,Red,Welterweight
+09/19/2009,Eliot Marshall,Jason Brilz,Red,Light Heavyweight
+09/19/2009,Vladimir Matyushenko,Igor Pokrajac,Red,Light Heavyweight
+09/19/2009,Rafael Dos Anjos,Rob Emerson,Red,Lightweight
+09/16/2009,Nate Diaz,Melvin Guillard,Red,Lightweight
+09/16/2009,Gray Maynard,Roger Huerta,Red,Lightweight
+09/16/2009,Carlos Condit,Jake Ellenberger,Red,Welterweight
+09/16/2009,Nate Quarry,Tim Credeur,Red,Middleweight
+09/16/2009,Brian Stann,Steve Cantwell,Red,Light Heavyweight
+09/16/2009,Mike Pyle,Chris Wilson,Red,Welterweight
+09/16/2009,CB Dollaway,Jay Silva,Red,Middleweight
+09/16/2009,Jeremy Stephens,Justin Buchholz,Red,Lightweight
+09/16/2009,Mike Pierce,Brock Larson,Red,Welterweight
+09/16/2009,Ryan Jensen,Steve Steinbeiss,Red,Middleweight
+08/29/2009,Antonio Rodrigo Nogueira,Randy Couture,Red,Heavyweight
+08/29/2009,Thiago Silva,Keith Jardine,Red,Light Heavyweight
+08/29/2009,Jake Rosholt,Chris Leben,Red,Middleweight
+08/29/2009,Nate Marquardt,Demian Maia,Red,Middleweight
+08/29/2009,Brandon Vera,Krzysztof Soszynski,Red,Light Heavyweight
+08/29/2009,Aaron Simpson,Ed Herman,Red,Middleweight
+08/29/2009,Gabriel Gonzaga,Chris Tuchscherer,Red,Heavyweight
+08/29/2009,Mike Russow,Justin McCully,Red,Heavyweight
+08/29/2009,Todd Duffee,Tim Hague,Red,Heavyweight
+08/29/2009,Mark Munoz,Nick Catone,Red,Middleweight
+08/29/2009,Evan Dunham,Marcus Aurelio,Red,Lightweight
+08/08/2009,BJ Penn,Kenny Florian,Red,UFC Lightweight Title
+08/08/2009,Anderson Silva,Forrest Griffin,Red,Light Heavyweight
+08/08/2009,Aaron Riley,Shane Nelson,Red,Lightweight
+08/08/2009,Johny Hendricks,Amir Sadollah,Red,Welterweight
+08/08/2009,Ricardo Almeida,Kendall Grove,Red,Middleweight
+08/08/2009,Kurt Pellegrino,Josh Neer,Red,Lightweight
+08/08/2009,John Howard,Tamdan McCrory,Red,Welterweight
+08/08/2009,Alessio Sakara,Thales Leites,Red,Middleweight
+08/08/2009,Matthew Riddle,Dan Cramer,Red,Welterweight
+08/08/2009,George Sotiropoulos,George Roop,Red,Lightweight
+08/08/2009,Jesse Lennox,Danillo Villefort,Red,Welterweight
+07/11/2009,Jon Fitch,Paulo Thiago,Red,Welterweight
+07/11/2009,Brock Lesnar,Frank Mir,Red,UFC Heavyweight Title
+07/11/2009,Georges St-Pierre,Thiago Alves,Red,UFC Welterweight Title
+07/11/2009,Dan Henderson,Michael Bisping,Red,Middleweight
+07/11/2009,Yoshihiro Akiyama,Alan Belcher,Red,Middleweight
+07/11/2009,Mark Coleman,Stephan Bonnar,Red,Light Heavyweight
+07/11/2009,Jim Miller,Mac Danzig,Red,Lightweight
+07/11/2009,Jon Jones,Jake O'Brien,Red,Light Heavyweight
+07/11/2009,Dong Hyun Kim,TJ Grant,Red,Welterweight
+07/11/2009,Tom Lawlor,CB Dollaway,Red,Middleweight
+07/11/2009,Shannon Gugerty,Matt Grice,Red,Lightweight
+06/20/2009,Diego Sanchez,Clay Guida,Red,Lightweight
+06/20/2009,James Wilks,DaMarques Johnson,Red,Ultimate Fighter 9 Welterweight Tournament Title
+06/20/2009,Chris Lytle,Kevin Burns,Red,Welterweight
+06/20/2009,Ross Pearson,Andre Winner,Red,Ultimate Fighter 9 Lightweight Tournament Title
+06/20/2009,Joe Stevenson,Nate Diaz,Red,Lightweight
+06/20/2009,Melvin Guillard,Gleison Tibau,Red,Lightweight
+06/20/2009,Brad Blackburn,Edgar Garcia,Red,Welterweight
+06/20/2009,Tomasz Drwal,Mike Ciesnolevicz,Red,Light Heavyweight
+06/20/2009,Nick Osipczak,Frank Lester,Red,Welterweight
+06/20/2009,Jason Dent,Cameron Dollar,Red,Lightweight
+06/13/2009,Rich Franklin,Wanderlei Silva,Red,Catch Weight
+06/13/2009,Cain Velasquez,Cheick Kongo,Red,Heavyweight
+06/13/2009,Mirko Filipovic,Mostapha Al-Turk,Red,Heavyweight
+06/13/2009,Mike Swick,Ben Saunders,Red,Welterweight
+06/13/2009,Spencer Fisher,Caol Uno,Red,Lightweight
+06/13/2009,Dan Hardy,Marcus Davis,Red,Welterweight
+06/13/2009,Terry Etim,Justin Buchholz,Red,Lightweight
+06/13/2009,Dennis Siver,Dale Hartt,Red,Lightweight
+06/13/2009,Paul Taylor,Peter Sobotta,Red,Welterweight
+06/13/2009,Paul Kelly,Rolando Delgado,Red,Lightweight
+06/13/2009,Stefan Struve,Denis Stojnic,Red,Heavyweight
+06/13/2009,John Hathaway,Rick Story,Red,Welterweight
+05/23/2009,Lyoto Machida,Rashad Evans,Red,UFC Light Heavyweight Title
+05/23/2009,Matt Hughes,Matt Serra,Red,Welterweight
+05/23/2009,Drew McFedries,Xavier Foupa-Pokam,Red,Middleweight
+05/23/2009,Chael Sonnen,Dan Miller,Red,Middleweight
+05/23/2009,Frankie Edgar,Sean Sherk,Red,Lightweight
+05/23/2009,Brock Larson,Mike Pyle,Red,Welterweight
+05/23/2009,Tim Hague,Pat Barry,Red,Heavyweight
+05/23/2009,Kyle Bradley,Phillipe Nover,Red,Lightweight
+05/23/2009,Krzysztof Soszynski,Andre Gusmao,Red,Light Heavyweight
+05/23/2009,Yoshiyuki Yoshida,Brandon Wolff,Red,Welterweight
+05/23/2009,George Roop,David Kaplan,Red,Lightweight
+04/18/2009,Anderson Silva,Thales Leites,Red,UFC Middleweight Title
+04/18/2009,Sam Stout,Matt Wiman,Red,Lightweight
+04/18/2009,Mauricio Rua,Chuck Liddell,Red,Light Heavyweight
+04/18/2009,Krzysztof Soszynski,Brian Stann,Red,Light Heavyweight
+04/18/2009,Cheick Kongo,Antoni Hardonk,Red,Heavyweight
+04/18/2009,Luiz Cane,Steve Cantwell,Red,Light Heavyweight
+04/18/2009,Denis Kang,Xavier Foupa-Pokam,Red,Middleweight
+04/18/2009,Nate Quarry,Jason MacDonald,Red,Middleweight
+04/18/2009,Ed Herman,David Loiseau,Red,Middleweight
+04/18/2009,Mark Bocek,David Bielkheden,Red,Lightweight
+04/18/2009,TJ Grant,Ryo Chonan,Red,Welterweight
+04/18/2009,Eliot Marshall,Vinny Magalhaes,Red,Light Heavyweight
+04/01/2009,Martin Kampmann,Carlos Condit,Red,Welterweight
+04/01/2009,Ryan Bader,Carmelo Marrero,Red,Light Heavyweight
+04/01/2009,Tyson Griffin,Rafael Dos Anjos,Red,Lightweight
+04/01/2009,Cole Miller,Junie Browning,Red,Lightweight
+04/01/2009,Gleison Tibau,Jeremy Stephens,Red,Lightweight
+04/01/2009,Ricardo Almeida,Matt Horwich,Red,Middleweight
+04/01/2009,Brock Larson,Jesse Sanders,Red,Welterweight
+04/01/2009,Tim Credeur,Nick Catone,Red,Middleweight
+04/01/2009,Jorge Rivera,Nissen Osterneck,Red,Middleweight
+04/01/2009,Rob Kimmons,Joe Vedepo,Red,Middleweight
+04/01/2009,Aaron Simpson,Tim McKenzie,Red,Middleweight
+03/07/2009,Quinton Jackson,Keith Jardine,Red,Light Heavyweight
+03/07/2009,Shane Carwin,Gabriel Gonzaga,Red,Heavyweight
+03/07/2009,Matt Brown,Pete Sell,Red,Welterweight
+03/07/2009,Matt Hamill,Mark Munoz,Red,Light Heavyweight
+03/07/2009,Gray Maynard,Jim Miller,Red,Lightweight
+03/07/2009,Tamdan McCrory,Ryan Madigan,Red,Welterweight
+03/07/2009,Kendall Grove,Jason Day,Red,Middleweight
+03/07/2009,Jason Brilz,Tim Boetsch,Red,Light Heavyweight
+03/07/2009,Brandon Vera,Michael Patt,Red,Light Heavyweight
+03/07/2009,Shane Nelson,Aaron Riley,Red,Lightweight
+02/21/2009,Diego Sanchez,Joe Stevenson,Red,Lightweight
+02/21/2009,Dan Hardy,Rory Markham,Red,Welterweight
+02/21/2009,Nate Marquardt,Wilson Gouveia,Red,Middleweight
+02/21/2009,Demian Maia,Chael Sonnen,Red,Middleweight
+02/21/2009,Paulo Thiago,Josh Koscheck,Red,Welterweight
+02/21/2009,Terry Etim,Brian Cobb,Red,Lightweight
+02/21/2009,Junior Dos Santos,Stefan Struve,Red,Heavyweight
+02/21/2009,Evan Dunham,Per Eklund,Red,Lightweight
+02/21/2009,Mike Ciesnolevicz,Neil Grove,Red,Heavyweight
+02/21/2009,Paul Kelly,Troy Mandaloniz,Red,Welterweight
+02/07/2009,Joe Lauzon,Jeremy Stephens,Red,Lightweight
+02/07/2009,Cain Velasquez,Denis Stojnic,Red,Heavyweight
+02/07/2009,Josh Neer,Mac Danzig,Red,Lightweight
+02/07/2009,Anthony Johnson,Luigi Fioravanti,Red,Welterweight
+02/07/2009,Kurt Pellegrino,Rob Emerson,Red,Lightweight
+02/07/2009,Dan Miller,Jake Rosholt,Red,Middleweight
+02/07/2009,Matt Veach,Matt Grice,Red,Lightweight
+02/07/2009,Gleison Tibau,Rich Clementi,Red,Lightweight
+02/07/2009,Nick Catone,Derek Downey,Red,Middleweight
+02/07/2009,Matthew Riddle,Steve Bruno,Red,Welterweight
+01/31/2009,Georges St-Pierre,BJ Penn,Red,UFC Welterweight Title
+01/31/2009,Lyoto Machida,Thiago Silva,Red,Light Heavyweight
+01/31/2009,Jon Jones,Stephan Bonnar,Red,Light Heavyweight
+01/31/2009,Clay Guida,Nate Diaz,Red,Lightweight
+01/31/2009,Jon Fitch,Akihiro Gono,Red,Welterweight
+01/31/2009,Thiago Tavares,Manvel Gamburyan,Red,Lightweight
+01/31/2009,John Howard,Chris Wilson,Red,Welterweight
+01/31/2009,Jake O'Brien,Christian Wellisch,Red,Light Heavyweight
+01/31/2009,Dan Cramer,Matt Arroyo,Red,Welterweight
+01/17/2009,Dan Henderson,Rich Franklin,Red,Light Heavyweight
+01/17/2009,Mauricio Rua,Mark Coleman,Red,Light Heavyweight
+01/17/2009,Rousimar Palhares,Jeremy Horn,Red,Middleweight
+01/17/2009,Alan Belcher,Denis Kang,Red,Middleweight
+01/17/2009,Marcus Davis,Chris Lytle,Red,Welterweight
+01/17/2009,John Hathaway,Tom Egan,Red,Welterweight
+01/17/2009,Martin Kampmann,Alexandre Barros,Red,Welterweight
+01/17/2009,Eric Schafer,Antonio Mendes,Red,Light Heavyweight
+01/17/2009,Tomasz Drwal,Ivan Serati,Red,Light Heavyweight
+01/17/2009,Dennis Siver,Nate Mohr,Red,Lightweight
+12/27/2008,Rashad Evans,Forrest Griffin,Red,UFC Light Heavyweight Title
+12/27/2008,Frank Mir,Antonio Rodrigo Nogueira,Red,UFC Interim Heavyweight Title
+12/27/2008,CB Dollaway,Mike Massenzio,Red,Middleweight
+12/27/2008,Quinton Jackson,Wanderlei Silva,Red,Light Heavyweight
+12/27/2008,Cheick Kongo,Mostapha Al-Turk,Red,Heavyweight
+12/27/2008,Yushin Okami,Dean Lister,Red,Middleweight
+12/27/2008,Antoni Hardonk,Mike Wessel,Red,Heavyweight
+12/27/2008,Matt Hamill,Reese Andy,Red,Light Heavyweight
+12/27/2008,Brad Blackburn,Ryo Chonan,Red,Welterweight
+12/27/2008,Pat Barry,Dan Evensen,Red,Heavyweight
+12/13/2008,Efrain Escudero,Phillipe Nover,Red,Ultimate Fighter 8 Lightweight Tournament Title
+12/13/2008,Ryan Bader,Vinny Magalhaes,Red,Ultimate Fighter 8 Light Heavyweight Tournament Title
+12/13/2008,Anthony Johnson,Kevin Burns,Red,Welterweight
+12/13/2008,Wilson Gouveia,Jason MacDonald,Red,Middleweight
+12/13/2008,Junie Browning,David Kaplan,Red,Lightweight
+12/13/2008,Krzysztof Soszynski,Shane Primm,Red,Light Heavyweight
+12/13/2008,Eliot Marshall,Jules Bruchez,Red,Light Heavyweight
+12/13/2008,Tom Lawlor,Kyle Kingsbury,Red,Light Heavyweight
+12/13/2008,Shane Nelson,George Roop,Red,Lightweight
+12/13/2008,Rolando Delgado,John Polakowski,Red,Lightweight
+12/10/2008,Josh Koscheck,Yoshiyuki Yoshida,Red,Welterweight
+12/10/2008,Mike Swick,Jonathan Goulet,Red,Welterweight
+12/10/2008,Steve Cantwell,Razak Al-Hassan,Red,Light Heavyweight
+12/10/2008,Tim Credeur,Nate Loughran,Red,Middleweight
+12/10/2008,Jim Miller,Matt Wiman,Red,Lightweight
+12/10/2008,Luigi Fioravanti,Brodie Farber,Red,Catch Weight
+12/10/2008,Steve Bruno,Johnny Rees,Red,Welterweight
+12/10/2008,Ben Saunders,Brandon Wolff,Red,Welterweight
+12/10/2008,Dale Hartt,Corey Hill,Red,Lightweight
+12/10/2008,Justin McCully,Eddie Sanchez,Red,Heavyweight
+11/15/2008,Brock Lesnar,Randy Couture,Red,UFC Heavyweight Title
+11/15/2008,Kenny Florian,Joe Stevenson,Red,Lightweight
+11/15/2008,Dustin Hazelett,Tamdan McCrory,Red,Welterweight
+11/15/2008,Gabriel Gonzaga,Josh Hendricks,Red,Heavyweight
+11/15/2008,Demian Maia,Nate Quarry,Red,Middleweight
+11/15/2008,Aaron Riley,Jorge Gurgel,Red,Lightweight
+11/15/2008,Jeremy Stephens,Rafael Dos Anjos,Red,Lightweight
+11/15/2008,Mark Bocek,Alvin Robinson,Red,Lightweight
+11/15/2008,Matt Brown,Ryan Thomas,Red,Welterweight
+10/25/2008,Anderson Silva,Patrick Cote,Red,UFC Middleweight Title
+10/25/2008,Thiago Alves,Josh Koscheck,Red,Welterweight
+10/25/2008,Gray Maynard,Rich Clementi,Red,Lightweight
+10/25/2008,Junior Dos Santos,Fabricio Werdum,Red,Heavyweight
+10/25/2008,Sean Sherk,Tyson Griffin,Red,Lightweight
+10/25/2008,Thales Leites,Drew McFedries,Red,Middleweight
+10/25/2008,Spencer Fisher,Shannon Gugerty,Red,Lightweight
+10/25/2008,Dan Miller,Matt Horwich,Red,Middleweight
+10/25/2008,Hermes Franca,Marcus Aurelio,Red,Lightweight
+10/25/2008,Pete Sell,Joshua Burkman,Red,Welterweight
+10/18/2008,Michael Bisping,Chris Leben,Red,Middleweight
+10/18/2008,Keith Jardine,Brandon Vera,Red,Light Heavyweight
+10/18/2008,Luiz Cane,Rameau Thierry Sokoudjou,Red,Light Heavyweight
+10/18/2008,Chris Lytle,Paul Taylor,Red,Welterweight
+10/18/2008,Marcus Davis,Paul Kelly,Red,Welterweight
+10/18/2008,Dan Hardy,Akihiro Gono,Red,Welterweight
+10/18/2008,Shane Carwin,Neil Wain,Red,Heavyweight
+10/18/2008,David Bielkheden,Jess Liaudin,Red,Lightweight
+10/18/2008,Terry Etim,Sam Stout,Red,Lightweight
+10/18/2008,Jim Miller,David Baron,Red,Lightweight
+10/18/2008,Per Eklund,Samy Schiavo,Red,Lightweight
+09/17/2008,Nate Diaz,Josh Neer,Red,Lightweight
+09/17/2008,Clay Guida,Mac Danzig,Red,Lightweight
+09/17/2008,Alan Belcher,Ed Herman,Red,Middleweight
+09/17/2008,Eric Schafer,Houston Alexander,Red,Light Heavyweight
+09/17/2008,Alessio Sakara,Joe Vedepo,Red,Middleweight
+09/17/2008,Wilson Gouveia,Ryan Jensen,Red,Middleweight
+09/17/2008,Joe Lauzon,Kyle Bradley,Red,Lightweight
+09/17/2008,Jason Brilz,Brad Morris,Red,Light Heavyweight
+09/17/2008,Mike Massenzio,Drew McFedries,Red,Middleweight
+09/17/2008,Dan Miller,Rob Kimmons,Red,Middleweight
+09/06/2008,Rashad Evans,Chuck Liddell,Red,Light Heavyweight
+09/06/2008,Rich Franklin,Matt Hamill,Red,Light Heavyweight
+09/06/2008,Dan Henderson,Rousimar Palhares,Red,Middleweight
+09/06/2008,Nate Marquardt,Martin Kampmann,Red,Middleweight
+09/06/2008,Dong Hyun Kim,Matt Brown,Red,Welterweight
+09/06/2008,Kurt Pellegrino,Thiago Tavares,Red,Lightweight
+09/06/2008,Tim Boetsch,Michael Patt,Red,Light Heavyweight
+09/06/2008,Jason MacDonald,Jason Lambert,Red,Middleweight
+09/06/2008,Ryo Chonan,Roan Carneiro,Red,Welterweight
+08/09/2008,Georges St-Pierre,Jon Fitch,Red,UFC Welterweight Title
+08/09/2008,Brock Lesnar,Heath Herring,Red,Heavyweight
+08/09/2008,Rob Emerson,Manvel Gamburyan,Red,Lightweight
+08/09/2008,Kenny Florian,Roger Huerta,Red,Lightweight
+08/09/2008,Demian Maia,Jason MacDonald,Red,Middleweight
+08/09/2008,Tamdan McCrory,Luke Cummo,Red,Welterweight
+08/09/2008,Cheick Kongo,Dan Evensen,Red,Heavyweight
+08/09/2008,Jon Jones,Andre Gusmao,Red,Light Heavyweight
+08/09/2008,Chris Wilson,Steve Bruno,Red,Welterweight
+08/09/2008,Ben Saunders,Ryan Thomas,Red,Welterweight
+07/19/2008,Anderson Silva,James Irvin,Red,Light Heavyweight
+07/19/2008,Brandon Vera,Reese Andy,Red,Light Heavyweight
+07/19/2008,Frankie Edgar,Hermes Franca,Red,Lightweight
+07/19/2008,Cain Velasquez,Jake O'Brien,Red,Heavyweight
+07/19/2008,Kevin Burns,Anthony Johnson,Red,Welterweight
+07/19/2008,CB Dollaway,Jesse Taylor,Red,Middleweight
+07/19/2008,Tim Credeur,Cale Yarbrough,Red,Middleweight
+07/19/2008,Rory Markham,Brodie Farber,Red,Welterweight
+07/19/2008,Nate Loughran,Johnny Rees,Red,Middleweight
+07/19/2008,Brad Blackburn,James Giboo,Red,Welterweight
+07/19/2008,Shannon Gugerty,Dale Hartt,Red,Lightweight
+07/05/2008,Forrest Griffin,Quinton Jackson,Red,UFC Light Heavyweight Title
+07/05/2008,Patrick Cote,Ricardo Almeida,Red,Middleweight
+07/05/2008,Joe Stevenson,Gleison Tibau,Red,Lightweight
+07/05/2008,Josh Koscheck,Chris Lytle,Red,Welterweight
+07/05/2008,Tyson Griffin,Marcus Aurelio,Red,Lightweight
+07/05/2008,Gabriel Gonzaga,Justin McCully,Red,Heavyweight
+07/05/2008,Cole Miller,Jorge Gurgel,Red,Lightweight
+07/05/2008,Melvin Guillard,Dennis Siver,Red,Lightweight
+07/05/2008,Justin Buchholz,Corey Hill,Red,Lightweight
+06/21/2008,Kendall Grove,Evan Tanner,Red,Middleweight
+06/21/2008,Amir Sadollah,CB Dollaway,Red,Ultimate Fighter 7 Middleweight Tournament Title
+06/21/2008,Diego Sanchez,Luigi Fioravanti,Red,Welterweight
+06/21/2008,Spencer Fisher,Jeremy Stephens,Red,Lightweight
+06/21/2008,Matthew Riddle,Dante Rivera,Red,Middleweight
+06/21/2008,Dustin Hazelett,Joshua Burkman,Red,Welterweight
+06/21/2008,Drew McFedries,Marvin Eastman,Red,Middleweight
+06/21/2008,Matt Brown,Matt Arroyo,Red,Welterweight
+06/21/2008,Dean Lister,Jeremy Horn,Red,Middleweight
+06/21/2008,Rob Kimmons,Rob Yundt,Red,Middleweight
+06/07/2008,Thiago Alves,Matt Hughes,Red,Welterweight
+06/07/2008,Michael Bisping,Jason Day,Red,Middleweight
+06/07/2008,Mike Swick,Marcus Davis,Red,Welterweight
+06/07/2008,Thales Leites,Nate Marquardt,Red,Middleweight
+06/07/2008,Fabricio Werdum,Brandon Vera,Red,Heavyweight
+06/07/2008,Martin Kampmann,Jorge Rivera,Red,Middleweight
+06/07/2008,Matt Wiman,Thiago Tavares,Red,Lightweight
+06/07/2008,Kevin Burns,Roan Carneiro,Red,Welterweight
+06/07/2008,Luiz Cane,Jason Lambert,Red,Light Heavyweight
+06/07/2008,Paul Taylor,Jess Liaudin,Red,Welterweight
+06/07/2008,Antoni Hardonk,Eddie Sanchez,Red,Heavyweight
+05/24/2008,BJ Penn,Sean Sherk,Red,UFC Lightweight Title
+05/24/2008,Wanderlei Silva,Keith Jardine,Red,Light Heavyweight
+05/24/2008,Goran Reljic,Wilson Gouveia,Red,Light Heavyweight
+05/24/2008,Lyoto Machida,Tito Ortiz,Red,Light Heavyweight
+05/24/2008,Thiago Silva,Antonio Mendes,Red,Light Heavyweight
+05/24/2008,Rousimar Palhares,Ivan Salaverry,Red,Middleweight
+05/24/2008,Rameau Thierry Sokoudjou,Kazuhiro Nakamura,Red,Light Heavyweight
+05/24/2008,Rich Clementi,Terry Etim,Red,Lightweight
+05/24/2008,Yoshiyuki Yoshida,War Machine,Red,Welterweight
+05/24/2008,Dong Hyun Kim,Jason Tan,Red,Welterweight
+05/24/2008,Shane Carwin,Christian Wellisch,Red,Heavyweight
+04/19/2008,Georges St-Pierre,Matt Serra,Red,UFC Welterweight Title
+04/19/2008,Rich Franklin,Travis Lutter,Red,Middleweight
+04/19/2008,Nate Quarry,Kalib Starnes,Red,Middleweight
+04/19/2008,Michael Bisping,Charles McCarthy,Red,Middleweight
+04/19/2008,Mac Danzig,Mark Bocek,Red,Lightweight
+04/19/2008,Jason MacDonald,Joe Doerksen,Red,Middleweight
+04/19/2008,Jason Day,Alan Belcher,Red,Middleweight
+04/19/2008,Demian Maia,Ed Herman,Red,Middleweight
+04/19/2008,Rich Clementi,Sam Stout,Red,Lightweight
+04/19/2008,Cain Velasquez,Brad Morris,Red,Heavyweight
+04/19/2008,Jonathan Goulet,Kuniyoshi Hironaka,Red,Welterweight
+04/02/2008,Kenny Florian,Joe Lauzon,Red,Lightweight
+04/02/2008,Gray Maynard,Frankie Edgar,Red,Lightweight
+04/02/2008,Thiago Alves,Karo Parisyan,Red,Welterweight
+04/02/2008,Matt Hamill,Tim Boetsch,Red,Light Heavyweight
+04/02/2008,Nate Diaz,Kurt Pellegrino,Red,Lightweight
+04/02/2008,James Irvin,Houston Alexander,Red,Light Heavyweight
+04/02/2008,Josh Neer,Din Thomas,Red,Lightweight
+04/02/2008,Marcus Aurelio,Ryan Roberts,Red,Lightweight
+04/02/2008,Manvel Gamburyan,Jeff Cox,Red,Lightweight
+04/02/2008,Clay Guida,Samy Schiavo,Red,Lightweight
+04/02/2008,George Sotiropoulos,Roman Mitichyan,Red,Welterweight
+04/02/2008,Anthony Johnson,Tommy Speer,Red,Welterweight
+03/01/2008,Anderson Silva,Dan Henderson,Red,UFC Middleweight Title
+03/01/2008,Heath Herring,Cheick Kongo,Red,Heavyweight
+03/01/2008,Chris Leben,Alessio Sakara,Red,Middleweight
+03/01/2008,Yushin Okami,Evan Tanner,Red,Middleweight
+03/01/2008,Jon Fitch,Chris Wilson,Red,Welterweight
+03/01/2008,Andrei Arlovski,Jake O'Brien,Red,Heavyweight
+03/01/2008,Luigi Fioravanti,Luke Cummo,Red,Welterweight
+03/01/2008,Josh Koscheck,Dustin Hazelett,Red,Welterweight
+03/01/2008,Diego Sanchez,David Bielkheden,Red,Welterweight
+03/01/2008,Jorge Gurgel,John Halverson,Red,Lightweight
+02/02/2008,Antonio Rodrigo Nogueira,Tim Sylvia,Red,UFC Interim Heavyweight Title
+02/02/2008,Frank Mir,Brock Lesnar,Red,Heavyweight
+02/02/2008,Nate Marquardt,Jeremy Horn,Red,Middleweight
+02/02/2008,Ricardo Almeida,Rob Yundt,Red,Middleweight
+02/02/2008,Tyson Griffin,Gleison Tibau,Red,Lightweight
+02/02/2008,Chris Lytle,Kyle Bradley,Red,Welterweight
+02/02/2008,Tim Boetsch,David Heath,Red,Light Heavyweight
+02/02/2008,Marvin Eastman,Terry Martin,Red,Middleweight
+02/02/2008,Rob Emerson,Keita Nakamura,Red,Lightweight
+01/23/2008,Mike Swick,Joshua Burkman,Red,Welterweight
+01/23/2008,Patrick Cote,Drew McFedries,Red,Middleweight
+01/23/2008,Thiago Tavares,Michihiro Omigawa,Red,Lightweight
+01/23/2008,Nate Diaz,Alvin Robinson,Red,Lightweight
+01/23/2008,Kurt Pellegrino,Alberto Crane,Red,Lightweight
+01/23/2008,Gray Maynard,Dennis Siver,Red,Lightweight
+01/23/2008,Jeremy Stephens,Cole Miller,Red,Lightweight
+01/23/2008,Corey Hill,Joe Veres,Red,Lightweight
+01/23/2008,Matt Wiman,Justin Buchholz,Red,Lightweight
+01/19/2008,BJ Penn,Joe Stevenson,Red,UFC Lightweight Title
+01/19/2008,Fabricio Werdum,Gabriel Gonzaga,Red,Heavyweight
+01/19/2008,Marcus Davis,Jess Liaudin,Red,Welterweight
+01/19/2008,Wilson Gouveia,Jason Lambert,Red,Light Heavyweight
+01/19/2008,Jorge Rivera,Kendall Grove,Red,Middleweight
+01/19/2008,Antoni Hardonk,Colin Robinson,Red,Heavyweight
+01/19/2008,Paul Kelly,Paul Taylor,Red,Welterweight
+01/19/2008,Alessio Sakara,James Lee,Red,Light Heavyweight
+01/19/2008,Sam Stout,Per Eklund,Red,Lightweight
+12/29/2007,Georges St-Pierre,Matt Hughes,Red,UFC Interim Welterweight Title
+12/29/2007,Chuck Liddell,Wanderlei Silva,Red,Light Heavyweight
+12/29/2007,Eddie Sanchez,Soa Palelei,Red,Heavyweight
+12/29/2007,Lyoto Machida,Rameau Thierry Sokoudjou,Red,Light Heavyweight
+12/29/2007,Rich Clementi,Melvin Guillard,Red,Lightweight
+12/29/2007,James Irvin,Luiz Cane,Red,Light Heavyweight
+12/29/2007,Manvel Gamburyan,Nate Mohr,Red,Lightweight
+12/29/2007,Dean Lister,Jordan Radev,Red,Middleweight
+12/29/2007,Roan Carneiro,Tony DeSouza,Red,Welterweight
+12/29/2007,Mark Bocek,Doug Evans,Red,Lightweight
+12/08/2007,Roger Huerta,Clay Guida,Red,Lightweight
+12/08/2007,Mac Danzig,Tommy Speer,Red,Ultimate Fighter 6 Welterweight Tournament Title
+12/08/2007,War Machine,Jared Rollins,Red,Welterweight
+12/08/2007,George Sotiropoulos,Billy Miles,Red,Welterweight
+12/08/2007,Ben Saunders,Dan Barrera,Red,Welterweight
+12/08/2007,Troy Mandaloniz,Richie Hightower,Red,Welterweight
+12/08/2007,Matt Arroyo,John Kolosci,Red,Welterweight
+12/08/2007,Roman Mitichyan,Dorian Price,Red,Welterweight
+12/08/2007,Jonathan Goulet,Paul Georgieff,Red,Welterweight
+11/17/2007,Rashad Evans,Michael Bisping,Red,Light Heavyweight
+11/17/2007,Thiago Silva,Houston Alexander,Red,Light Heavyweight
+11/17/2007,Karo Parisyan,Ryo Chonan,Red,Welterweight
+11/17/2007,Ed Herman,Joe Doerksen,Red,Middleweight
+11/17/2007,Frankie Edgar,Spencer Fisher,Red,Lightweight
+11/17/2007,Thiago Alves,Chris Lytle,Red,Welterweight
+11/17/2007,Joe Lauzon,Jason Reinhardt,Red,Lightweight
+11/17/2007,Marcus Aurelio,Luke Caudillo,Red,Lightweight
+11/17/2007,Akihiro Gono,Tamdan McCrory,Red,Welterweight
+10/20/2007,Anderson Silva,Rich Franklin,Red,UFC Middleweight Title
+10/20/2007,Tim Sylvia,Brandon Vera,Red,Heavyweight
+10/20/2007,Alvin Robinson,Jorge Gurgel,Red,Lightweight
+10/20/2007,Stephan Bonnar,Eric Schafer,Red,Light Heavyweight
+10/20/2007,Alan Belcher,Kalib Starnes,Red,Middleweight
+10/20/2007,Yushin Okami,Jason MacDonald,Red,Middleweight
+10/20/2007,Demian Maia,Ryan Jensen,Red,Middleweight
+10/20/2007,Joshua Burkman,Forrest Petz,Red,Welterweight
+10/20/2007,Matt Grice,Jason Black,Red,Lightweight
+09/22/2007,Keith Jardine,Chuck Liddell,Red,Light Heavyweight
+09/22/2007,Forrest Griffin,Mauricio Rua,Red,Light Heavyweight
+09/22/2007,Jon Fitch,Diego Sanchez,Red,Welterweight
+09/22/2007,Lyoto Machida,Kazuhiro Nakamura,Red,Light Heavyweight
+09/22/2007,Tyson Griffin,Thiago Tavares,Red,Lightweight
+09/22/2007,Rich Clementi,Anthony Johnson,Red,Welterweight
+09/22/2007,Jeremy Stephens,Diego Saraiva,Red,Lightweight
+09/22/2007,Christian Wellisch,Scott Junk,Red,Heavyweight
+09/22/2007,Matt Wiman,Michihiro Omigawa,Red,Lightweight
+09/19/2007,Kenny Florian,Din Thomas,Red,Lightweight
+09/19/2007,Chris Leben,Terry Martin,Red,Middleweight
+09/19/2007,Nate Diaz,Junior Assuncao,Red,Lightweight
+09/19/2007,Nate Quarry,Pete Sell,Red,Middleweight
+09/19/2007,Luke Cummo,Edilberto de Oliveira,Red,Welterweight
+09/19/2007,Cole Miller,Leonard Garcia,Red,Lightweight
+09/19/2007,Gray Maynard,Joe Veres,Red,Lightweight
+09/19/2007,Thiago Alves,Kuniyoshi Hironaka,Red,Welterweight
+09/19/2007,Dustin Hazelett,Jonathan Goulet,Red,Welterweight
+09/08/2007,Quinton Jackson,Dan Henderson,Red,UFC Light Heavyweight Title
+09/08/2007,Michael Bisping,Matt Hamill,Red,Light Heavyweight
+09/08/2007,Cheick Kongo,Mirko Filipovic,Red,Heavyweight
+09/08/2007,Marcus Davis,Paul Taylor,Red,Welterweight
+09/08/2007,Houston Alexander,Alessio Sakara,Red,Light Heavyweight
+09/08/2007,Gleison Tibau,Terry Etim,Red,Lightweight
+09/08/2007,Thiago Silva,Tomasz Drwal,Red,Light Heavyweight
+09/08/2007,Dennis Siver,Naoyuki Kotani,Red,Lightweight
+09/08/2007,Jess Liaudin,Anthony Torres,Red,Welterweight
+08/25/2007,Randy Couture,Gabriel Gonzaga,Red,UFC Heavyweight Title
+08/25/2007,Georges St-Pierre,Josh Koscheck,Red,Welterweight
+08/25/2007,Roger Huerta,Alberto Crane,Red,Lightweight
+08/25/2007,Joe Stevenson,Kurt Pellegrino,Red,Lightweight
+08/25/2007,Patrick Cote,Kendall Grove,Red,Middleweight
+08/25/2007,Renato Sobral,David Heath,Red,Light Heavyweight
+08/25/2007,Frank Mir,Antoni Hardonk,Red,Heavyweight
+08/25/2007,Thales Leites,Ryan Jensen,Red,Middleweight
+08/25/2007,Clay Guida,Marcus Aurelio,Red,Lightweight
+07/07/2007,Kenny Florian,Alvin Robinson,Red,Lightweight
+07/07/2007,Anderson Silva,Nate Marquardt,Red,UFC Middleweight Title
+07/07/2007,Sean Sherk,Hermes Franca,Red,UFC Lightweight Title
+07/07/2007,Antonio Rodrigo Nogueira,Heath Herring,Red,Heavyweight
+07/07/2007,Stephan Bonnar,Mike Nickels,Red,Light Heavyweight
+07/07/2007,Jorge Gurgel,Diego Saraiva,Red,Lightweight
+07/07/2007,Chris Lytle,Jason Gilliam,Red,Welterweight
+07/07/2007,Frankie Edgar,Mark Bocek,Red,Lightweight
+06/23/2007,BJ Penn,Jens Pulver,Red,Lightweight
+06/23/2007,Nate Diaz,Manvel Gamburyan,Red,Ultimate Fighter 5 Lightweight Tournament Title
+06/23/2007,Thales Leites,Floyd Sword,Red,Middleweight
+06/23/2007,Roger Huerta,Doug Evans,Red,Lightweight
+06/23/2007,Joe Lauzon,Brandon Melendez,Red,Lightweight
+06/23/2007,Cole Miller,Andy Wang,Red,Lightweight
+06/23/2007,Leonard Garcia,Allen Berube,Red,Lightweight
+06/23/2007,Matt Wiman,Brian Geraghty,Red,Lightweight
+06/16/2007,Rich Franklin,Yushin Okami,Red,Middleweight
+06/16/2007,Forrest Griffin,Hector Ramirez,Red,Light Heavyweight
+06/16/2007,Jason MacDonald,Rory Singer,Red,Middleweight
+06/16/2007,Tyson Griffin,Clay Guida,Red,Lightweight
+06/16/2007,Ed Herman,Scott Smith,Red,Middleweight
+06/16/2007,Marcus Davis,Jason Tan,Red,Welterweight
+06/16/2007,Eddie Sanchez,Colin Robinson,Red,Heavyweight
+06/16/2007,Dustin Hazelett,Stevie Lynch,Red,Welterweight
+06/12/2007,Spencer Fisher,Sam Stout,Red,Lightweight
+06/12/2007,Jon Fitch,Roan Carneiro,Red,Welterweight
+06/12/2007,Drew McFedries,Jordan Radev,Red,Middleweight
+06/12/2007,Thiago Tavares,Jason Black,Red,Lightweight
+06/12/2007,Forrest Petz,Luigi Fioravanti,Red,Welterweight
+06/12/2007,Tamdan McCrory,Pete Spratt,Red,Welterweight
+06/12/2007,Gleison Tibau,Jeff Cox,Red,Lightweight
+06/12/2007,Anthony Johnson,Chad Reiner,Red,Welterweight
+06/12/2007,Nate Mohr,Luke Caudillo,Red,Lightweight
+05/26/2007,Quinton Jackson,Chuck Liddell,Red,UFC Light Heavyweight Title
+05/26/2007,Karo Parisyan,Joshua Burkman,Red,Welterweight
+05/26/2007,Terry Martin,Ivan Salaverry,Red,Middleweight
+05/26/2007,Houston Alexander,Keith Jardine,Red,Light Heavyweight
+05/26/2007,Kalib Starnes,Chris Leben,Red,Middleweight
+05/26/2007,Thiago Silva,James Irvin,Red,Light Heavyweight
+05/26/2007,Alan Belcher,Sean Salmon,Red,Light Heavyweight
+05/26/2007,Din Thomas,Jeremy Stephens,Red,Lightweight
+05/26/2007,Wilson Gouveia,Carmelo Marrero,Red,Light Heavyweight
+04/21/2007,Gabriel Gonzaga,Mirko Filipovic,Red,Heavyweight
+04/21/2007,Andrei Arlovski,Fabricio Werdum,Red,Heavyweight
+04/21/2007,Michael Bisping,Elvis Sinosic,Red,Light Heavyweight
+04/21/2007,Lyoto Machida,David Heath,Red,Light Heavyweight
+04/21/2007,Cheick Kongo,Assuerio Silva,Red,Heavyweight
+04/21/2007,Terry Etim,Matt Grice,Red,Lightweight
+04/21/2007,Junior Assuncao,David Lee,Red,Lightweight
+04/21/2007,Alessio Sakara,Victor Valimaki,Red,Light Heavyweight
+04/21/2007,Jess Liaudin,Dennis Siver,Red,Welterweight
+04/21/2007,Paul Taylor,Edilberto de Oliveira,Red,Welterweight
+04/07/2007,Matt Serra,Georges St-Pierre,Red,UFC Welterweight Title
+04/07/2007,Josh Koscheck,Diego Sanchez,Red,Welterweight
+04/07/2007,Roger Huerta,Leonard Garcia,Red,Lightweight
+04/07/2007,Yushin Okami,Mike Swick,Red,Middleweight
+04/07/2007,Kendall Grove,Alan Belcher,Red,Middleweight
+04/07/2007,Heath Herring,Brad Imes,Red,Heavyweight
+04/07/2007,Thales Leites,Pete Sell,Red,Middleweight
+04/07/2007,Marcus Davis,Pete Spratt,Red,Welterweight
+04/07/2007,Luke Cummo,Josh Haynes,Red,Welterweight
+04/05/2007,Joe Stevenson,Melvin Guillard,Red,Lightweight
+04/05/2007,Justin McCully,Antoni Hardonk,Red,Heavyweight
+04/05/2007,Kenny Florian,Dokonjonosuke Mishima,Red,Lightweight
+04/05/2007,Wilson Gouveia,Seth Petruzelli,Red,Light Heavyweight
+04/05/2007,Drew Fickett,Keita Nakamura,Red,Welterweight
+04/05/2007,Kurt Pellegrino,Nate Mohr,Red,Lightweight
+04/05/2007,Kuniyoshi Hironaka,Forrest Petz,Red,Welterweight
+04/05/2007,Roan Carneiro,Rich Clementi,Red,Welterweight
+04/05/2007,Thiago Tavares,Naoyuki Kotani,Red,Lightweight
+03/03/2007,Randy Couture,Tim Sylvia,Red,UFC Heavyweight Title
+03/03/2007,Martin Kampmann,Drew McFedries,Red,Middleweight
+03/03/2007,Rich Franklin,Jason MacDonald,Red,Middleweight
+03/03/2007,Matt Hughes,Chris Lytle,Red,Welterweight
+03/03/2007,Jason Lambert,Renato Sobral,Red,Light Heavyweight
+03/03/2007,Matt Hamill,Rex Holman,Red,Light Heavyweight
+03/03/2007,Jon Fitch,Luigi Fioravanti,Red,Welterweight
+03/03/2007,Gleison Tibau,Jason Dent,Red,Lightweight
+03/03/2007,Jamie Varner,Jason Gilliam,Red,Lightweight
+02/03/2007,Anderson Silva,Travis Lutter,Red,Middleweight
+02/03/2007,Mirko Filipovic,Eddie Sanchez,Red,Heavyweight
+02/03/2007,Roger Huerta,John Halverson,Red,Lightweight
+02/03/2007,Quinton Jackson,Marvin Eastman,Red,Light Heavyweight
+02/03/2007,Patrick Cote,Scott Smith,Red,Middleweight
+02/03/2007,Terry Martin,Jorge Rivera,Red,Middleweight
+02/03/2007,Frankie Edgar,Tyson Griffin,Red,Lightweight
+02/03/2007,Lyoto Machida,Sam Hoger,Red,Light Heavyweight
+02/03/2007,Dustin Hazelett,Diego Saraiva,Red,Lightweight
+01/25/2007,Rashad Evans,Sean Salmon,Red,Light Heavyweight
+01/25/2007,Jake O'Brien,Heath Herring,Red,Heavyweight
+01/25/2007,Hermes Franca,Spencer Fisher,Red,Lightweight
+01/25/2007,Nate Marquardt,Dean Lister,Red,Middleweight
+01/25/2007,Joshua Burkman,Chad Reiner,Red,Welterweight
+01/25/2007,Ed Herman,Chris Price,Red,Middleweight
+01/25/2007,Din Thomas,Clay Guida,Red,Lightweight
+01/25/2007,Rich Clementi,Ross Pointon,Red,Welterweight
+12/30/2006,Chuck Liddell,Tito Ortiz,Red,UFC Light Heavyweight Title
+12/30/2006,Keith Jardine,Forrest Griffin,Red,Light Heavyweight
+12/30/2006,Jason MacDonald,Chris Leben,Red,Middleweight
+12/30/2006,Andrei Arlovski,Marcio Cruz,Red,Heavyweight
+12/30/2006,Michael Bisping,Eric Schafer,Red,Light Heavyweight
+12/30/2006,Thiago Alves,Tony DeSouza,Red,Welterweight
+12/30/2006,Gabriel Gonzaga,Carmelo Marrero,Red,Heavyweight
+12/30/2006,Yushin Okami,Rory Singer,Red,Middleweight
+12/30/2006,Christian Wellisch,Anthony Perosh,Red,Heavyweight
+12/13/2006,Diego Sanchez,Joe Riggs,Red,Welterweight
+12/13/2006,Josh Koscheck,Jeff Joslin,Red,Welterweight
+12/13/2006,Karo Parisyan,Drew Fickett,Red,Welterweight
+12/13/2006,Marcus Davis,Shonie Carter,Red,Welterweight
+12/13/2006,David Heath,Victor Valimaki,Red,Light Heavyweight
+12/13/2006,Alan Belcher,Jorge Santiago,Red,Middleweight
+12/13/2006,Luigi Fioravanti,Dave Menne,Red,Welterweight
+12/13/2006,Brock Larson,Keita Nakamura,Red,Welterweight
+12/13/2006,Logan Clark,Steve Byrnes,Red,Middleweight
+11/18/2006,Georges St-Pierre,Matt Hughes,Red,UFC Welterweight Title
+11/18/2006,Tim Sylvia,Jeff Monson,Red,UFC Heavyweight Title
+11/18/2006,Drew McFedries,Alessio Sakara,Red,Light Heavyweight
+11/18/2006,Brandon Vera,Frank Mir,Red,Heavyweight
+11/18/2006,Joe Stevenson,Dokonjonosuke Mishima,Red,Lightweight
+11/18/2006,Nick Diaz,Gleison Tibau,Red,Welterweight
+11/18/2006,Antoni Hardonk,Sherman Pendergarst,Red,Heavyweight
+11/18/2006,James Irvin,Hector Ramirez,Red,Light Heavyweight
+11/18/2006,Jake O'Brien,Josh Shockman,Red,Heavyweight
+11/11/2006,Matt Serra,Chris Lytle,Red,Ultimate Fighter 4 Welterweight Tournament Title
+11/11/2006,Travis Lutter,Patrick Cote,Red,Ultimate Fighter 4 Middleweight Tournament Title
+11/11/2006,Din Thomas,Rich Clementi,Red,Lightweight
+11/11/2006,Jorge Rivera,Edwin DeWees,Red,Middleweight
+11/11/2006,Pete Spratt,Jeremy Jackson,Red,Welterweight
+11/11/2006,Scott Smith,Pete Sell,Red,Middleweight
+11/11/2006,Charles McCarthy,Gideon Ray,Red,Middleweight
+11/11/2006,Martin Kampmann,Thales Leites,Red,Middleweight
+10/14/2006,Anderson Silva,Rich Franklin,Red,UFC Middleweight Title
+10/14/2006,Sean Sherk,Kenny Florian,Red,UFC Lightweight Title
+10/14/2006,Jon Fitch,Kuniyoshi Hironaka,Red,Welterweight
+10/14/2006,Carmelo Marrero,Cheick Kongo,Red,Heavyweight
+10/14/2006,Spencer Fisher,Dan Lauzon,Red,Lightweight
+10/14/2006,Yushin Okami,Kalib Starnes,Red,Middleweight
+10/14/2006,Clay Guida,Justin James,Red,Lightweight
+10/14/2006,Kurt Pellegrino,Junior Assuncao,Red,Lightweight
+10/10/2006,Tito Ortiz,Ken Shamrock,Red,Light Heavyweight
+10/10/2006,Kendall Grove,Chris Price,Red,Middleweight
+10/10/2006,Jason MacDonald,Ed Herman,Red,Middleweight
+10/10/2006,Matt Hamill,Seth Petruzelli,Red,Light Heavyweight
+10/10/2006,Nate Marquardt,Crafton Wallace,Red,Middleweight
+10/10/2006,Tony DeSouza,Dustin Hazelett,Red,Welterweight
+10/10/2006,Rory Singer,Josh Haynes,Red,Middleweight
+10/10/2006,Thiago Alves,John Alessio,Red,Welterweight
+10/10/2006,Marcus Davis,Forrest Petz,Red,Welterweight
+09/23/2006,Matt Hughes,BJ Penn,Red,UFC Welterweight Title
+09/23/2006,Mike Swick,David Loiseau,Red,Middleweight
+09/23/2006,Melvin Guillard,Gabe Ruediger,Red,Lightweight
+09/23/2006,Rashad Evans,Jason Lambert,Red,Light Heavyweight
+09/23/2006,Joe Lauzon,Jens Pulver,Red,Lightweight
+09/23/2006,Roger Huerta,Jason Dent,Red,Lightweight
+09/23/2006,Eddie Sanchez,Mario Neto,Red,Heavyweight
+09/23/2006,Jorge Gurgel,Danny Abbadi,Red,Lightweight
+09/23/2006,Tyson Griffin,David Lee,Red,Lightweight
+08/26/2006,Chuck Liddell,Renato Sobral,Red,UFC Light Heavyweight Title
+08/26/2006,Forrest Griffin,Stephan Bonnar,Red,Light Heavyweight
+08/26/2006,Nick Diaz,Josh Neer,Red,Welterweight
+08/26/2006,Cheick Kongo,Christian Wellisch,Red,Heavyweight
+08/26/2006,Hermes Franca,Jamie Varner,Red,Lightweight
+08/26/2006,Eric Schafer,Rob MacDonald,Red,Light Heavyweight
+08/26/2006,Wilson Gouveia,Wes Combs,Red,Light Heavyweight
+08/26/2006,David Heath,Cory Walmsley,Red,Light Heavyweight
+08/26/2006,Yushin Okami,Alan Belcher,Red,Middleweight
+08/17/2006,Diego Sanchez,Karo Parisyan,Red,Welterweight
+08/17/2006,Chris Leben,Jorge Santiago,Red,Middleweight
+08/17/2006,Dean Lister,Yuki Sasaki,Red,Middleweight
+08/17/2006,Josh Koscheck,Jonathan Goulet,Red,Welterweight
+08/17/2006,Martin Kampmann,Crafton Wallace,Red,Middleweight
+08/17/2006,Joe Riggs,Jason Von Flue,Red,Welterweight
+08/17/2006,Jake O'Brien,Kristof Midoux,Red,Heavyweight
+08/17/2006,Forrest Petz,Sammy Morgan,Red,Welterweight
+08/17/2006,Anthony Torres,Pat Healy,Red,Welterweight
+07/08/2006,Tim Sylvia,Andrei Arlovski,Red,UFC Heavyweight Title
+07/08/2006,Joshua Burkman,Josh Neer,Red,Welterweight
+07/08/2006,Tito Ortiz,Ken Shamrock,Red,Light Heavyweight
+07/08/2006,Frank Mir,Dan Christison,Red,Heavyweight
+07/08/2006,Joe Stevenson,Yves Edwards,Red,Lightweight
+07/08/2006,Hermes Franca,Joe Jordan,Red,Catch Weight
+07/08/2006,Jeff Monson,Anthony Perosh,Red,Heavyweight
+07/08/2006,Cheick Kongo,Gilbert Aldana,Red,Heavyweight
+07/08/2006,Drew Fickett,Kurt Pellegrino,Red,Welterweight
+06/28/2006,Jonathan Goulet,Luke Cummo,Red,Welterweight
+06/28/2006,Anderson Silva,Chris Leben,Red,Middleweight
+06/28/2006,Rashad Evans,Stephan Bonnar,Red,Light Heavyweight
+06/28/2006,Mark Hominick,Jorge Gurgel,Red,Lightweight
+06/28/2006,Josh Koscheck,Dave Menne,Red,Welterweight
+06/28/2006,Jason Lambert,Branden Lee Hinkle,Red,Light Heavyweight
+06/28/2006,Jon Fitch,Thiago Alves,Red,Welterweight
+06/28/2006,Rob MacDonald,Kristian Rothaermel,Red,Light Heavyweight
+06/28/2006,Jorge Santiago,Justin Levens,Red,Middleweight
+06/24/2006,Kenny Florian,Sam Stout,Red,Lightweight
+06/24/2006,Michael Bisping,Josh Haynes,Red,Ultimate Fighter 3 Light Heavyweight Tournament Title
+06/24/2006,Kendall Grove,Ed Herman,Red,Ultimate Fighter 3 Middleweight Tournament Title
+06/24/2006,Keith Jardine,Wilson Gouveia,Red,Light Heavyweight
+06/24/2006,Rory Singer,Ross Pointon,Red,Middleweight
+06/24/2006,Kalib Starnes,Danny Abbadi,Red,Middleweight
+06/24/2006,Luigi Fioravanti,Solomon Hutcherson,Red,Middleweight
+06/24/2006,Matt Hamill,Jesse Forbes,Red,Light Heavyweight
+06/24/2006,Mike Nickels,Wes Combs,Red,Light Heavyweight
+05/27/2006,Matt Hughes,Royce Gracie,Red,Catch Weight
+05/27/2006,Dean Lister,Alessio Sakara,Red,Light Heavyweight
+05/27/2006,Diego Sanchez,John Alessio,Red,Welterweight
+05/27/2006,Brandon Vera,Assuerio Silva,Red,Heavyweight
+05/27/2006,Mike Swick,Joe Riggs,Red,Middleweight
+05/27/2006,Jeremy Horn,Chael Sonnen,Red,Middleweight
+05/27/2006,Spencer Fisher,Matt Wiman,Red,Lightweight
+05/27/2006,Gabriel Gonzaga,Fabiano Scherner,Red,Heavyweight
+05/27/2006,Melvin Guillard,Rick Davis,Red,Lightweight
+04/15/2006,Tim Sylvia,Andrei Arlovski,Red,UFC Heavyweight Title
+04/15/2006,Sean Sherk,Nick Diaz,Red,Welterweight
+04/15/2006,Tito Ortiz,Forrest Griffin,Red,Light Heavyweight
+04/15/2006,Evan Tanner,Justin Levens,Red,Middleweight
+04/15/2006,Jeff Monson,Marcio Cruz,Red,Heavyweight
+04/15/2006,Karo Parisyan,Nick Thompson,Red,Welterweight
+04/15/2006,David Terrell,Scott Smith,Red,Middleweight
+04/15/2006,Jason Lambert,Terry Martin,Red,Light Heavyweight
+04/15/2006,Thiago Alves,Derrick Noble,Red,Welterweight
+04/06/2006,Stephan Bonnar,Keith Jardine,Red,Light Heavyweight
+04/06/2006,Rashad Evans,Sam Hoger,Red,Light Heavyweight
+04/06/2006,Josh Neer,Joe Stevenson,Red,Welterweight
+04/06/2006,Chris Leben,Luigi Fioravanti,Red,Middleweight
+04/06/2006,Luke Cummo,Jason Von Flue,Red,Welterweight
+04/06/2006,Jon Fitch,Joshua Burkman,Red,Welterweight
+04/06/2006,Dan Christison,Brad Imes,Red,Heavyweight
+04/06/2006,Josh Koscheck,Ansar Chalangov,Red,Welterweight
+04/06/2006,Chael Sonnen,Trevor Prangley,Red,Middleweight
+03/04/2006,Rich Franklin,David Loiseau,Red,UFC Middleweight Title
+03/04/2006,Mike Swick,Steve Vigneault,Red,Middleweight
+03/04/2006,Georges St-Pierre,BJ Penn,Red,Welterweight
+03/04/2006,Nate Marquardt,Joe Doerksen,Red,Middleweight
+03/04/2006,Mark Hominick,Yves Edwards,Red,Lightweight
+03/04/2006,Sam Stout,Spencer Fisher,Red,Lightweight
+03/04/2006,Jason Lambert,Rob MacDonald,Red,Light Heavyweight
+03/04/2006,Tom Murphy,Icho Larenas,Red,Heavyweight
+02/04/2006,Chuck Liddell,Randy Couture,Red,UFC Light Heavyweight Title
+02/04/2006,Brandon Vera,Justin Eilers,Red,Heavyweight
+02/04/2006,Marcio Cruz,Frank Mir,Red,Heavyweight
+02/04/2006,Renato Sobral,Mike van Arsdale,Red,Light Heavyweight
+02/04/2006,Joe Riggs,Nick Diaz,Red,Welterweight
+02/04/2006,Alessio Sakara,Elvis Sinosic,Red,Light Heavyweight
+02/04/2006,Paul Buentello,Gilbert Aldana,Red,Heavyweight
+02/04/2006,Jeff Monson,Branden Lee Hinkle,Red,Heavyweight
+02/04/2006,Keith Jardine,Mike Whitehead,Red,Light Heavyweight
+01/16/2006,Tim Sylvia,Assuerio Silva,Red,Heavyweight
+01/16/2006,Stephan Bonnar,James Irvin,Red,Light Heavyweight
+01/16/2006,Joshua Burkman,Drew Fickett,Red,Welterweight
+01/16/2006,Chris Leben,Jorge Rivera,Red,Middleweight
+01/16/2006,Josh Neer,Melvin Guillard,Red,Welterweight
+01/16/2006,Duane Ludwig,Jonathan Goulet,Red,Welterweight
+01/16/2006,Spencer Fisher,Aaron Riley,Red,Welterweight
+01/16/2006,Jason Von Flue,Alex Karalexis,Red,Welterweight
+11/19/2005,Rich Franklin,Nate Quarry,Red,UFC Middleweight Title
+11/19/2005,Gabriel Gonzaga,Kevin Jordan,Red,Heavyweight
+11/19/2005,Matt Hughes,Joe Riggs,Red,Welterweight
+11/19/2005,Georges St-Pierre,Sean Sherk,Red,Welterweight
+11/19/2005,Jeremy Horn,Trevor Prangley,Red,Middleweight
+11/19/2005,Sam Hoger,Jeff Newton,Red,Light Heavyweight
+11/19/2005,Thiago Alves,Ansar Chalangov,Red,Welterweight
+11/19/2005,Nick Thompson,Keith Wisniewski,Red,Welterweight
+11/05/2005,Diego Sanchez,Nick Diaz,Red,Welterweight
+11/05/2005,Rashad Evans,Brad Imes,Red,Ultimate Fighter 2 Heavyweight Tournament Title
+11/05/2005,Joe Stevenson,Luke Cummo,Red,Ultimate Fighter 2 Welterweight Tournament Title
+11/05/2005,Kenny Florian,Kit Cope,Red,Welterweight
+11/05/2005,Joshua Burkman,Sammy Morgan,Red,Welterweight
+11/05/2005,Melvin Guillard,Marcus Davis,Red,Welterweight
+11/05/2005,Keith Jardine,Kerry Schall,Red,Heavyweight
+10/07/2005,Andrei Arlovski,Paul Buentello,Red,UFC Heavyweight Title
+10/07/2005,Branden Lee Hinkle,Sean Gannon,Red,Heavyweight
+10/07/2005,Forrest Griffin,Elvis Sinosic,Red,Light Heavyweight
+10/07/2005,Renato Sobral,Chael Sonnen,Red,Light Heavyweight
+10/07/2005,Joe Riggs,Chris Lytle,Red,Welterweight
+10/07/2005,Jorge Rivera,Dennis Hallman,Red,Middleweight
+10/07/2005,Marcio Cruz,Keigo Kunihara,Red,Heavyweight
+10/03/2005,David Loiseau,Evan Tanner,Red,Middleweight
+10/03/2005,Chris Leben,Edwin DeWees,Red,Middleweight
+10/03/2005,Brandon Vera,Fabiano Scherner,Red,Heavyweight
+10/03/2005,Drew Fickett,Josh Koscheck,Red,Welterweight
+10/03/2005,Spencer Fisher,Thiago Alves,Red,Welterweight
+10/03/2005,Jon Fitch,Brock Larson,Red,Middleweight
+10/03/2005,Jonathan Goulet,Jay Hieron,Red,Welterweight
+08/20/2005,Chuck Liddell,Jeremy Horn,Red,UFC Light Heavyweight Title
+08/20/2005,Tim Sylvia,Tra Telligman,Red,Heavyweight
+08/20/2005,Randy Couture,Mike van Arsdale,Red,Light Heavyweight
+08/20/2005,Diego Sanchez,Brian Gassaway,Red,Welterweight
+08/20/2005,Georges St-Pierre,Frank Trigg,Red,Welterweight
+08/20/2005,Matt Lindland,Joe Doerksen,Red,Middleweight
+08/20/2005,Trevor Prangley,Travis Lutter,Red,Middleweight
+08/20/2005,James Irvin,Terry Martin,Red,Light Heavyweight
+08/06/2005,Nate Marquardt,Ivan Salaverry,Red,Middleweight
+08/06/2005,Chris Leben,Patrick Cote,Red,Middleweight
+08/06/2005,Stephan Bonnar,Sam Hoger,Red,Light Heavyweight
+08/06/2005,Nate Quarry,Pete Sell,Red,Middleweight
+08/06/2005,Josh Koscheck,Pete Spratt,Red,Welterweight
+08/06/2005,Mike Swick,Gideon Ray,Red,Middleweight
+08/06/2005,Kenny Florian,Alex Karalexis,Red,Welterweight
+08/06/2005,Drew Fickett,Josh Neer,Red,Welterweight
+06/04/2005,Andrei Arlovski,Justin Eilers,Red,UFC Interim Heavyweight Title
+06/04/2005,Karo Parisyan,Matt Serra,Red,Welterweight
+06/04/2005,Rich Franklin,Evan Tanner,Red,UFC Middleweight Title
+06/04/2005,Forrest Griffin,Bill Mahood,Red,Light Heavyweight
+06/04/2005,Paul Buentello,Kevin Jordan,Red,Heavyweight
+06/04/2005,Nate Quarry,Shonie Carter,Red,Middleweight
+06/04/2005,David Loiseau,Charles McCarthy,Red,Middleweight
+06/04/2005,Nick Diaz,Koji Oishi,Red,Welterweight
+04/16/2005,Chuck Liddell,Randy Couture,Red,UFC Light Heavyweight Title
+04/16/2005,Renato Sobral,Travis Wiuff,Red,Light Heavyweight
+04/16/2005,Matt Hughes,Frank Trigg,Red,UFC Welterweight Title
+04/16/2005,Matt Lindland,Travis Lutter,Red,Middleweight
+04/16/2005,Georges St-Pierre,Jason Miller,Red,Welterweight
+04/16/2005,Ivan Salaverry,Joe Riggs,Red,Middleweight
+04/16/2005,Joe Doerksen,Patrick Cote,Red,Middleweight
+04/16/2005,Mike van Arsdale,John Marsh,Red,Heavyweight
+04/09/2005,Rich Franklin,Ken Shamrock,Red,Light Heavyweight
+04/09/2005,Forrest Griffin,Stephan Bonnar,Red,Ultimate Fighter 1 Light Heavyweight Tournament Title
+04/09/2005,Diego Sanchez,Kenny Florian,Red,Ultimate Fighter 1 Middleweight Tournament Title
+04/09/2005,Sam Hoger,Bobby Southworth,Red,Light Heavyweight
+04/09/2005,Chris Leben,Jason Thacker,Red,Middleweight
+04/09/2005,Josh Koscheck,Chris Sanford,Red,Middleweight
+04/09/2005,Nate Quarry,Lodune Sincaid,Red,Middleweight
+04/09/2005,Mike Swick,Alex Schoenauer,Red,Middleweight
+04/09/2005,Alex Karalexis,Josh Rafferty,Red,Welterweight
+02/05/2005,Tito Ortiz,Vitor Belfort,Red,Light Heavyweight
+02/05/2005,Pete Sell,Phil Baroni,Red,Middleweight
+02/05/2005,Andrei Arlovski,Tim Sylvia,Red,UFC Interim Heavyweight Title
+02/05/2005,Evan Tanner,David Terrell,Red,UFC Middleweight Title
+02/05/2005,Paul Buentello,Justin Eilers,Red,Heavyweight
+02/05/2005,Mike Kyle,James Irvin,Red,Heavyweight
+02/05/2005,David Loiseau,Gideon Ray,Red,Middleweight
+02/05/2005,Karo Parisyan,Chris Lytle,Red,Welterweight
+02/05/2005,Nick Diaz,Drew Fickett,Red,Welterweight
+10/22/2004,Tito Ortiz,Patrick Cote,Red,Light Heavyweight
+10/22/2004,Rich Franklin,Jorge Rivera,Red,Middleweight
+10/22/2004,Matt Hughes,Georges St-Pierre,Red,UFC Welterweight Title
+10/22/2004,Frank Trigg,Renato Verissimo,Red,Welterweight
+10/22/2004,Evan Tanner,Robbie Lawler,Red,Middleweight
+10/22/2004,Ivan Salaverry,Tony Fryklund,Red,Middleweight
+10/22/2004,Travis Lutter,Marvin Eastman,Red,Light Heavyweight
+08/21/2004,Randy Couture,Vitor Belfort,Red,UFC Light Heavyweight Title
+08/21/2004,Joe Riggs,Joe Doerksen,Red,Middleweight
+08/21/2004,Chuck Liddell,Vernon White,Red,Light Heavyweight
+08/21/2004,David Terrell,Matt Lindland,Red,Middleweight
+08/21/2004,Justin Eilers,Mike Kyle,Red,Heavyweight
+08/21/2004,Chris Lytle,Ronald Jhun,Red,Welterweight
+08/21/2004,Karo Parisyan,Nick Diaz,Red,Welterweight
+08/21/2004,Yves Edwards,Josh Thomson,Red,Lightweight
+06/19/2004,Ken Shamrock,Kimo Leopoldo,Red,Heavyweight
+06/19/2004,Frank Trigg,Dennis Hallman,Red,Welterweight
+06/19/2004,Frank Mir,Tim Sylvia,Red,UFC Heavyweight Title
+06/19/2004,Matt Hughes,Renato Verissimo,Red,Welterweight
+06/19/2004,Evan Tanner,Phil Baroni,Red,Middleweight
+06/19/2004,Matt Serra,Ivan Menjivar,Red,Lightweight
+06/19/2004,Georges St-Pierre,Jay Hieron,Red,Welterweight
+06/19/2004,Trevor Prangley,Curtis Stout,Red,Middleweight
+04/02/2004,Chuck Liddell,Tito Ortiz,Red,Light Heavyweight
+04/02/2004,Chris Lytle,Tiki Ghosn,Red,Welterweight
+04/02/2004,Yves Edwards,Hermes Franca,Red,Lightweight
+04/02/2004,Andrei Arlovski,Wesley Correira,Red,Heavyweight
+04/02/2004,Nick Diaz,Robbie Lawler,Red,Welterweight
+04/02/2004,Mike Kyle,Wes Sims,Red,Heavyweight
+04/02/2004,Jonathan Wiezorek,Wade Shipp,Red,Heavyweight
+04/02/2004,Genki Sudo,Mike Brown,Red,Lightweight
+01/31/2004,Vitor Belfort,Randy Couture,Red,UFC Light Heavyweight Title
+01/31/2004,Renato Verissimo,Carlos Newton,Red,Welterweight
+01/31/2004,BJ Penn,Matt Hughes,Red,UFC Welterweight Title
+01/31/2004,Frank Mir,Wes Sims,Red,Heavyweight
+01/31/2004,Lee Murray,Jorge Rivera,Red,Middleweight
+01/31/2004,Georges St-Pierre,Karo Parisyan,Red,Welterweight
+01/31/2004,Josh Thomson,Hermes Franca,Red,Lightweight
+01/31/2004,Matt Serra,Jeff Curran,Red,Lightweight
+11/21/2003,Matt Hughes,Frank Trigg,Red,UFC Welterweight Title
+11/21/2003,Matt Lindland,Falaniko Vitale,Red,Middleweight
+11/21/2003,Wesley Correira,David Abbott,Red,Heavyweight
+11/21/2003,Evan Tanner,Phil Baroni,Red,Middleweight
+11/21/2003,Robbie Lawler,Chris Lytle,Red,Welterweight
+11/21/2003,Pedro Rizzo,Ricco Rodriguez,Red,Heavyweight
+11/21/2003,Keith Rockel,Chris Liguori,Red,Middleweight
+11/21/2003,Yves Edwards,Nick Agallar,Red,Lightweight
+09/26/2003,Randy Couture,Tito Ortiz,Red,UFC Light Heavyweight Title
+09/26/2003,Andrei Arlovski,Vladimir Matyushenko,Red,Heavyweight
+09/26/2003,Tim Sylvia,Gan McGee,Red,UFC Heavyweight Title
+09/26/2003,Jorge Rivera,David Loiseau,Red,Middleweight
+09/26/2003,Rich Franklin,Edwin DeWees,Red,Light Heavyweight
+09/26/2003,Karo Parisyan,Dave Strasser,Red,Welterweight
+09/26/2003,Josh Thomson,Gerald Strebendt,Red,Lightweight
+09/26/2003,Nick Diaz,Jeremy Jackson,Red,Welterweight
+09/26/2003,Hermes Franca,Caol Uno,Red,Lightweight
+06/06/2003,Randy Couture,Chuck Liddell,Red,UFC Interim Light Heavyweight Title
+06/06/2003,Kimo Leopoldo,David Abbott,Red,Heavyweight
+06/06/2003,Vitor Belfort,Marvin Eastman,Red,Light Heavyweight
+06/06/2003,Frank Mir,Wes Sims,Red,Heavyweight
+06/06/2003,Yves Edwards,Eddie Ruiz,Red,Lightweight
+06/06/2003,Falaniko Vitale,Matt Lindland,Red,Middleweight
+06/06/2003,Pedro Rizzo,Tra Telligman,Red,Heavyweight
+04/25/2003,Matt Hughes,Sean Sherk,Red,UFC Welterweight Title
+04/25/2003,Pete Spratt,Robbie Lawler,Red,Welterweight
+04/25/2003,Dave Strasser,Romie Aram,Red,Welterweight
+04/25/2003,Wesley Correira,Sean Alvarez,Red,Heavyweight
+04/25/2003,Rich Franklin,Evan Tanner,Red,Light Heavyweight
+04/25/2003,Duane Ludwig,Genki Sudo,Red,Lightweight
+04/25/2003,Hermes Franca,Richard Crunkilton,Red,Lightweight
+04/25/2003,David Loiseau,Mark Weir,Red,Middleweight
+02/28/2003,Tim Sylvia,Ricco Rodriguez,Red,UFC Heavyweight Title
+02/28/2003,Frank Mir,David Abbott,Red,Heavyweight
+02/28/2003,Matt Lindland,Phil Baroni,Red,Middleweight
+02/28/2003,Vladimir Matyushenko,Pedro Rizzo,Red,Heavyweight
+02/28/2003,Din Thomas,Matt Serra,Red,Lightweight
+02/28/2003,Gan McGee,Alexandre Dantas,Red,Heavyweight
+02/28/2003,Yves Edwards,Rich Clementi,Red,Lightweight
+11/22/2002,Tito Ortiz,Ken Shamrock,Red,UFC Light Heavyweight Title
+11/22/2002,Chuck Liddell,Renato Sobral,Red,Light Heavyweight
+11/22/2002,Matt Hughes,Gil Castillo,Red,UFC Welterweight Title
+11/22/2002,Carlos Newton,Pete Spratt,Red,Welterweight
+11/22/2002,Robbie Lawler,Tiki Ghosn,Red,Welterweight
+11/22/2002,Andrei Arlovski,Ian Freeman,Red,Heavyweight
+11/22/2002,Vladimir Matyushenko,Travis Wiuff,Red,Heavyweight
+11/22/2002,Phillip Miller,Mark Weir,Red,Middleweight
+09/27/2002,Ricco Rodriguez,Randy Couture,Red,UFC Heavyweight Title
+09/27/2002,Tim Sylvia,Wesley Correira,Red,Heavyweight
+09/27/2002,BJ Penn,Matt Serra,Red,Lightweight
+09/27/2002,Caol Uno,Din Thomas,Red,Lightweight
+09/27/2002,Gan McGee,Pedro Rizzo,Red,Heavyweight
+09/27/2002,Phil Baroni,Dave Menne,Red,Middleweight
+09/27/2002,Matt Lindland,Ivan Salaverry,Red,Middleweight
+09/27/2002,Sean Sherk,Benji Radach,Red,Welterweight
+07/13/2002,Matt Hughes,Carlos Newton,Red,UFC Welterweight Title
+07/13/2002,Ian Freeman,Frank Mir,Red,Heavyweight
+07/13/2002,Mark Weir,Eugene Jackson,Red,Middleweight
+07/13/2002,Genki Sudo,Leigh Remedios,Red,Lightweight
+07/13/2002,Phillip Miller,James Zikic,Red,Light Heavyweight
+07/13/2002,Renato Sobral,Elvis Sinosic,Red,Light Heavyweight
+07/13/2002,Evan Tanner,Chris Haseman,Red,Light Heavyweight
+06/22/2002,Chuck Liddell,Vitor Belfort,Red,Light Heavyweight
+06/22/2002,Benji Radach,Nick Serra,Red,Welterweight
+06/22/2002,Pete Spratt,Zach Light,Red,Welterweight
+06/22/2002,Robbie Lawler,Steve Berger,Red,Welterweight
+06/22/2002,Tony Fryklund,Rodrigo Ruas,Red,Middleweight
+06/22/2002,Yves Edwards,Joao Pierini,Red,Lightweight
+05/10/2002,Murilo Bustamante,Matt Lindland,Red,UFC Middleweight Title
+05/10/2002,Ricco Rodriguez,Tsuyoshi Kohsaka,Red,Heavyweight
+05/10/2002,BJ Penn,Paul Creighton,Red,Lightweight
+05/10/2002,Phil Baroni,Amar Suloev,Red,Middleweight
+05/10/2002,Caol Uno,Yves Edwards,Red,Lightweight
+05/10/2002,Ivan Salaverry,Andrei Semenov,Red,Middleweight
+05/10/2002,Robbie Lawler,Aaron Riley,Red,Welterweight
+03/22/2002,Josh Barnett,Randy Couture,Red,UFC Heavyweight Title
+03/22/2002,Pedro Rizzo,Andrei Arlovski,Red,Heavyweight
+03/22/2002,Matt Hughes,Hayato Sakurai,Red,UFC Welterweight Title
+03/22/2002,Matt Lindland,Pat Miletich,Red,Middleweight
+03/22/2002,Evan Tanner,Elvis Sinosic,Red,Light Heavyweight
+03/22/2002,Frank Mir,Pete Williams,Red,Heavyweight
+03/22/2002,Matt Serra,Kelly Dullanty,Red,Lightweight
+03/22/2002,Sean Sherk,Jutaro Nakao,Red,Welterweight
+01/11/2002,Jens Pulver,BJ Penn,Red,UFC Lightweight Title
+01/11/2002,Ricco Rodriguez,Jeff Monson,Red,Heavyweight
+01/11/2002,Murilo Bustamante,Dave Menne,Red,UFC Middleweight Title
+01/11/2002,Chuck Liddell,Amar Suloev,Red,Light Heavyweight
+01/11/2002,Andrei Semenov,Ricardo Almeida,Red,Middleweight
+01/11/2002,Kevin Randleman,Renato Sobral,Red,Light Heavyweight
+01/11/2002,Gil Castillo,Chris Brennan,Red,Welterweight
+01/11/2002,Eugene Jackson,Keith Rockel,Red,Middleweight
+11/02/2001,Randy Couture,Pedro Rizzo,Red,UFC Heavyweight Title
+11/02/2001,Ricco Rodriguez,Pete Williams,Red,Heavyweight
+11/02/2001,Matt Hughes,Carlos Newton,Red,UFC Welterweight Title
+11/02/2001,BJ Penn,Caol Uno,Red,Lightweight
+11/02/2001,Josh Barnett,Bobby Hoffman,Red,Heavyweight
+11/02/2001,Evan Tanner,Homer Moore,Red,Light Heavyweight
+11/02/2001,Matt Lindland,Phil Baroni,Red,Middleweight
+11/02/2001,Frank Mir,Roberto Traven,Red,Heavyweight
+09/28/2001,Tito Ortiz,Vladimir Matyushenko,Red,UFC Light Heavyweight Title
+09/28/2001,Jens Pulver,Dennis Hallman,Red,UFC Lightweight Title
+09/28/2001,Chuck Liddell,Murilo Bustamante,Red,Light Heavyweight
+09/28/2001,Matt Serra,Yves Edwards,Red,Welterweight
+09/28/2001,Dave Menne,Gil Castillo,Red,UFC Middleweight Title
+09/28/2001,Jutaro Nakao,Tony DeSouza,Red,Welterweight
+09/28/2001,Ricardo Almeida,Eugene Jackson,Red,Middleweight
+09/28/2001,Din Thomas,Fabiano Iha,Red,Lightweight
+06/29/2001,Tito Ortiz,Elvis Sinosic,Red,UFC Light Heavyweight Title
+06/29/2001,BJ Penn,Din Thomas,Red,Lightweight
+06/29/2001,Josh Barnett,Semmy Schilt,Red,Heavyweight
+06/29/2001,Pat Miletich,Shonie Carter,Red,Welterweight
+06/29/2001,Caol Uno,Fabiano Iha,Red,Lightweight
+06/29/2001,Vladimir Matyushenko,Yuki Kondo,Red,Light Heavyweight
+06/29/2001,Ricco Rodriguez,Andrei Arlovski,Red,Heavyweight
+06/29/2001,Tony DeSouza,Paul Rodriguez,Red,Welterweight
+05/04/2001,Randy Couture,Pedro Rizzo,Red,UFC Heavyweight Title
+05/04/2001,Carlos Newton,Pat Miletich,Red,UFC Welterweight Title
+05/04/2001,Chuck Liddell,Kevin Randleman,Red,Light Heavyweight
+05/04/2001,Shonie Carter,Matt Serra,Red,Welterweight
+05/04/2001,Semmy Schilt,Pete Williams,Red,Heavyweight
+05/04/2001,Matt Lindland,Ricardo Almeida,Red,Light Heavyweight
+05/04/2001,BJ Penn,Joey Gilbert,Red,Lightweight
+05/04/2001,Tony DeSouza,Steve Berger,Red,Welterweight
+02/23/2001,Tito Ortiz,Evan Tanner,Red,UFC Light Heavyweight Title
+02/23/2001,Jens Pulver,Caol Uno,Red,UFC Lightweight Title
+02/23/2001,Fabiano Iha,Phil Johns,Red,Welterweight
+02/23/2001,Elvis Sinosic,Jeremy Horn,Red,Middleweight
+02/23/2001,Pedro Rizzo,Josh Barnett,Red,Heavyweight
+02/23/2001,Phil Baroni,Curtis Stout,Red,Middleweight
+02/23/2001,Sean Sherk,Tiki Ghosn,Red,Welterweight
+12/16/2000,Tito Ortiz,Yuki Kondo,Red,UFC Light Heavyweight Title
+12/16/2000,Pat Miletich,Kenichi Yamamoto,Red,UFC Welterweight Title
+12/16/2000,Matt Lindland,Yoji Anjo,Red,Middleweight
+12/16/2000,Fabiano Iha,Daiju Takase,Red,Welterweight
+12/16/2000,Evan Tanner,Lance Gibson,Red,Middleweight
+12/16/2000,Dennis Hallman,Matt Hughes,Red,Welterweight
+12/16/2000,Chuck Liddell,Jeff Monson,Red,Middleweight
+11/17/2000,Randy Couture,Kevin Randleman,Red,UFC Heavyweight Title
+11/17/2000,Renato Sobral,Maurice Smith,Red,Heavyweight
+11/17/2000,Josh Barnett,Gan McGee,Red,Super Heavyweight
+11/17/2000,Andrei Arlovski,Aaron Brink,Red,Heavyweight
+11/17/2000,Jens Pulver,John Lewis,Red,Lightweight
+11/17/2000,Mark Hughes,Alex Stiebling,Red,Middleweight
+11/17/2000,Ben Earwood,Chris Lytle,Red,Welterweight
+09/22/2000,Pedro Rizzo,Dan Severn,Red,Heavyweight
+09/22/2000,Maurice Smith,Bobby Hoffman,Red,Heavyweight
+09/22/2000,Jeremy Horn,Eugene Jackson,Red,Middleweight
+09/22/2000,Fabiano Iha,Laverne Clark,Red,Welterweight
+09/22/2000,Yuki Kondo,Alexandre Dantas,Red,Middleweight
+09/22/2000,Ian Freeman,Tedd Williams,Red,Heavyweight
+09/22/2000,Jeff Monson,Tim Lajcik,Red,Heavyweight
+06/09/2000,Kevin Randleman,Pedro Rizzo,Red,UFC Heavyweight Title
+06/09/2000,Tyrone Roberts,David Dodd,Red,Middleweight
+06/09/2000,Pat Miletich,John Alessio,Red,UFC Welterweight Title
+06/09/2000,Amaury Bitetti,Alex Andrade,Red,Middleweight
+06/09/2000,Matt Hughes,Marcelo Aguiar,Red,Welterweight
+06/09/2000,Jens Pulver,Joao Roque,Red,Lightweight
+06/09/2000,Ian Freeman,Nate Schroeder,Red,Heavyweight
+06/09/2000,Shonie Carter,Adrian Serrano,Red,Welterweight
+04/14/2000,Tito Ortiz,Wanderlei Silva,Red,UFC Light Heavyweight Title
+04/14/2000,Murilo Bustamante,Yoji Anjo,Red,Middleweight
+04/14/2000,Sanae Kikuta,Eugene Jackson,Red,Middleweight
+04/14/2000,Ron Waterman,Satoshi Honma,Red,Heavyweight
+04/14/2000,Ikuhisa Minowa,Joe Slick,Red,Middleweight
+04/14/2000,Laverne Clark,Koji Oishi,Red,Lightweight
+03/10/2000,Tedd Williams,Steve Judson,Red,Heavyweight
+03/10/2000,Lance Gibson,Jermaine Andre,Red,Middleweight
+03/10/2000,Dave Menne,Fabiano Iha,Red,Lightweight
+03/10/2000,Bob Cook,Tiki Ghosn,Red,Lightweight
+03/10/2000,Jens Pulver,David Velasquez,Red,Lightweight
+03/10/2000,Scott Adams,Ian Freeman,Red,Heavyweight
+03/10/2000,Shonie Carter,Brad Gumm,Red,Lightweight
+11/19/1999,Kevin Randleman,Pete Williams,Red,UFC Heavyweight Title
+11/19/1999,Pedro Rizzo,Tsuyoshi Kohsaka,Red,Heavyweight
+11/19/1999,Kenichi Yamamoto,Katsuhisa Fujii,Red,Ultimate Japan 2 Heavyweight Tournament Title
+11/19/1999,Joe Slick,Jason DeLucia,Red,Middleweight
+11/19/1999,Eugene Jackson,Keiichiro Yamamiya,Red,Middleweight
+11/19/1999,Kenichi Yamamoto,Daiju Takase,Red,Open Weight
+11/19/1999,Katsuhisa Fujii,Masutatsu Yano,Red,Open Weight
+09/24/1999,Frank Shamrock,Tito Ortiz,Red,UFC Light Heavyweight Title
+09/24/1999,Jeremy Horn,Jason Godsey,Red,Heavyweight
+09/24/1999,Brad Kohler,Steve Judson,Red,Heavyweight
+09/24/1999,Chuck Liddell,Paul Jones,Red,Middleweight
+09/24/1999,Matt Hughes,Valeri Ignatov,Red,Lightweight
+09/24/1999,John Lewis,Lowell Anderson,Red,Middleweight
+07/16/1999,Maurice Smith,Marco Ruas,Red,Heavyweight
+07/16/1999,Pat Miletich,Andre Pederneiras,Red,UFC Welterweight Title
+07/16/1999,Jeremy Horn,Daiju Takase,Red,Middleweight
+07/16/1999,Paul Jones,Flavio Luiz Moura,Red,Middleweight
+07/16/1999,Tsuyoshi Kohsaka,Tim Lajcik,Red,Heavyweight
+07/16/1999,Eugene Jackson,Royce Alger,Red,Middleweight
+07/16/1999,Andre Roberts,Ron Waterman,Red,Heavyweight
+07/16/1999,Travis Fulton,David Dodd,Red,Heavyweight
+05/07/1999,Bas Rutten,Kevin Randleman,Red,UFC Heavyweight Title
+05/07/1999,Pedro Rizzo,Tra Telligman,Red,Heavyweight
+05/07/1999,Pete Williams,Travis Fulton,Red,Heavyweight
+05/07/1999,Wanderlei Silva,Tony Petarra,Red,Middleweight
+05/07/1999,Marcelo Mello,David Roberts,Red,Lightweight
+05/07/1999,Laverne Clark,Fabiano Iha,Red,Lightweight
+05/07/1999,Ron Waterman,Chris Condo,Red,Heavyweight
+03/05/1999,Tito Ortiz,Guy Mezger,Red,Middleweight
+03/05/1999,Gary Goodridge,Andre Roberts,Red,Heavyweight
+03/05/1999,Jeremy Horn,Chuck Liddell,Red,Middleweight
+03/05/1999,Kevin Randleman,Maurice Smith,Red,Heavyweight
+03/05/1999,Evan Tanner,Valeri Ignatov,Red,Middleweight
+03/05/1999,Pete Williams,Jason Godsey,Red,Heavyweight
+03/05/1999,Sione Latu,Joey Roberts,Red,Heavyweight
+01/08/1999,Bas Rutten,Tsuyoshi Kohsaka,Red,Heavyweight
+01/08/1999,Pat Miletich,Jorge Patino,Red,UFC Welterweight Title
+01/08/1999,Pedro Rizzo,Mark Coleman,Red,Heavyweight
+01/08/1999,Tito Ortiz,Jerry Bohlander,Red,Middleweight
+01/08/1999,Mikey Burnett,Townsend Saunders,Red,Lightweight
+01/08/1999,Evan Tanner,Darrel Gholar,Red,Middleweight
+01/08/1999,Laverne Clark,Frank Caracci,Red,Lightweight
+10/16/1998,Frank Shamrock,John Lober,Red,UFC Light Heavyweight Title
+10/16/1998,Vitor Belfort,Wanderlei Silva,Red,Middleweight
+10/16/1998,Pedro Rizzo,David Abbott,Red,Heavyweight
+10/16/1998,Pat Miletich,Mikey Burnett,Red,UFC Welterweight Title
+10/16/1998,Tsuyoshi Kohsaka,Pete Williams,Red,Heavyweight
+10/16/1998,Ebenezer Fontes Braga,Jeremy Horn,Red,Middleweight
+10/16/1998,Tulio Palhares,Adriano Santos,Red,Middleweight
+10/16/1998,Cesar Marscucci,Paulo Santos,Red,Lightweight
+05/15/1998,Frank Shamrock,Jeremy Horn,Red,UFC Light Heavyweight Title
+05/15/1998,Pete Williams,Mark Coleman,Red,Heavyweight
+05/15/1998,Dan Henderson,Carlos Newton,Red,UFC 17 Middleweight Tournament Title
+05/15/1998,David Abbott,Hugo Duarte,Red,Heavyweight
+05/15/1998,Mike van Arsdale,Joe Pardo,Red,Heavyweight
+05/15/1998,Carlos Newton,Bob Gilstrap,Red,Middleweight
+05/15/1998,Dan Henderson,Allan Goes,Red,Middleweight
+05/15/1998,Andre Roberts,Harry Moskowitz,Red,Heavyweight
+05/15/1998,Chuck Liddell,Noe Hernandez,Red,Middleweight
+03/13/1998,Frank Shamrock,Igor Zinoviev,Red,UFC Light Heavyweight Title
+03/13/1998,Tsuyoshi Kohsaka,Kimo Leopoldo,Red,Heavyweight
+03/13/1998,Pat Miletich,Chris Brennan,Red,Lightweight
+03/13/1998,Jerry Bohlander,Kevin Jackson,Red,Middleweight
+03/13/1998,Pat Miletich,Townsend Saunders,Red,Lightweight
+03/13/1998,Mikey Burnett,Eugenio Tadeu,Red,Lightweight
+03/13/1998,Chris Brennan,Courtney Turner,Red,Lightweight
+03/13/1998,Laverne Clark,Josh Stuart,Red,Lightweight
+12/21/1997,Randy Couture,Maurice Smith,Red,UFC Heavyweight Title
+12/21/1997,Kazushi Sakuraba,Marcus Silveira,Red,Ultimate Japan Heavyweight Tournament Title
+12/21/1997,Vitor Belfort,Joe Charles,Red,Heavyweight
+12/21/1997,Frank Shamrock,Kevin Jackson,Red,UFC Light Heavyweight Title
+12/21/1997,David Abbott,Yoji Anjo,Red,Heavyweight
+12/21/1997,Tra Telligman,Brad Kohler,Red,Heavyweight
+10/17/1997,Maurice Smith,David Abbott,Red,UFC Heavyweight Title
+10/17/1997,Mark Kerr,Dwayne Cason,Red,UFC 15 Heavyweight Tournament Title
+10/17/1997,Randy Couture,Vitor Belfort,Red,Heavyweight
+10/17/1997,Dave Beneteau,Carlos Barreto,Red,Heavyweight
+10/17/1997,Mark Kerr,Greg Stott,Red,Heavyweight
+10/17/1997,Dwayne Cason,Houston Dorr,Red,Heavyweight
+10/17/1997,Alex Hunter,Harry Moskowitz,Red,Heavyweight
+07/27/1997,Maurice Smith,Mark Coleman,Red,UFC Heavyweight Title
+07/27/1997,Mark Kerr,Dan Bobish,Red,UFC 14 Heavyweight Tournament Title
+07/27/1997,Kevin Jackson,Tony Fryklund,Red,UFC 14 Middleweight Tournament Title
+07/27/1997,Dan Bobish,Brian Johnston,Red,Heavyweight
+07/27/1997,Mark Kerr,Moti Horenstein,Red,Heavyweight
+07/27/1997,Kevin Jackson,Todd Butler,Red,Lightweight
+07/27/1997,Joe Moreira,Yuri Vaulin,Red,Lightweight
+07/27/1997,Alex Hunter,Sam Fulton,Red,Heavyweight
+07/27/1997,Tony Fryklund,Donnie Chappell,Red,Lightweight
+05/30/1997,Vitor Belfort,David Abbott,Red,Heavyweight
+05/30/1997,Randy Couture,Steven Graham,Red,UFC 13 Heavyweight Tournament Title
+05/30/1997,Guy Mezger,Tito Ortiz,Red,UFC 13 Lightweight Tournament Title
+05/30/1997,Randy Couture,Tony Halme,Red,Heavyweight
+05/30/1997,Steven Graham,Dmitri Stepanov,Red,Heavyweight
+05/30/1997,Enson Inoue,Royce Alger,Red,Lightweight
+05/30/1997,Guy Mezger,Christophe Leninger,Red,Lightweight
+05/30/1997,Jack Nilson,Saeed Hosseini,Red,Lightweight
+05/30/1997,Tito Ortiz,Wes Albritton,Red,Lightweight
+02/07/1997,Mark Coleman,Dan Severn,Red,UFC Heavyweight Title
+02/07/1997,Vitor Belfort,Scott Ferrozzo,Red,Heavyweight
+02/07/1997,Jerry Bohlander,Nick Sanzo,Red,Lightweight
+02/07/1997,Vitor Belfort,Tra Telligman,Red,Heavyweight
+02/07/1997,Scott Ferrozzo,Jim Mullen,Red,Heavyweight
+02/07/1997,Yoshiki Takahashi,Wallid Ismail,Red,Lightweight
+02/07/1997,Jerry Bohlander,Rainy Martinez,Red,Lightweight
+02/07/1997,Justin Martin,Eric Martin,Red,Heavyweight
+02/07/1997,Nick Sanzo,Jackie Lee,Red,Lightweight
+12/07/1996,Don Frye,David Abbott,Red,Ultimate Ultimate '96 Tournament Title
+12/07/1996,David Abbott,Steve Nelmark,Red,Open Weight
+12/07/1996,Don Frye,Mark Hall,Red,Open Weight
+12/07/1996,Ken Shamrock,Brian Johnston,Red,Open Weight
+12/07/1996,Kimo Leopoldo,Paul Varelans,Red,Open Weight
+12/07/1996,David Abbott,Cal Worsham,Red,Open Weight
+12/07/1996,Don Frye,Gary Goodridge,Red,Open Weight
+12/07/1996,Tai Bowden,Jack Nilson,Red,Open Weight
+12/07/1996,Steve Nelmark,Marcus Bossett,Red,Open Weight
+12/07/1996,Mark Hall,Felix Lee Mitchell,Red,Open Weight
+09/20/1996,Scott Ferrozzo,David Abbott,Red,Open Weight
+09/20/1996,Mark Coleman,Brian Johnston,Red,Open Weight
+09/20/1996,Jerry Bohlander,Fabio Gurgel,Red,Open Weight
+09/20/1996,David Abbott,Sam Adkins,Red,Open Weight
+09/20/1996,Brian Johnston,Reza Nasri,Red,Open Weight
+09/20/1996,Mark Coleman,Julian Sanchez,Red,Open Weight
+09/20/1996,Roberto Traven,Dave Berry,Red,Open Weight
+09/20/1996,Scott Ferrozzo,Sam Fulton,Red,Open Weight
+07/12/1996,Mark Coleman,Don Frye,Red,UFC 10 Tournament Title
+07/12/1996,Mark Coleman,Gary Goodridge,Red,Open Weight
+07/12/1996,Don Frye,Brian Johnston,Red,Open Weight
+07/12/1996,Gary Goodridge,John Campetella,Red,Open Weight
+07/12/1996,Mark Coleman,Moti Horenstein,Red,Open Weight
+07/12/1996,Brian Johnston,Scott Fiedler,Red,Open Weight
+07/12/1996,Don Frye,Mark Hall,Red,Open Weight
+07/12/1996,Sam Adkins,Felix Lee Mitchell,Red,Open Weight
+07/12/1996,Geza Kalman,Dieusel Berto,Red,Open Weight
+05/17/1996,Dan Severn,Ken Shamrock,Red,UFC Superfight Championship
+05/17/1996,Don Frye,Amaury Bitetti,Red,Open Weight
+05/17/1996,Mark Hall,Koji Kitao,Red,Open Weight
+05/17/1996,Mark Schultz,Gary Goodridge,Red,Open Weight
+05/17/1996,Rafael Carino,Matt Andersen,Red,Open Weight
+05/17/1996,Cal Worsham,Zane Frazier,Red,Open Weight
+05/17/1996,Steve Nelmark,Tai Bowden,Red,Open Weight
+02/16/1996,Don Frye,Gary Goodridge,Red,UFC 8 Tournament Title
+02/16/1996,Ken Shamrock,Kimo Leopoldo,Red,UFC Superfight Championship
+02/16/1996,Gary Goodridge,Jerry Bohlander,Red,Open Weight
+02/16/1996,Don Frye,Sam Adkins,Red,Open Weight
+02/16/1996,Gary Goodridge,Paul Herrera,Red,Open Weight
+02/16/1996,Jerry Bohlander,Scott Ferrozzo,Red,Open Weight
+02/16/1996,Paul Varelans,Joe Moreira,Red,Open Weight
+02/16/1996,Don Frye,Thomas Ramirez,Red,Open Weight
+02/16/1996,Sam Adkins,Keith Mielke,Red,Open Weight
+12/16/1995,Dan Severn,Oleg Taktarov,Red,Ultimate Ultimate '95 Tournament Title
+12/16/1995,Oleg Taktarov,Marco Ruas,Red,Open Weight
+12/16/1995,Dan Severn,David Abbott,Red,Open Weight
+12/16/1995,Oleg Taktarov,Dave Beneteau,Red,Open Weight
+12/16/1995,Marco Ruas,Keith Hackney,Red,Open Weight
+12/16/1995,Dan Severn,Paul Varelans,Red,Open Weight
+12/16/1995,David Abbott,Steve Jennum,Red,Open Weight
+12/16/1995,Mark Hall,Trent Jenkins,Red,Open Weight
+12/16/1995,Joe Charles,Scott Bessac,Red,Open Weight
+09/08/1995,Marco Ruas,Paul Varelans,Red,UFC 7 Tournament Title
+09/08/1995,Marco Ruas,Remco Pardoel,Red,Open Weight
+09/08/1995,Paul Varelans,Mark Hall,Red,Open Weight
+09/08/1995,Marco Ruas,Larry Cureton,Red,Open Weight
+09/08/1995,Remco Pardoel,Ryan Parker,Red,Open Weight
+09/08/1995,Mark Hall,Harold Howard,Red,Open Weight
+09/08/1995,Paul Varelans,Gerry Harris,Red,Open Weight
+09/08/1995,Scott Bessac,David Hood,Red,Open Weight
+09/08/1995,Onassis Parungao,Francesco Maturi,Red,Open Weight
+09/08/1995,Joel Sutton,Geza Kalman,Red,Open Weight
+07/14/1995,Oleg Taktarov,David Abbott,Red,UFC 6 Tournament Title
+07/14/1995,Ken Shamrock,Dan Severn,Red,UFC Superfight Championship
+07/14/1995,Oleg Taktarov,Anthony Macias,Red,Open Weight
+07/14/1995,David Abbott,Paul Varelans,Red,Open Weight
+07/14/1995,Oleg Taktarov,Dave Beneteau,Red,Open Weight
+07/14/1995,Patrick Smith,Rudyard Moncayo,Red,Open Weight
+07/14/1995,Paul Varelans,Cal Worsham,Red,Open Weight
+07/14/1995,David Abbott,John Matua,Red,Open Weight
+07/14/1995,Anthony Macias,He-Man Gipson,Red,Open Weight
+07/14/1995,Joel Sutton,Jack McGlaughlin,Red,Open Weight
+04/07/1995,Dan Severn,Dave Beneteau,Red,UFC 5 Tournament Title
+04/07/1995,Dan Severn,Oleg Taktarov,Red,Open Weight
+04/07/1995,Dave Beneteau,Todd Medina,Red,Open Weight
+04/07/1995,Dan Severn,Joe Charles,Red,Open Weight
+04/07/1995,Oleg Taktarov,Ernie Verdicia,Red,Open Weight
+04/07/1995,Todd Medina,Larry Cureton,Red,Open Weight
+04/07/1995,Jon Hess,Andy Anderson,Red,Open Weight
+04/07/1995,Guy Mezger,John Dowdy,Red,Open Weight
+04/07/1995,Dave Beneteau,Asbel Cancio,Red,Open Weight
+12/16/1994,Royce Gracie,Dan Severn,Red,UFC 4 Tournament Title
+12/16/1994,Dan Severn,Marcus Bossett,Red,Open Weight
+12/16/1994,Royce Gracie,Keith Hackney,Red,Open Weight
+12/16/1994,Dan Severn,Anthony Macias,Red,Open Weight
+12/16/1994,Steve Jennum,Melton Bowen,Red,Open Weight
+12/16/1994,Keith Hackney,Joe Son,Red,Open Weight
+12/16/1994,Royce Gracie,Ron van Clief,Red,Open Weight
+12/16/1994,Guy Mezger,Jason Fairn,Red,Open Weight
+12/16/1994,Marcus Bossett,Eldo Xavier Dias,Red,Open Weight
+12/16/1994,Joe Charles,Kevin Rosier,Red,Open Weight
+09/09/1994,Steve Jennum,Harold Howard,Red,UFC 3 Tournament Title
+09/09/1994,Ken Shamrock,Felix Lee Mitchell,Red,Open Weight
+09/09/1994,Royce Gracie,Kimo Leopoldo,Red,Open Weight
+09/09/1994,Harold Howard,Roland Payne,Red,Open Weight
+09/09/1994,Ken Shamrock,Christophe Leninger,Red,Open Weight
+09/09/1994,Keith Hackney,Emmanuel Yarborough,Red,Open Weight
+03/11/1994,Royce Gracie,Patrick Smith,Red,UFC 2 Tournament Title
+03/11/1994,Royce Gracie,Remco Pardoel,Red,Open Weight
+03/11/1994,Patrick Smith,Johnny Rhodes,Red,Open Weight
+03/11/1994,Royce Gracie,Jason DeLucia,Red,Open Weight
+03/11/1994,Remco Pardoel,Orlando Wiet,Red,Open Weight
+03/11/1994,Johnny Rhodes,Fred Ettish,Red,Open Weight
+03/11/1994,Patrick Smith,Scott Morris,Red,Open Weight
+03/11/1994,Royce Gracie,Minoki Ichihara,Red,Open Weight
+03/11/1994,Jason DeLucia,Scott Baker,Red,Open Weight
+03/11/1994,Remco Pardoel,Alberta Cerra Leon,Red,Open Weight
+03/11/1994,Orlando Wiet,Robert Lucarelli,Red,Open Weight
+03/11/1994,Frank Hamaker,Thaddeus Luster,Red,Open Weight
+03/11/1994,Johnny Rhodes,David Levicki,Red,Open Weight
+03/11/1994,Patrick Smith,Ray Wizard,Red,Open Weight
+03/11/1994,Scott Morris,Sean Daugherty,Red,Open Weight

--- a/dataset/preprocessed/event_list_shuffled.csv
+++ b/dataset/preprocessed/event_list_shuffled.csv
@@ -1,0 +1,7440 @@
+date,r_fighter,b_fighter,winner,weight_class
+03/23/2024,Amanda Ribas,Rose Namajunas,Blue,Women's Flyweight
+03/23/2024,Justin Tafa,Karl Williams,Blue,Heavyweight
+03/23/2024,Edmen Shahbazyan,AJ Dobson,Red,Middleweight
+03/23/2024,Payton Talbott,Cameron Saaiman,Red,Bantamweight
+03/23/2024,Youssef Zalal,Billy Quarantillo,Red,Featherweight
+03/23/2024,Fernando Padilla,Luis Pajuelo,Red,Featherweight
+03/23/2024,Kurt Holobaugh,Trey Ogden,Blue,Lightweight
+03/23/2024,Julian Erosa,Ricardo Ramos,Red,Featherweight
+03/23/2024,Cody Gibson,Miles Johns,Blue,Bantamweight
+03/23/2024,Jarno Errens,Steven Nguyen,Red,Featherweight
+03/23/2024,Daria Zhelezniakova,Montserrat Rendon,Red,Women's Bantamweight
+03/23/2024,Igor Severino,Andre Lima,Blue,Flyweight
+03/23/2024,Mohammed Usman,Mick Parkin,Blue,Heavyweight
+03/16/2024,Marcin Tybura,Tai Tuivasa,Red,Heavyweight
+03/16/2024,Ovince Saint Preux,Kennedy Nzechukwu,Red,Light Heavyweight
+03/16/2024,Isaac Dulgarian,Christian Rodriguez,Blue,Featherweight
+03/16/2024,Pannie Kianzad,Macy Chiasson,Blue,Women's Bantamweight
+03/16/2024,Gerald Meerschaert,Bryan Barberena,Red,Middleweight
+03/16/2024,Natan Levy,Mike Davis,Blue,Lightweight
+03/16/2024,Chelsea Chandler,Josiane Nunes,Red,Women's Bantamweight
+03/16/2024,Jafel Filho,Ode Osbourne,Red,Flyweight
+03/16/2024,Josh Culibao,Danny Silva,Blue,Featherweight
+03/16/2024,Jaqueline Amorim,Cory McKenna,Red,Women's Strawweight
+03/16/2024,Mitch Ramirez,Thiago Moises,Blue,Lightweight
+03/16/2024,Chad Anheliger,Charalampos Grigoriou,Red,Bantamweight
+03/09/2024,Sean O'Malley,Marlon Vera,Red,UFC Bantamweight Title
+03/09/2024,Dustin Poirier,Benoit Saint Denis,Red,Lightweight
+03/09/2024,Kevin Holland,Michael Page,Blue,Welterweight
+03/09/2024,Jack Della Maddalena,Gilbert Burns,Red,Welterweight
+03/09/2024,Song Yadong,Petr Yan,Blue,Bantamweight
+03/09/2024,Curtis Blaydes,Jailton Almeida,Red,Heavyweight
+03/09/2024,Maycee Barber,Katlyn Cerminara,Red,Women's Flyweight
+03/09/2024,Rafael Dos Anjos,Mateusz Gamrot,Blue,Lightweight
+03/09/2024,Pedro Munhoz,Kyler Phillips,Blue,Bantamweight
+03/09/2024,Philipe Lins,Ion Cutelaba,Red,Light Heavyweight
+03/09/2024,Michal Oleksiejczuk,Michel Pereira,Blue,Middleweight
+03/09/2024,Josh Parisian,Robelis Despaigne,Blue,Heavyweight
+03/09/2024,CJ Vergara,Asu Almabayev,Blue,Flyweight
+03/09/2024,Joanne Wood,Maryna Moroz,Red,Women's Flyweight
+03/02/2024,Shamil Gaziev,Jairzinho Rozenstruik,Blue,Heavyweight
+03/02/2024,Vitor Petrino,Tyson Pedro,Red,Light Heavyweight
+03/02/2024,Alex Perez,Muhammad Mokaev,Blue,Flyweight
+03/02/2024,Bekzat Almakhan,Umar Nurmagomedov,Blue,Bantamweight
+03/02/2024,Matt Schnell,Steve Erceg,Blue,Flyweight
+03/02/2024,Eryk Anders,Jamie Pickett,Red,Middleweight
+03/02/2024,Benardo Sopaj,Vinicius Oliveira,Blue,Bantamweight
+03/02/2024,Aiemann Zahabi,Javid Basharat,Red,Bantamweight
+03/02/2024,Christian Leroy Duncan,Claudio Ribeiro,Red,Middleweight
+03/02/2024,Ludovit Klein,AJ Cunningham,Red,Lightweight
+03/02/2024,Abdul-Kareem Al-Selwady,Loik Radzhabov,Blue,Lightweight
+02/24/2024,Brandon Royval,Brandon Moreno,Red,Flyweight
+02/24/2024,Brian Ortega,Yair Rodriguez,Red,Featherweight
+02/24/2024,Daniel Zellhuber,Francisco Prado,Red,Lightweight
+02/24/2024,Yazmin Jauregui,Sam Hughes,Red,Women's Strawweight
+02/24/2024,Manuel Torres,Chris Duncan,Red,Lightweight
+02/24/2024,Cristian Quinonez,Raoni Barcelos,Blue,Bantamweight
+02/24/2024,Jesus Aguilar,Mateus Mendonca,Red,Flyweight
+02/24/2024,Daniel Lacerda,Edgar Chairez,Blue,Flyweight
+02/24/2024,Fares Ziam,Claudio Puelles,Red,Lightweight
+02/24/2024,Ronaldo Rodriguez,Denys Bondar,Red,Flyweight
+02/24/2024,Felipe dos Santos,Victor Altamirano,Red,Flyweight
+02/24/2024,Muhammad Naimov,Erik Silva,Red,Featherweight
+02/17/2024,Alexander Volkanovski,Ilia Topuria,Blue,UFC Featherweight Title
+02/17/2024,Robert Whittaker,Paulo Costa,Red,Middleweight
+02/17/2024,Ian Machado Garry,Geoff Neal,Red,Welterweight
+02/17/2024,Henry Cejudo,Merab Dvalishvili,Blue,Bantamweight
+02/17/2024,Roman Kopylov,Anthony Hernandez,Blue,Middleweight
+02/17/2024,Amanda Lemos,Mackenzie Dern,Red,Women's Strawweight
+02/17/2024,Marcos Rogerio de Lima,Junior Tafa,Red,Heavyweight
+02/17/2024,Rinya Nakamura,Carlos Vera,Red,Bantamweight
+02/17/2024,Zhang Mingyang,Brendson Ribeiro,Red,Light Heavyweight
+02/17/2024,Danny Barlow,Josh Quinlan,Red,Welterweight
+02/17/2024,Oban Elliott,Val Woodburn,Red,Welterweight
+02/17/2024,Miranda Maverick,Andrea Lee,Red,Women's Flyweight
+02/10/2024,Joe Pyfer,Jack Hermansson,Blue,Middleweight
+02/10/2024,Andre Fili,Dan Ige,Blue,Featherweight
+02/10/2024,Ihor Potieria,Robert Bryczek,Red,Middleweight
+02/10/2024,Gregory Rodrigues,Brad Tavares,Red,Middleweight
+02/10/2024,Michael Johnson,Darrius Flowers,Red,Lightweight
+02/10/2024,Armen Petrosyan,Rodolfo Vieira,Blue,Middleweight
+02/10/2024,Trevin Giles,Carlos Prates,Blue,Welterweight
+02/10/2024,Timmy Cuamba,Bolaji Oki,Blue,Lightweight
+02/10/2024,Loma Lookboonmee,Bruna Brasil,Red,Women's Strawweight
+02/10/2024,Marcin Prachnio,Devin Clark,Red,Light Heavyweight
+02/10/2024,Max Griffin,Jeremiah Wells,Red,Welterweight
+02/10/2024,Bogdan Guskov,Zac Pauga,Red,Light Heavyweight
+02/10/2024,Hyder Amil,Fernie Garcia,Red,Featherweight
+02/03/2024,Roman Dolidze,Nassourdine Imavov,Blue,Middleweight
+02/03/2024,Renato Moicano,Drew Dober,Red,Lightweight
+02/03/2024,Randy Brown,Muslim Salikhov,Red,Welterweight
+02/03/2024,Viviane Araujo,Natalia Silva,Blue,Women's Flyweight
+02/03/2024,Gilbert Urbina,Charles Radtke,Blue,Welterweight
+02/03/2024,Diana Belbita,Molly McCann,Blue,Women's Strawweight
+02/03/2024,Azat Maksum,Charles Johnson,Blue,Flyweight
+02/03/2024,Pete Rodriguez,Themba Gorimbo,Blue,Welterweight
+02/03/2024,Blake Bilder,JeongYeong Lee,Blue,Featherweight
+02/03/2024,Julija Stoliarenko,Luana Carolina,Blue,Women's Flyweight
+02/03/2024,MarQuel Mederos,Landon Quinones,Red,Lightweight
+02/03/2024,Thomas Petersen,Jamal Pogues,Blue,Heavyweight
+01/20/2024,Dricus Du Plessis,Sean Strickland,Red,UFC Middleweight Title
+01/20/2024,Mayra Bueno Silva,Raquel Pennington,Blue,UFC Women's Bantamweight Title
+01/20/2024,Neil Magny,Mike Malott,Red,Welterweight
+01/20/2024,Chris Curtis,Marc-Andre Barriault,Red,Middleweight
+01/20/2024,Movsar Evloev,Arnold Allen,Red,Featherweight
+01/20/2024,Brad Katona,Garrett Armfield,Blue,Bantamweight
+01/20/2024,Sean Woodson,Charles Jourdain,Red,Featherweight
+01/20/2024,Serhiy Sidey,Ramon Taveras,Blue,Bantamweight
+01/20/2024,Polyana Viana,Gillian Robertson,Blue,Women's Strawweight
+01/20/2024,Yohan Lainesse,Sam Patterson,Blue,Welterweight
+01/20/2024,Jasmine Jasudavicius,Priscila Cachoeira,Red,Women's Bantamweight
+01/20/2024,Malcolm Gordon,Jimmy Flick,Blue,Flyweight
+01/13/2024,Magomed Ankalaev,Johnny Walker,Red,Light Heavyweight
+01/13/2024,Jim Miller,Gabriel Benitez,Red,Lightweight
+01/13/2024,Mario Bautista,Ricky Simon,Red,Bantamweight
+01/13/2024,Phil Hawes,Brunno Ferreira,Blue,Middleweight
+01/13/2024,Andrei Arlovski,Waldo Cortes-Acosta,Blue,Heavyweight
+01/13/2024,Matthew Semelsberger,Preston Parsons,Blue,Welterweight
+01/13/2024,Marcus McGhee,Gaston Bolanos,Red,Bantamweight
+01/13/2024,Taylor Lapilus,Farid Basharat,Blue,Bantamweight
+01/13/2024,Jean Silva,Westin Wilson,Red,Featherweight
+01/13/2024,Nikolas Motta,Tom Nolan,Red,Lightweight
+01/13/2024,Joshua Van,Felipe Bunes,Red,Flyweight
+12/16/2023,Colby Covington,Leon Edwards,Blue,UFC Welterweight Title
+12/16/2023,Brandon Royval,Alexandre Pantoja,Blue,UFC Flyweight Title
+12/16/2023,Stephen Thompson,Shavkat Rakhmonov,Blue,Welterweight
+12/16/2023,Paddy Pimblett,Tony Ferguson,Red,Lightweight
+12/16/2023,Josh Emmett,Bryce Mitchell,Red,Featherweight
+12/16/2023,Dustin Jacoby,Alonzo Menifield,Blue,Light Heavyweight
+12/16/2023,Irene Aldana,Karol Rosa,Red,Women's Bantamweight
+12/16/2023,Cody Garbrandt,Brian Kelleher,Red,Bantamweight
+12/16/2023,Ariane Lipski,Casey O'Neill,Red,Women's Flyweight
+12/16/2023,Tagir Ulanbekov,Cody Durden,Red,Flyweight
+12/16/2023,Lucas Almeida,Andre Fili,Blue,Featherweight
+12/16/2023,Martin Buday,Shamil Gaziev,Blue,Heavyweight
+12/09/2023,Song Yadong,Chris Gutierrez,Red,Bantamweight
+12/09/2023,Khalil Rountree Jr.,Anthony Smith,Red,Light Heavyweight
+12/09/2023,Nasrat Haqparast,Jamie Mullarkey,Red,Lightweight
+12/09/2023,Sumudaerji,Tim Elliott,Blue,Bantamweight
+12/09/2023,JunYong Park,Andre Muniz,Blue,Middleweight
+12/09/2023,Song Kenan,Kevin Jousset,Blue,Welterweight
+12/09/2023,HyunSung Park,Shannon Ross,Red,Flyweight
+12/09/2023,Steve Garcia,Melquizael Costa,Red,Lightweight
+12/09/2023,Luana Santos,Stephanie Egger,Red,Women's Bantamweight
+12/09/2023,Carlos Hernandez,Tatsuro Taira,Blue,Flyweight
+12/09/2023,Talita Alencar,Rayanne Amanda,Red,Women's Strawweight
+12/02/2023,Arman Tsarukyan,Beneil Dariush,Red,Lightweight
+12/02/2023,Jalin Turner,Bobby Green,Red,Lightweight
+12/02/2023,Rob Font,Deiveson Figueiredo,Blue,Bantamweight
+12/02/2023,Kelvin Gastelum,Sean Brady,Blue,Welterweight
+12/02/2023,Joaquim Silva,Clay Guida,Red,Lightweight
+12/02/2023,Dustin Stoltzfus,Punahele Soriano,Red,Middleweight
+12/02/2023,Miesha Tate,Julia Avila,Red,Women's Bantamweight
+12/02/2023,Cody Brundage,Zach Reese,Red,Middleweight
+12/02/2023,Drakkar Klose,Joe Solecki,Red,Lightweight
+12/02/2023,Rodolfo Bellato,Ihor Potieria,Red,Light Heavyweight
+12/02/2023,Wellington Turman,Jared Gooden,Blue,Welterweight
+12/02/2023,Jamey-Lyn Horth,Veronica Hardy,Blue,Women's Flyweight
+11/18/2023,Paul Craig,Brendan Allen,Blue,Middleweight
+11/18/2023,Jake Matthews,Michael Morales,Blue,Welterweight
+11/18/2023,Chase Hooper,Jordan Leavitt,Red,Lightweight
+11/18/2023,Payton Talbott,Nick Aguirre,Red,Bantamweight
+11/18/2023,Amanda Ribas,Luana Pinheiro,Red,Women's Strawweight
+11/18/2023,Uros Medic,Myktybek Orolbai,Blue,Welterweight
+11/18/2023,Jonathan Pearce,Joanderson Brito,Blue,Featherweight
+11/18/2023,Chad Anheliger,Jose Johnson,Blue,Bantamweight
+11/18/2023,Christian Leroy Duncan,Denis Tiuliulin,Red,Middleweight
+11/18/2023,Caio Machado,Mick Parkin,Blue,Heavyweight
+11/18/2023,Jeka Saragih,Lucas Alexander,Red,Featherweight
+11/18/2023,Lucie Pudilova,Ailin Perez,Blue,Women's Bantamweight
+11/18/2023,Rafael Estevam,Charles Johnson,Red,Flyweight
+11/11/2023,Alex Pereira,Jiri Prochazka,Red,UFC Light Heavyweight Title
+11/11/2023,Sergei Pavlovich,Tom Aspinall,Blue,UFC Interim Heavyweight Title
+11/11/2023,Jessica Andrade,Mackenzie Dern,Red,Women's Strawweight
+11/11/2023,Benoit Saint Denis,Matt Frevola,Red,Lightweight
+11/11/2023,Diego Lopes,Pat Sabatini,Red,Featherweight
+11/11/2023,Alessandro Costa,Steve Erceg,Blue,Flyweight
+11/11/2023,Loopy Godinez,Tabatha Ricci,Red,Women's Strawweight
+11/11/2023,Roosevelt Roberts,Mateusz Rebecki,Blue,Lightweight
+11/11/2023,Mark Madsen,Jared Gordon,Blue,Lightweight
+11/11/2023,Kyung Ho Kang,John Castaneda,Blue,Catch Weight
+11/11/2023,Kevin Borjas,Joshua Van,Blue,Flyweight
+11/11/2023,Dennis Buzukja,Jamall Emmers,Blue,Featherweight
+11/04/2023,Derrick Lewis,Jailton Almeida,Blue,Heavyweight
+11/04/2023,Gabriel Bonfim,Nicolas Dalby,Blue,Welterweight
+11/04/2023,Rodrigo Nascimento,Don'Tale Mayes,Red,Heavyweight
+11/04/2023,Abus Magomedov,Caio Borralho,Blue,Middleweight
+11/04/2023,Kaynan Kruschewsky,Elves Brener,Blue,Catch Weight
+11/04/2023,Vitor Petrino,Modestas Bukauskas,Red,Light Heavyweight
+11/04/2023,Denise Gomes,Angela Hill,Blue,Women's Strawweight
+11/04/2023,Montserrat Conejo Ruiz,Eduarda Moura,Blue,Women's Strawweight
+11/04/2023,Kaue Fernandes,Marc Diakiese,Blue,Lightweight
+10/21/2023,Islam Makhachev,Alexander Volkanovski,Red,UFC Lightweight Title
+10/21/2023,Kamaru Usman,Khamzat Chimaev,Blue,Middleweight
+10/21/2023,Warlley Alves,Ikram Aliskerov,Blue,Middleweight
+10/21/2023,Said Nurmagomedov,Muin Gafurov,Red,Bantamweight
+10/21/2023,Tim Elliott,Muhammad Mokaev,Blue,Flyweight
+10/21/2023,Trevor Peek,Mohammad Yahya,Red,Lightweight
+10/21/2023,Abu Azaitar,Sedriques Dumas,Blue,Middleweight
+10/21/2023,Anshul Jubli,Mike Breeden,Blue,Lightweight
+10/21/2023,Muhammad Naimov,Nathaniel Wood,Red,Featherweight
+10/21/2023,Jinh Yu Frey,Viktoriia Dudakova,Blue,Women's Strawweight
+10/21/2023,Bruno Silva,Shara Magomedov,Blue,Middleweight
+10/14/2023,Edson Barboza,Sodiq Yusuff,Red,Featherweight
+10/14/2023,Viviane Araujo,Jennifer Maia,Red,Women's Flyweight
+10/14/2023,Jonathan Martinez,Adrian Yanez,Red,Bantamweight
+10/14/2023,Michel Pereira,Andre Petroski,Red,Middleweight
+10/14/2023,Cameron Saaiman,Christian Rodriguez,Blue,Bantamweight
+10/14/2023,TJ Brown,Darren Elkins,Blue,Featherweight
+10/14/2023,Ravena Oliveira,Tainara Lisboa,Blue,Women's Bantamweight
+10/14/2023,Terrance McKinney,Brendon Marotte,Red,Lightweight
+10/14/2023,Irina Alekseeva,Melissa Dixon,Blue,Women's Bantamweight
+10/14/2023,Alatengheili,Chris Gutierrez,Blue,Bantamweight
+10/14/2023,Emily Ducote,Ashley Yoder,Red,Women's Strawweight
+10/07/2023,Bobby Green,Grant Dawson,Red,Lightweight
+10/07/2023,Joe Pyfer,Abdul Razak Alhassan,Red,Middleweight
+10/07/2023,Alex Morono,Joaquin Buckley,Blue,Welterweight
+10/07/2023,Drew Dober,Ricky Glenn,Red,Lightweight
+10/07/2023,Alexander Hernandez,Bill Algeo,Blue,Featherweight
+10/07/2023,Karolina Kowalkiewicz,Diana Belbita,Red,Women's Strawweight
+10/07/2023,Nate Maness,Mateus Mendonca,Red,Flyweight
+10/07/2023,Vanessa Demopoulos,Kanako Murata,Red,Women's Strawweight
+10/07/2023,Johnny Munoz,Aoriqileng,Blue,Bantamweight
+10/07/2023,Montana De La Rosa,JJ Aldrich,Blue,Women's Flyweight
+09/23/2023,Mateusz Gamrot,Rafael Fiziev,Red,Lightweight
+09/23/2023,Bryce Mitchell,Dan Ige,Red,Featherweight
+09/23/2023,Michelle Waterson-Gomez,Marina Rodriguez,Blue,Women's Strawweight
+09/23/2023,Bryan Battle,AJ Fletcher,Red,Welterweight
+09/23/2023,Ricardo Ramos,Charles Jourdain,Blue,Featherweight
+09/23/2023,Tim Means,Andre Fialho,Red,Welterweight
+09/23/2023,Cody Brundage,Jacob Malkoun,Red,Middleweight
+09/23/2023,Mohammed Usman,Jake Collier,Red,Heavyweight
+09/23/2023,Mizuki,Hannah Goldy,Red,Women's Strawweight
+09/23/2023,Montserrat Rendon,Tamires Vidal,Red,Women's Bantamweight
+09/16/2023,Jack Della Maddalena,Kevin Holland,Red,Welterweight
+09/16/2023,Raul Rosas Jr.,Terrence Mitchell,Red,Bantamweight
+09/16/2023,Daniel Zellhuber,Christos Giagos,Red,Lightweight
+09/16/2023,Fernando Padilla,Kyle Nelson,Blue,Featherweight
+09/16/2023,Loopy Godinez,Elise Reed,Red,Women's Strawweight
+09/16/2023,Roman Kopylov,Josh Fremd,Red,Middleweight
+09/16/2023,Tracy Cortez,Jasmine Jasudavicius,Red,Women's Flyweight
+09/16/2023,Charlie Campbell,Alex Reyes,Red,Lightweight
+09/16/2023,Josefine Knutsson,Marnic Mann,Red,Women's Strawweight
+09/09/2023,Israel Adesanya,Sean Strickland,Blue,UFC Middleweight Title
+09/09/2023,Tai Tuivasa,Alexander Volkov,Blue,Heavyweight
+09/09/2023,Felipe dos Santos,Manel Kape,Blue,Flyweight
+09/09/2023,Austen Lane,Justin Tafa,Blue,Heavyweight
+09/09/2023,Anton Turkalj,Tyson Pedro,Blue,Light Heavyweight
+09/09/2023,Carlos Ulberg,Da Woon Jung,Red,Light Heavyweight
+09/09/2023,Chepe Mariscal,Jack Jenkins,Red,Featherweight
+09/09/2023,John Makdessi,Jamie Mullarkey,Blue,Lightweight
+09/09/2023,Nasrat Haqparast,Landon Quinones,Red,Lightweight
+09/09/2023,Charles Radtke,Blood Diamond,Red,Welterweight
+09/09/2023,Shane Young,Gabriel Miranda,Blue,Featherweight
+09/09/2023,Kiefer Crosbie,Kevin Jousset,Blue,Welterweight
+09/02/2023,Serghei Spivac,Ciryl Gane,Blue,Heavyweight
+09/02/2023,Manon Fiorot,Rose Namajunas,Red,Women's Flyweight
+09/02/2023,Thiago Moises,Benoit Saint Denis,Blue,Lightweight
+09/02/2023,Volkan Oezdemir,Bogdan Guskov,Red,Light Heavyweight
+09/02/2023,Yanis Ghemmouri,William Gomis,Blue,Featherweight
+09/02/2023,Manolo Zecchini,Morgan Charriere,Blue,Featherweight
+09/02/2023,Caolan Loughran,Taylor Lapilus,Blue,Bantamweight
+09/02/2023,Rhys McKee,Ange Loosa,Blue,Welterweight
+09/02/2023,Joselyne Edwards,Nora Cornolle,Blue,Women's Bantamweight
+09/02/2023,Kleydson Rodrigues,Farid Basharat,Blue,Bantamweight
+09/02/2023,Zarah Fairn,Jacqueline Cavalcanti,Blue,Catch Weight
+08/26/2023,Chan Sung Jung,Max Holloway,Blue,Featherweight
+08/26/2023,Anthony Smith,Ryan Spann,Red,Light Heavyweight
+08/26/2023,Alex Caceres,Giga Chikadze,Blue,Featherweight
+08/26/2023,Rinya Nakamura,Fernie Garcia,Red,Bantamweight
+08/26/2023,Erin Blanchfield,Taila Santos,Red,Women's Flyweight
+08/26/2023,Parker Porter,Junior Tafa,Blue,Heavyweight
+08/26/2023,Waldo Cortes-Acosta,Lukasz Brzeski,Red,Heavyweight
+08/26/2023,Toshiomi Kazama,Garrett Armfield,Blue,Bantamweight
+08/26/2023,Chidi Njokuani,Michal Oleksiejczuk,Blue,Middleweight
+08/26/2023,Rolando Bedoya,Song Kenan,Blue,Welterweight
+08/26/2023,Billy Goff,Yusaku Kinoshita,Red,Welterweight
+08/26/2023,Liang Na,JJ Aldrich,Blue,Women's Flyweight
+08/26/2023,SeungWoo Choi,Jarno Errens,Red,Featherweight
+08/19/2023,Aljamain Sterling,Sean O'Malley,Blue,UFC Bantamweight Title
+08/19/2023,Zhang Weili,Amanda Lemos,Red,UFC Women's Strawweight Title
+08/19/2023,Ian Machado Garry,Neil Magny,Red,Welterweight
+08/19/2023,Mario Bautista,Da'Mon Blackshear,Red,Bantamweight
+08/19/2023,Marlon Vera,Pedro Munhoz,Red,Bantamweight
+08/19/2023,Chris Weidman,Brad Tavares,Blue,Middleweight
+08/19/2023,Gregory Rodrigues,Denis Tiuliulin,Red,Middleweight
+08/19/2023,Kurt Holobaugh,Austin Hubbard,Red,Lightweight
+08/19/2023,Cody Gibson,Brad Katona,Blue,Bantamweight
+08/19/2023,Gerald Meerschaert,Andre Petroski,Blue,Middleweight
+08/19/2023,Natalia Silva,Andrea Lee,Red,Women's Flyweight
+08/19/2023,Karine Silva,Maryna Moroz,Red,Women's Flyweight
+08/12/2023,Rafael Dos Anjos,Vicente Luque,Blue,Welterweight
+08/12/2023,Cub Swanson,Hakeem Dawodu,Red,Featherweight
+08/12/2023,Khalil Rountree Jr.,Chris Daukaus,Red,Light Heavyweight
+08/12/2023,Iasmin Lucindo,Polyana Viana,Red,Women's Strawweight
+08/12/2023,AJ Dobson,Tafon Nchukwi,Red,Middleweight
+08/12/2023,Jamie Pickett,Josh Fremd,Blue,Middleweight
+08/12/2023,JP Buys,Marcus McGhee,Blue,Bantamweight
+08/12/2023,Mike Breeden,Terrance McKinney,Blue,Lightweight
+08/12/2023,Isaac Dulgarian,Francis Marshall,Red,Featherweight
+08/12/2023,Martin Buday,Josh Parisian,Red,Heavyweight
+08/12/2023,Montserrat Conejo Ruiz,Jaqueline Amorim,Blue,Women's Strawweight
+08/12/2023,Jose Johnson,Da'Mon Blackshear,Blue,Bantamweight
+08/12/2023,Juliana Miller,Luana Santos,Blue,Women's Flyweight
+08/05/2023,Rob Font,Cory Sandhagen,Blue,Catch Weight
+08/05/2023,Jessica Andrade,Tatiana Suarez,Blue,Women's Strawweight
+08/05/2023,Dustin Jacoby,Kennedy Nzechukwu,Red,Light Heavyweight
+08/05/2023,Gavin Tucker,Diego Lopes,Blue,Featherweight
+08/05/2023,Aleksa Camur,Tanner Boser,Blue,Light Heavyweight
+08/05/2023,Ludovit Klein,Ignacio Bahamondes,Red,Lightweight
+08/05/2023,Raoni Barcelos,Kyler Phillips,Blue,Bantamweight
+08/05/2023,Carlston Harris,Jeremiah Wells,Red,Welterweight
+08/05/2023,Damon Jackson,Billy Quarantillo,Blue,Featherweight
+08/05/2023,Cody Durden,Jake Hadley,Red,Flyweight
+08/05/2023,Sean Woodson,Dennis Buzukja,Red,Featherweight
+08/05/2023,Ode Osbourne,Asu Almabayev,Blue,Flyweight
+07/29/2023,Dustin Poirier,Justin Gaethje,Blue,Lightweight
+07/29/2023,Alex Pereira,Jan Blachowicz,Red,Light Heavyweight
+07/29/2023,Derrick Lewis,Marcos Rogerio de Lima,Red,Heavyweight
+07/29/2023,Tony Ferguson,Bobby Green,Blue,Lightweight
+07/29/2023,Kevin Holland,Michael Chiesa,Red,Welterweight
+07/29/2023,Trevin Giles,Gabriel Bonfim,Blue,Welterweight
+07/29/2023,Vinicius Salvador,CJ Vergara,Blue,Flyweight
+07/29/2023,Roman Kopylov,Claudio Ribeiro,Red,Middleweight
+07/29/2023,Jake Matthews,Darrius Flowers,Red,Welterweight
+07/29/2023,Matthew Semelsberger,Uros Medic,Blue,Welterweight
+07/29/2023,Priscila Cachoeira,Miranda Maverick,Blue,Women's Flyweight
+07/22/2023,Marcin Tybura,Tom Aspinall,Blue,Heavyweight
+07/22/2023,Molly McCann,Julija Stoliarenko,Blue,Women's Flyweight
+07/22/2023,Andre Fili,Nathaniel Wood,Blue,Featherweight
+07/22/2023,Andre Muniz,Paul Craig,Blue,Middleweight
+07/22/2023,Jai Herbert,Fares Ziam,Blue,Lightweight
+07/22/2023,Lerone Murphy,Josh Culibao,Red,Featherweight
+07/22/2023,Davey Grant,Daniel Marcos,Blue,Bantamweight
+07/22/2023,Danny Roberts,Jonny Parsons,Blue,Welterweight
+07/22/2023,Marc Diakiese,Joel Alvarez,Blue,Lightweight
+07/22/2023,Mick Parkin,Jamal Pogues,Red,Heavyweight
+07/22/2023,Bryan Barberena,Makhmud Muradov,Blue,Middleweight
+07/22/2023,Ketlen Vieira,Pannie Kianzad,Red,Women's Bantamweight
+07/22/2023,Yanal Ashmouz,Chris Duncan,Blue,Lightweight
+07/22/2023,Shauna Bannon,Bruna Brasil,Blue,Women's Strawweight
+07/22/2023,Daniel Barez,Jafel Filho,Blue,Flyweight
+07/15/2023,Bassil Hafez,Jack Della Maddalena,Blue,Welterweight
+07/15/2023,Francisco Prado,Ottman Azaitar,Red,Lightweight
+07/15/2023,JunYong Park,Albert Duraev,Red,Middleweight
+07/15/2023,Chelsea Chandler,Norma Dumont,Blue,Women's Featherweight
+07/15/2023,Nazim Sadykhov,Terrance McKinney,Red,Lightweight
+07/15/2023,Tucker Lutz,Melsik Baghdasaryan,Blue,Featherweight
+07/15/2023,Istela Nunes,Viktoriia Dudakova,Blue,Women's Strawweight
+07/15/2023,Austin Lingo,Melquizael Costa,Blue,Featherweight
+07/15/2023,Evan Elder,Genaro Valdez,Red,Lightweight
+07/15/2023,Tyson Nam,Azat Maksum,Blue,Flyweight
+07/15/2023,Carl Deaton,Alexander Munoz,Blue,Lightweight
+07/15/2023,Ashlee Evans-Smith,Ailin Perez,Blue,Women's Bantamweight
+07/08/2023,Yair Rodriguez,Alexander Volkanovski,Blue,UFC Featherweight Title
+07/08/2023,Brandon Moreno,Alexandre Pantoja,Blue,UFC Flyweight Title
+07/08/2023,Robert Whittaker,Dricus Du Plessis,Blue,Middleweight
+07/08/2023,Dan Hooker,Jalin Turner,Red,Lightweight
+07/08/2023,Val Woodburn,Bo Nickal,Blue,Middleweight
+07/08/2023,Niko Price,Robbie Lawler,Blue,Welterweight
+07/08/2023,Tatsuro Taira,Edgar Chairez,Red,Catch Weight
+07/08/2023,Yazmin Jauregui,Denise Gomes,Blue,Women's Strawweight
+07/08/2023,Alonzo Menifield,Jimmy Crute,Red,Light Heavyweight
+07/08/2023,Vitor Petrino,Marcin Prachnio,Red,Light Heavyweight
+07/08/2023,Cameron Saaiman,Terrence Mitchell,Red,Bantamweight
+07/08/2023,Shannon Ross,Jesus Aguilar,Blue,Flyweight
+07/08/2023,Kamuela Kirk,Esteban Ribovics,Blue,Lightweight
+07/01/2023,Sean Strickland,Abus Magomedov,Red,Middleweight
+07/01/2023,Damir Ismagulov,Grant Dawson,Blue,Lightweight
+07/01/2023,Max Griffin,Michael Morales,Blue,Welterweight
+07/01/2023,Melissa Gatto,Ariane Lipski,Blue,Women's Flyweight
+07/01/2023,Ismael Bonfim,Benoit Saint Denis,Blue,Lightweight
+07/01/2023,Brunno Ferreira,Nursulton Ruziboev,Blue,Middleweight
+07/01/2023,Kevin Lee,Rinat Fakhretdinov,Blue,Welterweight
+07/01/2023,Joanderson Brito,Westin Wilson,Red,Featherweight
+07/01/2023,Karol Rosa,Yana Santos,Red,Women's Featherweight
+07/01/2023,Elves Brener,Guram Kutateladze,Red,Lightweight
+07/01/2023,Ivana Petrovic,Luana Carolina,Blue,Women's Flyweight
+07/01/2023,Blagoy Ivanov,Alexandr Romanov,Blue,Heavyweight
+06/24/2023,Ilia Topuria,Josh Emmett,Red,Featherweight
+06/24/2023,Amanda Ribas,Maycee Barber,Blue,Women's Flyweight
+06/24/2023,Gabriel Santos,David Onama,Blue,Featherweight
+06/24/2023,Bruno Silva,Brendan Allen,Blue,Middleweight
+06/24/2023,Phil Rowe,Neil Magny,Blue,Welterweight
+06/24/2023,Randy Brown,Wellington Turman,Red,Welterweight
+06/24/2023,Mateusz Rebecki,Loik Radzhabov,Red,Lightweight
+06/24/2023,Gillian Robertson,Tabatha Ricci,Blue,Women's Strawweight
+06/24/2023,Zhalgas Zhumagulov,Joshua Van,Blue,Flyweight
+06/24/2023,Chepe Mariscal,Trevor Peek,Red,Lightweight
+06/24/2023,Jack Jenkins,Jamall Emmers,Red,Featherweight
+06/24/2023,Cody Brundage,Sedriques Dumas,Blue,Middleweight
+06/17/2023,Marvin Vettori,Jared Cannonier,Blue,Middleweight
+06/17/2023,Arman Tsarukyan,Joaquim Silva,Red,Lightweight
+06/17/2023,Christian Leroy Duncan,Armen Petrosyan,Blue,Middleweight
+06/17/2023,Lucas Almeida,Pat Sabatini,Blue,Featherweight
+06/17/2023,Manuel Torres,Nikolas Motta,Red,Lightweight
+06/17/2023,Nicolas Dalby,Muslim Salikhov,Red,Welterweight
+06/17/2023,Jimmy Flick,Alessandro Costa,Blue,Flyweight
+06/17/2023,Cristian Quinonez,Kyung Ho Kang,Blue,Bantamweight
+06/17/2023,Carlos Hernandez,Denys Bondar,Red,Flyweight
+06/17/2023,Tereza Bleda,Gabriella Fernandes,Red,Women's Flyweight
+06/17/2023,Zac Pauga,Modestas Bukauskas,Blue,Light Heavyweight
+06/10/2023,Irene Aldana,Amanda Nunes,Blue,UFC Women's Bantamweight Title
+06/10/2023,Charles Oliveira,Beneil Dariush,Red,Lightweight
+06/10/2023,Mike Malott,Adam Fugitt,Red,Welterweight
+06/10/2023,Dan Ige,Nate Landwehr,Red,Featherweight
+06/10/2023,Marc-Andre Barriault,Eryk Anders,Red,Middleweight
+06/10/2023,Miranda Maverick,Jasmine Jasudavicius,Blue,Women's Flyweight
+06/10/2023,Aoriqileng,Aiemann Zahabi,Blue,Bantamweight
+06/10/2023,Kyle Nelson,Blake Bilder,Red,Featherweight
+06/10/2023,David Dvorak,Steve Erceg,Blue,Flyweight
+06/10/2023,Maria Oliveira,Diana Belbita,Blue,Women's Strawweight
+06/03/2023,Kai Kara-France,Amir Albazi,Blue,Flyweight
+06/03/2023,Daniel Pineda,Alex Caceres,Blue,Featherweight
+06/03/2023,Jesse Butler,Jim Miller,Blue,Lightweight
+06/03/2023,Tim Elliott,Victor Altamirano,Red,Flyweight
+06/03/2023,Ketlen Souza,Karine Silva,Blue,Women's Flyweight
+06/03/2023,Abubakar Nurmagomedov,Elizeu Zaleski dos Santos,Blue,Welterweight
+06/03/2023,Johnny Munoz,Daniel Santos,Blue,Bantamweight
+06/03/2023,Andrei Arlovski,Don'Tale Mayes,Blue,Heavyweight
+06/03/2023,John Castaneda,Muin Gafurov,Red,Bantamweight
+06/03/2023,Jamie Mullarkey,Muhammad Naimov,Blue,Lightweight
+06/03/2023,Elise Reed,Jinh Yu Frey,Red,Women's Strawweight
+06/03/2023,Da'Mon Blackshear,Luan Lacerda,Red,Bantamweight
+06/03/2023,Maxim Grishin,Philipe Lins,Blue,Light Heavyweight
+05/20/2023,Mackenzie Dern,Angela Hill,Red,Women's Strawweight
+05/20/2023,Edmen Shahbazyan,Anthony Hernandez,Blue,Middleweight
+05/20/2023,Emily Ducote,Loopy Godinez,Blue,Catch Weight
+05/20/2023,Andre Fialho,Joaquin Buckley,Blue,Welterweight
+05/20/2023,Diego Ferreira,Michael Johnson,Red,Lightweight
+05/20/2023,Maheshate,Viacheslav Borshchev,Blue,Lightweight
+05/20/2023,Karolina Kowalkiewicz,Vanessa Demopoulos,Red,Women's Strawweight
+05/20/2023,Orion Cosce,Gilbert Urbina,Blue,Welterweight
+05/20/2023,Ilir Latifi,Rodrigo Nascimento,Blue,Heavyweight
+05/20/2023,Chase Hooper,Nick Fiore,Red,Lightweight
+05/20/2023,Natalia Silva,Victoria Leonardo,Red,Women's Flyweight
+05/20/2023,Takashi Sato,Themba Gorimbo,Blue,Welterweight
+05/13/2023,Jailton Almeida,Jairzinho Rozenstruik,Red,Heavyweight
+05/13/2023,Anthony Smith,Johnny Walker,Blue,Light Heavyweight
+05/13/2023,Daniel Rodriguez,Ian Machado Garry,Blue,Welterweight
+05/13/2023,Carlos Ulberg,Ihor Potieria,Red,Light Heavyweight
+05/13/2023,Alex Morono,Tim Means,Red,Welterweight
+05/13/2023,Matt Brown,Court McGee,Red,Welterweight
+05/13/2023,Chase Sherman,Karl Williams,Blue,Heavyweight
+05/13/2023,Douglas Silva de Andrade,Cody Stamann,Red,Catch Weight
+05/13/2023,Mandy Bohm,Ji Yeon Kim,Red,Women's Flyweight
+05/13/2023,Bryan Battle,Gabe Green,Red,Welterweight
+05/13/2023,Jessica-Rose Clark,Tainara Lisboa,Blue,Women's Bantamweight
+05/06/2023,Henry Cejudo,Aljamain Sterling,Blue,UFC Bantamweight Title
+05/06/2023,Gilbert Burns,Belal Muhammad,Blue,Welterweight
+05/06/2023,Jessica Andrade,Yan Xiaonan,Blue,Women's Strawweight
+05/06/2023,Movsar Evloev,Diego Lopes,Red,Featherweight
+05/06/2023,Kron Gracie,Charles Jourdain,Blue,Featherweight
+05/06/2023,Drew Dober,Matt Frevola,Blue,Lightweight
+05/06/2023,Kennedy Nzechukwu,Devin Clark,Red,Light Heavyweight
+05/06/2023,Khaos Williams,Rolando Bedoya,Red,Welterweight
+05/06/2023,Virna Jandiroba,Marina Rodriguez,Red,Women's Strawweight
+05/06/2023,Parker Porter,Braxton Smith,Red,Heavyweight
+05/06/2023,Phil Hawes,Ikram Aliskerov,Blue,Middleweight
+05/06/2023,Claudio Ribeiro,Joseph Holmes,Red,Middleweight
+04/29/2023,Song Yadong,Ricky Simon,Red,Bantamweight
+04/29/2023,Caio Borralho,Michal Oleksiejczuk,Red,Middleweight
+04/29/2023,Rodolfo Vieira,Cody Brundage,Red,Middleweight
+04/29/2023,Julian Erosa,Fernando Padilla,Blue,Featherweight
+04/29/2023,Marcos Rogerio de Lima,Waldo Cortes-Acosta,Red,Heavyweight
+04/29/2023,Trey Waters,Josh Quinlan,Red,Welterweight
+04/29/2023,Jake Collier,Martin Buday,Blue,Heavyweight
+04/29/2023,Charles Johnson,Cody Durden,Blue,Flyweight
+04/29/2023,Stephanie Egger,Irina Alekseeva,Blue,Women's Bantamweight
+04/29/2023,Journey Newson,Marcus McGhee,Blue,Catch Weight
+04/29/2023,Jamey-Lyn Horth,Hailey Cowan,Red,Women's Bantamweight
+04/22/2023,Curtis Blaydes,Sergei Pavlovich,Blue,Heavyweight
+04/22/2023,Brad Tavares,Bruno Silva,Blue,Middleweight
+04/22/2023,Iasmin Lucindo,Brogan Walker,Red,Women's Flyweight
+04/22/2023,Jeremiah Wells,Matthew Semelsberger,Red,Welterweight
+04/22/2023,Ricky Glenn,Christos Giagos,Blue,Lightweight
+04/22/2023,Montel Jackson,Rani Yahya,Red,Bantamweight
+04/22/2023,Karol Rosa,Norma Dumont,Blue,Women's Featherweight
+04/22/2023,Junior Tafa,Mohammed Usman,Blue,Heavyweight
+04/22/2023,William Gomis,Francis Marshall,Red,Featherweight
+04/22/2023,Brady Hiestand,Batgerel Danaa,Red,Bantamweight
+04/15/2023,Max Holloway,Arnold Allen,Red,Featherweight
+04/15/2023,Billy Quarantillo,Edson Barboza,Blue,Featherweight
+04/15/2023,Azamat Murzakanov,Dustin Jacoby,Red,Light Heavyweight
+04/15/2023,Ion Cutelaba,Tanner Boser,Red,Light Heavyweight
+04/15/2023,Pedro Munhoz,Chris Gutierrez,Red,Bantamweight
+04/15/2023,Rafa Garcia,Clay Guida,Red,Lightweight
+04/15/2023,Bill Algeo,TJ Brown,Red,Featherweight
+04/15/2023,Brandon Royval,Matheus Nicolau,Red,Flyweight
+04/15/2023,Ed Herman,Zak Cummings,Blue,Light Heavyweight
+04/15/2023,Piera Rodriguez,Gillian Robertson,Blue,Women's Strawweight
+04/15/2023,Lando Vannata,Daniel Zellhuber,Blue,Lightweight
+04/15/2023,Bruna Brasil,Denise Gomes,Blue,Women's Strawweight
+04/15/2023,Aaron Phillips,Gaston Bolanos,Blue,Bantamweight
+04/15/2023,Lucie Pudilova,Joselyne Edwards,Blue,Women's Bantamweight
+04/08/2023,Israel Adesanya,Alex Pereira,Red,UFC Middleweight Title
+04/08/2023,Gilbert Burns,Jorge Masvidal,Red,Welterweight
+04/08/2023,Adrian Yanez,Rob Font,Blue,Bantamweight
+04/08/2023,Kevin Holland,Santiago Ponzinibbio,Red,Welterweight
+04/08/2023,Raul Rosas Jr.,Christian Rodriguez,Blue,Bantamweight
+04/08/2023,Chris Curtis,Kelvin Gastelum,Blue,Middleweight
+04/08/2023,Michelle Waterson-Gomez,Luana Pinheiro,Blue,Women's Strawweight
+04/08/2023,Joe Pyfer,Gerald Meerschaert,Red,Middleweight
+04/08/2023,Loopy Godinez,Cynthia Calvillo,Red,Women's Strawweight
+04/08/2023,Ignacio Bahamondes,Trey Ogden,Red,Catch Weight
+04/08/2023,Shayilan Nuerdanbieke,Steve Garcia,Blue,Featherweight
+04/08/2023,Sam Hughes,Jaqueline Amorim,Red,Women's Strawweight
+03/25/2023,Marlon Vera,Cory Sandhagen,Blue,Bantamweight
+03/25/2023,Holly Holm,Yana Santos,Red,Women's Bantamweight
+03/25/2023,Nate Landwehr,Austin Lingo,Red,Featherweight
+03/25/2023,Maycee Barber,Andrea Lee,Red,Women's Flyweight
+03/25/2023,Chidi Njokuani,Albert Duraev,Blue,Middleweight
+03/25/2023,Tucker Lutz,Daniel Pineda,Blue,Featherweight
+03/25/2023,Steven Peterson,Lucas Alexander,Blue,Featherweight
+03/25/2023,Trevin Giles,Preston Parsons,Red,Welterweight
+03/25/2023,CJ Vergara,Daniel Lacerda,Red,Flyweight
+03/25/2023,Victor Altamirano,Vinicius Salvador,Red,Flyweight
+03/18/2023,Leon Edwards,Kamaru Usman,Red,UFC Welterweight Title
+03/18/2023,Justin Gaethje,Rafael Fiziev,Red,Lightweight
+03/18/2023,Bryan Barberena,Gunnar Nelson,Blue,Welterweight
+03/18/2023,Casey O'Neill,Jennifer Maia,Blue,Women's Flyweight
+03/18/2023,Roman Dolidze,Marvin Vettori,Blue,Middleweight
+03/18/2023,Makwan Amirkhani,Jack Shore,Blue,Featherweight
+03/18/2023,Chris Duncan,Omar Morales,Red,Lightweight
+03/18/2023,Sam Patterson,Yanal Ashmouz,Blue,Lightweight
+03/18/2023,Jafel Filho,Muhammad Mokaev,Blue,Flyweight
+03/18/2023,Lerone Murphy,Gabriel Santos,Red,Featherweight
+03/18/2023,Dusko Todorovic,Christian Leroy Duncan,Blue,Middleweight
+03/18/2023,Jake Hadley,Malcolm Gordon,Red,Flyweight
+03/18/2023,Joanne Wood,Luana Carolina,Red,Women's Flyweight
+03/18/2023,Juliana Miller,Veronica Hardy,Blue,Women's Flyweight
+03/11/2023,Petr Yan,Merab Dvalishvili,Blue,Bantamweight
+03/11/2023,Alexander Volkov,Alexandr Romanov,Red,Heavyweight
+03/11/2023,Nikita Krylov,Ryan Spann,Red,Catch Weight
+03/11/2023,Said Nurmagomedov,Jonathan Martinez,Blue,Bantamweight
+03/11/2023,Mario Bautista,Guido Cannetti,Red,Bantamweight
+03/11/2023,Anton Turkalj,Vitor Petrino,Blue,Light Heavyweight
+03/11/2023,Karl Williams,Lukasz Brzeski,Red,Heavyweight
+03/11/2023,Raphael Assuncao,Davey Grant,Blue,Bantamweight
+03/11/2023,Josh Fremd,Sedriques Dumas,Red,Middleweight
+03/11/2023,Tony Gravely,Victor Henry,Blue,Bantamweight
+03/11/2023,JJ Aldrich,Ariane Lipski,Blue,Women's Flyweight
+03/11/2023,Bruno Silva,Tyson Nam,Red,Flyweight
+03/11/2023,Carlston Harris,Jared Gooden,Red,Welterweight
+03/04/2023,Jon Jones,Ciryl Gane,Red,UFC Heavyweight Title
+03/04/2023,Valentina Shevchenko,Alexa Grasso,Blue,UFC Women's Flyweight Title
+03/04/2023,Shavkat Rakhmonov,Geoff Neal,Red,Welterweight
+03/04/2023,Mateusz Gamrot,Jalin Turner,Red,Lightweight
+03/04/2023,Bo Nickal,Jamie Pickett,Red,Middleweight
+03/04/2023,Trevin Jones,Cody Garbrandt,Blue,Bantamweight
+03/04/2023,Derek Brunson,Dricus Du Plessis,Blue,Middleweight
+03/04/2023,Viviane Araujo,Amanda Ribas,Blue,Women's Flyweight
+03/04/2023,Marc-Andre Barriault,Julian Marquez,Red,Middleweight
+03/04/2023,Ian Machado Garry,Song Kenan,Red,Welterweight
+03/04/2023,Mana Martinez,Cameron Saaiman,Blue,Bantamweight
+03/04/2023,Tabatha Ricci,Jessica Penne,Red,Women's Strawweight
+03/04/2023,Da'Mon Blackshear,Farid Basharat,Blue,Bantamweight
+03/04/2023,Esteban Ribovics,Loik Radzhabov,Blue,Lightweight
+02/25/2023,Andre Muniz,Brendan Allen,Blue,Middleweight
+02/25/2023,Don'Tale Mayes,Augusto Sakai,Blue,Heavyweight
+02/25/2023,Tatiana Suarez,Montana De La Rosa,Red,Women's Flyweight
+02/25/2023,Mike Malott,Yohan Lainesse,Red,Welterweight
+02/25/2023,Trevor Peek,Erick Gonzalez,Red,Lightweight
+02/25/2023,Jasmine Jasudavicius,Gabriella Fernandes,Red,Women's Flyweight
+02/25/2023,Jordan Leavitt,Victor Martinez,Red,Lightweight
+02/25/2023,Ode Osbourne,Charles Johnson,Red,Catch Weight
+02/25/2023,Joe Solecki,Carl Deaton,Red,Lightweight
+02/25/2023,Rafael Alves,Nurullo Aliev,Blue,Lightweight
+02/18/2023,Jessica Andrade,Erin Blanchfield,Blue,Women's Flyweight
+02/18/2023,Jordan Wright,Zac Pauga,Blue,Light Heavyweight
+02/18/2023,Jamal Pogues,Josh Parisian,Red,Heavyweight
+02/18/2023,William Knight,Marcin Prachnio,Blue,Light Heavyweight
+02/18/2023,Jim Miller,Alexander Hernandez,Blue,Lightweight
+02/18/2023,Evan Elder,Nazim Sadykhov,Blue,Lightweight
+02/18/2023,Mayra Bueno Silva,Lina Lansberg,Red,Women's Bantamweight
+02/18/2023,Khusein Askhabov,Jamall Emmers,Blue,Featherweight
+02/18/2023,Philipe Lins,Ovince Saint Preux,Red,Light Heavyweight
+02/18/2023,AJ Fletcher,Themba Gorimbo,Red,Welterweight
+02/18/2023,Clayton Carpenter,Juancamilo Ronderos,Red,Flyweight
+02/11/2023,Islam Makhachev,Alexander Volkanovski,Red,UFC Lightweight Title
+02/11/2023,Yair Rodriguez,Josh Emmett,Red,UFC Interim Featherweight Title
+02/11/2023,Jack Della Maddalena,Randy Brown,Red,Welterweight
+02/11/2023,Parker Porter,Justin Tafa,Blue,Heavyweight
+02/11/2023,Modestas Bukauskas,Tyson Pedro,Red,Light Heavyweight
+02/11/2023,Melsik Baghdasaryan,Josh Culibao,Blue,Featherweight
+02/11/2023,Shannon Ross,Kleydson Rodrigues,Blue,Flyweight
+02/11/2023,Jamie Mullarkey,Francisco Prado,Red,Lightweight
+02/11/2023,Jack Jenkins,Don Shainis,Red,Featherweight
+02/11/2023,Loma Lookboonmee,Elise Reed,Red,Women's Strawweight
+02/11/2023,Blake Bilder,Shane Young,Red,Featherweight
+02/11/2023,Elves Brener,Zubaira Tukhugov,Red,Lightweight
+02/04/2023,Derrick Lewis,Serghei Spivac,Blue,Heavyweight
+02/04/2023,Da Woon Jung,Devin Clark,Blue,Light Heavyweight
+02/04/2023,Blagoy Ivanov,Marcin Tybura,Blue,Heavyweight
+02/04/2023,Yusaku Kinoshita,Adam Fugitt,Blue,Welterweight
+02/04/2023,Jeka Saragih,Anshul Jubli,Blue,Lightweight
+02/04/2023,Yizha,JeongYeong Lee,Blue,Featherweight
+02/04/2023,Toshiomi Kazama,Rinya Nakamura,Blue,Bantamweight
+02/04/2023,HyunSung Park,SeungGuk Choi,Red,Flyweight
+02/04/2023,Denis Tiuliulin,JunYong Park,Blue,Middleweight
+02/04/2023,Jesus Aguilar,Tatsuro Taira,Blue,Flyweight
+01/21/2023,Glover Teixeira,Jamahal Hill,Blue,UFC Light Heavyweight Title
+01/21/2023,Deiveson Figueiredo,Brandon Moreno,Blue,UFC Flyweight Title
+01/21/2023,Neil Magny,Gilbert Burns,Blue,Welterweight
+01/21/2023,Jessica Andrade,Lauren Murphy,Red,Women's Flyweight
+01/21/2023,Paul Craig,Johnny Walker,Blue,Light Heavyweight
+01/21/2023,Mauricio Rua,Ihor Potieria,Blue,Light Heavyweight
+01/21/2023,Gregory Rodrigues,Brunno Ferreira,Blue,Middleweight
+01/21/2023,Thiago Moises,Melquizael Costa,Red,Lightweight
+01/21/2023,Gabriel Bonfim,Mounir Lazzez,Red,Welterweight
+01/21/2023,Jailton Almeida,Shamil Abdurakhimov,Red,Heavyweight
+01/21/2023,Luan Lacerda,Cody Stamann,Blue,Bantamweight
+01/21/2023,Ismael Bonfim,Terrance McKinney,Red,Lightweight
+01/21/2023,Nicolas Dalby,Warlley Alves,Red,Welterweight
+01/21/2023,Zarah Fairn,Josiane Nunes,Blue,Women's Featherweight
+01/21/2023,Daniel Marcos,Saimon Oliveira,Red,Bantamweight
+01/14/2023,Nassourdine Imavov,Sean Strickland,Blue,Light Heavyweight
+01/14/2023,Dan Ige,Damon Jackson,Red,Featherweight
+01/14/2023,Roman Kopylov,Punahele Soriano,Red,Middleweight
+01/14/2023,Raquel Pennington,Ketlen Vieira,Red,Women's Bantamweight
+01/14/2023,Raoni Barcelos,Umar Nurmagomedov,Blue,Bantamweight
+01/14/2023,Mateus Mendonca,Javid Basharat,Blue,Bantamweight
+01/14/2023,Claudio Ribeiro,Abdul Razak Alhassan,Blue,Middleweight
+01/14/2023,Mateusz Rebecki,Nick Fiore,Red,Lightweight
+01/14/2023,Carlos Hernandez,Allan Nascimento,Blue,Flyweight
+01/14/2023,Dan Argueta,Nick Aguirre,Red,Featherweight
+01/14/2023,Charles Johnson,Jimmy Flick,Red,Flyweight
+12/17/2022,Jared Cannonier,Sean Strickland,Red,Middleweight
+12/17/2022,Damir Ismagulov,Arman Tsarukyan,Blue,Lightweight
+12/17/2022,Amir Albazi,Alessandro Costa,Red,Flyweight
+12/17/2022,Alex Caceres,Julian Erosa,Red,Featherweight
+12/17/2022,Drew Dober,Bobby Green,Red,Lightweight
+12/17/2022,Cody Brundage,Michal Oleksiejczuk,Blue,Middleweight
+12/17/2022,Cheyanne Vlismas,Cory McKenna,Blue,Women's Strawweight
+12/17/2022,Matthew Semelsberger,Jake Matthews,Red,Welterweight
+12/17/2022,Said Nurmagomedov,Saidyokub Kakhramonov,Red,Bantamweight
+12/17/2022,Rafa Garcia,Maheshate,Red,Lightweight
+12/17/2022,Bryan Battle,Rinat Fakhretdinov,Blue,Welterweight
+12/17/2022,David Dvorak,Manel Kape,Blue,Flyweight
+12/17/2022,Sergey Morozov,Journey Newson,Red,Bantamweight
+12/10/2022,Paddy Pimblett,Jared Gordon,Red,Lightweight
+12/10/2022,Santiago Ponzinibbio,Alex Morono,Red,Catch Weight
+12/10/2022,Darren Till,Dricus Du Plessis,Blue,Middleweight
+12/10/2022,Ilia Topuria,Bryce Mitchell,Red,Featherweight
+12/10/2022,Jay Perrin,Raul Rosas Jr.,Blue,Bantamweight
+12/10/2022,Chris Daukaus,Jairzinho Rozenstruik,Blue,Heavyweight
+12/10/2022,Edmen Shahbazyan,Dalcha Lungiambula,Red,Middleweight
+12/10/2022,Chris Curtis,Joaquin Buckley,Red,Middleweight
+12/10/2022,Alexander Hernandez,Billy Quarantillo,Blue,Featherweight
+12/10/2022,Erik Silva,TJ Brown,Blue,Featherweight
+12/10/2022,Cameron Saaiman,Steven Koslow,Red,Bantamweight
+12/03/2022,Kevin Holland,Stephen Thompson,Blue,Welterweight
+12/03/2022,Rafael Dos Anjos,Bryan Barberena,Red,Welterweight
+12/03/2022,Matt Schnell,Matheus Nicolau,Blue,Flyweight
+12/03/2022,Tai Tuivasa,Sergei Pavlovich,Blue,Heavyweight
+12/03/2022,Roman Dolidze,Jack Hermansson,Red,Middleweight
+12/03/2022,Eryk Anders,Kyle Daukaus,Red,Middleweight
+12/03/2022,Niko Price,Phil Rowe,Blue,Welterweight
+12/03/2022,Angela Hill,Emily Ducote,Red,Women's Strawweight
+12/03/2022,Scott Holtzman,Clay Guida,Blue,Lightweight
+12/03/2022,Michael Johnson,Marc Diakiese,Red,Lightweight
+12/03/2022,Darren Elkins,Jonathan Pearce,Blue,Featherweight
+12/03/2022,Genaro Valdez,Natan Levy,Blue,Lightweight
+12/03/2022,Francis Marshall,Marcelo Rojo,Red,Featherweight
+12/03/2022,Istela Nunes,Yazmin Jauregui,Blue,Women's Strawweight
+11/19/2022,Ion Cutelaba,Kennedy Nzechukwu,Blue,Light Heavyweight
+11/19/2022,Waldo Cortes-Acosta,Chase Sherman,Red,Heavyweight
+11/19/2022,Muslim Salikhov,Andre Fialho,Red,Welterweight
+11/19/2022,Jack Della Maddalena,Danny Roberts,Red,Welterweight
+11/19/2022,Zhalgas Zhumagulov,Charles Johnson,Blue,Flyweight
+11/19/2022,Jennifer Maia,Maryna Moroz,Red,Women's Flyweight
+11/19/2022,Vince Morales,Miles Johns,Blue,Bantamweight
+11/19/2022,Ricky Turcios,Kevin Natividad,Red,Bantamweight
+11/19/2022,Maria Oliveira,Vanessa Demopoulos,Blue,Women's Strawweight
+11/19/2022,Brady Hiestand,Fernie Garcia,Red,Bantamweight
+11/19/2022,Tereza Bleda,Natalia Silva,Blue,Women's Flyweight
+11/12/2022,Alex Pereira,Israel Adesanya,Red,UFC Middleweight Title
+11/12/2022,Carla Esparza,Zhang Weili,Blue,UFC Women's Strawweight Title
+11/12/2022,Michael Chandler,Dustin Poirier,Blue,Lightweight
+11/12/2022,Chris Gutierrez,Frankie Edgar,Red,Bantamweight
+11/12/2022,Dan Hooker,Claudio Puelles,Red,Lightweight
+11/12/2022,Brad Riddell,Renato Moicano,Blue,Lightweight
+11/12/2022,Dominick Reyes,Ryan Spann,Blue,Light Heavyweight
+11/12/2022,Molly McCann,Erin Blanchfield,Blue,Women's Flyweight
+11/12/2022,Wellington Turman,Andre Petroski,Blue,Middleweight
+11/12/2022,Matt Frevola,Ottman Azaitar,Red,Lightweight
+11/12/2022,Karolina Kowalkiewicz,Silvana Gomez Juarez,Red,Women's Strawweight
+11/12/2022,Michael Trizano,SeungWoo Choi,Red,Featherweight
+11/12/2022,Julio Arce,Montel Jackson,Blue,Bantamweight
+11/12/2022,Carlos Ulberg,Nicolae Negumereanu,Red,Light Heavyweight
+11/05/2022,Marina Rodriguez,Amanda Lemos,Blue,Women's Strawweight
+11/05/2022,Daniel Rodriguez,Neil Magny,Blue,Welterweight
+11/05/2022,Darrick Minner,Shayilan Nuerdanbieke,Blue,Featherweight
+11/05/2022,Nate Maness,Tagir Ulanbekov,Blue,Flyweight
+11/05/2022,Grant Dawson,Mark Madsen,Red,Lightweight
+11/05/2022,Shanna Young,Miranda Maverick,Blue,Women's Flyweight
+11/05/2022,Benito Lopez,Mario Bautista,Blue,Bantamweight
+11/05/2022,Polyana Viana,Jinh Yu Frey,Red,Women's Strawweight
+11/05/2022,Liudvik Sholinian,Johnny Munoz,Blue,Bantamweight
+11/05/2022,Carlos Candelario,Jake Hadley,Blue,Flyweight
+11/05/2022,Ramona Pascual,Tamires Vidal,Blue,Women's Bantamweight
+10/29/2022,Calvin Kattar,Arnold Allen,Blue,Featherweight
+10/29/2022,Tim Means,Max Griffin,Blue,Welterweight
+10/29/2022,Jared Vanderaa,Waldo Cortes-Acosta,Blue,Heavyweight
+10/29/2022,Tresean Gore,Josh Fremd,Red,Middleweight
+10/29/2022,Khalil Rountree Jr.,Dustin Jacoby,Red,Light Heavyweight
+10/29/2022,Roman Dolidze,Phil Hawes,Red,Middleweight
+10/29/2022,Marcos Rogerio de Lima,Andrei Arlovski,Red,Heavyweight
+10/29/2022,JunYong Park,Joseph Holmes,Red,Middleweight
+10/29/2022,Steve Garcia,Chase Hooper,Red,Featherweight
+10/29/2022,Cody Durden,Carlos Mota,Red,Flyweight
+10/29/2022,Christian Rodriguez,Joshua Weems,Red,Bantamweight
+10/22/2022,Islam Makhachev,Charles Oliveira,Red,UFC Lightweight Title
+10/22/2022,TJ Dillashaw,Aljamain Sterling,Blue,UFC Bantamweight Title
+10/22/2022,Sean O'Malley,Petr Yan,Red,Bantamweight
+10/22/2022,Mateusz Gamrot,Beneil Dariush,Blue,Lightweight
+10/22/2022,Katlyn Cerminara,Manon Fiorot,Blue,Women's Flyweight
+10/22/2022,Belal Muhammad,Sean Brady,Red,Welterweight
+10/22/2022,Caio Borralho,Makhmud Muradov,Red,Middleweight
+10/22/2022,Volkan Oezdemir,Nikita Krylov,Blue,Light Heavyweight
+10/22/2022,Abubakar Nurmagomedov,Gadzhi Omargadzhiev,Red,Welterweight
+10/22/2022,AJ Dobson,Armen Petrosyan,Blue,Middleweight
+10/22/2022,Muhammad Mokaev,Malcolm Gordon,Red,Flyweight
+10/22/2022,Lina Lansberg,Karol Rosa,Blue,Women's Bantamweight
+10/15/2022,Viviane Araujo,Alexa Grasso,Blue,Women's Flyweight
+10/15/2022,Cub Swanson,Jonathan Martinez,Blue,Bantamweight
+10/15/2022,Jordan Wright,Dusko Todorovic,Blue,Middleweight
+10/15/2022,Raphael Assuncao,Victor Henry,Red,Bantamweight
+10/15/2022,Alonzo Menifield,Misha Cirkunov,Red,Light Heavyweight
+10/15/2022,Mana Martinez,Brandon Davis,Red,Bantamweight
+10/15/2022,Nick Maximov,Jacob Malkoun,Blue,Middleweight
+10/15/2022,Joanderson Brito,Lucas Alexander,Red,Featherweight
+10/15/2022,Piera Rodriguez,Sam Hughes,Red,Women's Strawweight
+10/15/2022,Tatsuro Taira,CJ Vergara,Red,Flyweight
+10/15/2022,Mike Jackson,Pete Rodriguez,Blue,Welterweight
+10/01/2022,Yan Xiaonan,Mackenzie Dern,Red,Women's Strawweight
+10/01/2022,Randy Brown,Francisco Trinaldo,Red,Welterweight
+10/01/2022,Trevin Jones,Raoni Barcelos,Blue,Bantamweight
+10/01/2022,Sodiq Yusuff,Don Shainis,Red,Featherweight
+10/01/2022,Viacheslav Borshchev,Mike Davis,Blue,Lightweight
+10/01/2022,John Castaneda,Daniel Santos,Blue,Catch Weight
+10/01/2022,Ilir Latifi,Aleksei Oleinik,Red,Heavyweight
+10/01/2022,Joaquim Silva,Jesse Ronson,Red,Lightweight
+10/01/2022,Brendan Allen,Krzysztof Jotko,Red,Middleweight
+10/01/2022,Julija Stoliarenko,Chelsea Chandler,Blue,Catch Weight
+10/01/2022,Randy Costa,Guido Cannetti,Blue,Bantamweight
+09/17/2022,Cory Sandhagen,Song Yadong,Red,Bantamweight
+09/17/2022,Gregory Rodrigues,Chidi Njokuani,Red,Middleweight
+09/17/2022,Andre Fili,Bill Algeo,Red,Featherweight
+09/17/2022,Alen Amedovski,Joe Pyfer,Blue,Middleweight
+09/17/2022,Rodrigo Nascimento,Tanner Boser,Red,Heavyweight
+09/17/2022,Anthony Hernandez,Marc-Andre Barriault,Red,Middleweight
+09/17/2022,Pat Sabatini,Damon Jackson,Blue,Featherweight
+09/17/2022,Trevin Giles,Louis Cosce,Red,Welterweight
+09/17/2022,Loma Lookboonmee,Denise Gomes,Red,Women's Strawweight
+09/17/2022,Trey Ogden,Daniel Zellhuber,Red,Lightweight
+09/17/2022,Mariya Agapova,Gillian Robertson,Blue,Women's Flyweight
+09/17/2022,Javid Basharat,Tony Gravely,Red,Bantamweight
+09/17/2022,Cameron VanCamp,Nikolas Motta,Blue,Lightweight
+09/10/2022,Nate Diaz,Tony Ferguson,Red,Welterweight
+09/10/2022,Kevin Holland,Khamzat Chimaev,Blue,Catch Weight
+09/10/2022,Li Jingliang,Daniel Rodriguez,Blue,Catch Weight
+09/10/2022,Irene Aldana,Macy Chiasson,Red,Catch Weight
+09/10/2022,Ion Cutelaba,Johnny Walker,Blue,Light Heavyweight
+09/10/2022,Julian Erosa,Hakeem Dawodu,Red,Featherweight
+09/10/2022,Anton Turkalj,Jailton Almeida,Blue,Catch Weight
+09/10/2022,Jamie Pickett,Denis Tiuliulin,Blue,Middleweight
+09/10/2022,Jake Collier,Chris Barnett,Blue,Heavyweight
+09/10/2022,Norma Dumont,Danyelle Wolf,Red,Women's Featherweight
+09/10/2022,Alatengheili,Chad Anheliger,Red,Bantamweight
+09/10/2022,Elise Reed,Melissa Martinez,Red,Women's Strawweight
+09/10/2022,Darian Weeks,Yohan Lainesse,Blue,Welterweight
+09/03/2022,Ciryl Gane,Tai Tuivasa,Red,Heavyweight
+09/03/2022,Marvin Vettori,Robert Whittaker,Blue,Middleweight
+09/03/2022,Nassourdine Imavov,Joaquin Buckley,Red,Middleweight
+09/03/2022,Alessio Di Chirico,Roman Kopylov,Blue,Middleweight
+09/03/2022,Jarno Errens,William Gomis,Blue,Featherweight
+09/03/2022,Nathaniel Wood,Charles Jourdain,Red,Featherweight
+09/03/2022,Dustin Stoltzfus,Abus Magomedov,Blue,Middleweight
+09/03/2022,Nasrat Haqparast,John Makdessi,Red,Lightweight
+09/03/2022,Fares Ziam,Michal Figlak,Red,Lightweight
+09/03/2022,Gabriel Miranda,Benoit Saint Denis,Blue,Lightweight
+09/03/2022,Khalid Taha,Cristian Quinonez,Blue,Bantamweight
+09/03/2022,Stephanie Egger,Ailin Perez,Red,Women's Featherweight
+08/20/2022,Kamaru Usman,Leon Edwards,Blue,UFC Welterweight Title
+08/20/2022,Paulo Costa,Luke Rockhold,Red,Middleweight
+08/20/2022,Jose Aldo,Merab Dvalishvili,Blue,Bantamweight
+08/20/2022,Wu Yanan,Lucie Pudilova,Blue,Women's Bantamweight
+08/20/2022,Tyson Pedro,Harry Hunsucker,Red,Light Heavyweight
+08/20/2022,Alexandr Romanov,Marcin Tybura,Blue,Heavyweight
+08/20/2022,Jared Gordon,Leonardo Santos,Red,Lightweight
+08/20/2022,Ange Loosa,AJ Fletcher,Red,Welterweight
+08/20/2022,Amir Albazi,Francisco Figueiredo,Red,Flyweight
+08/20/2022,Aoriqileng,Jay Perrin,Red,Bantamweight
+08/20/2022,Daniel Lacerda,Victor Altamirano,Blue,Flyweight
+08/13/2022,Dominick Cruz,Marlon Vera,Blue,Bantamweight
+08/13/2022,Nate Landwehr,David Onama,Red,Featherweight
+08/13/2022,Yazmin Jauregui,Iasmin Lucindo,Red,Women's Strawweight
+08/13/2022,Devin Clark,Azamat Murzakanov,Blue,Light Heavyweight
+08/13/2022,Priscila Cachoeira,Ariane Lipski,Red,Women's Bantamweight
+08/13/2022,Bruno Silva,Gerald Meerschaert,Blue,Middleweight
+08/13/2022,Loopy Godinez,Angela Hill,Blue,Catch Weight
+08/13/2022,Martin Buday,Lukasz Brzeski,Red,Heavyweight
+08/13/2022,Nina Nunes,Cynthia Calvillo,Red,Women's Flyweight
+08/13/2022,Gabriel Benitez,Charlie Ontiveros,Red,Lightweight
+08/13/2022,Tyson Nam,Ode Osbourne,Red,Flyweight
+08/13/2022,Josh Quinlan,Jason Witt,Red,Catch Weight
+08/06/2022,Jamahal Hill,Thiago Santos,Red,Light Heavyweight
+08/06/2022,Vicente Luque,Geoff Neal,Blue,Welterweight
+08/06/2022,Mohammed Usman,Zac Pauga,Red,Heavyweight
+08/06/2022,Juliana Miller,Brogan Walker,Red,Women's Flyweight
+08/06/2022,Serghei Spivac,Augusto Sakai,Red,Heavyweight
+08/06/2022,Erick Gonzalez,Terrance McKinney,Blue,Lightweight
+08/06/2022,Michal Oleksiejczuk,Sam Alvey,Red,Middleweight
+08/06/2022,Bryan Battle,Takashi Sato,Red,Welterweight
+08/06/2022,Miranda Granger,Cory McKenna,Blue,Women's Strawweight
+08/06/2022,Mayra Bueno Silva,Stephanie Egger,Red,Women's Bantamweight
+07/30/2022,Julianna Pena,Amanda Nunes,Blue,UFC Women's Bantamweight Title
+07/30/2022,Kai Kara-France,Brandon Moreno,Blue,UFC Interim Flyweight Title
+07/30/2022,Sergei Pavlovich,Derrick Lewis,Red,Heavyweight
+07/30/2022,Alexandre Pantoja,Alex Perez,Red,Flyweight
+07/30/2022,Anthony Smith,Magomed Ankalaev,Blue,Light Heavyweight
+07/30/2022,Alex Morono,Matthew Semelsberger,Red,Welterweight
+07/30/2022,Rafael Alves,Drew Dober,Blue,Lightweight
+07/30/2022,Rafa Garcia,Drakkar Klose,Blue,Lightweight
+07/30/2022,Michael Morales,Adam Fugitt,Red,Welterweight
+07/30/2022,Ji Yeon Kim,Joselyne Edwards,Blue,Women's Bantamweight
+07/30/2022,Nicolae Negumereanu,Ihor Potieria,Red,Light Heavyweight
+07/30/2022,Orion Cosce,Blood Diamond,Red,Welterweight
+07/23/2022,Tom Aspinall,Curtis Blaydes,Blue,Heavyweight
+07/23/2022,Jack Hermansson,Chris Curtis,Red,Middleweight
+07/23/2022,Paddy Pimblett,Jordan Leavitt,Red,Lightweight
+07/23/2022,Nikita Krylov,Alexander Gustafsson,Red,Light Heavyweight
+07/23/2022,Hannah Goldy,Molly McCann,Blue,Women's Flyweight
+07/23/2022,Paul Craig,Volkan Oezdemir,Blue,Light Heavyweight
+07/23/2022,Mason Jones,Ludovit Klein,Blue,Lightweight
+07/23/2022,Damir Hadzovic,Marc Diakiese,Blue,Lightweight
+07/23/2022,Charles Rosa,Nathaniel Wood,Blue,Featherweight
+07/23/2022,Jonathan Pearce,Makwan Amirkhani,Red,Featherweight
+07/23/2022,Muhammad Mokaev,Charles Johnson,Red,Flyweight
+07/23/2022,Kyle Nelson,Jai Herbert,Blue,Lightweight
+07/23/2022,Mandy Bohm,Victoria Leonardo,Blue,Women's Flyweight
+07/23/2022,Nicolas Dalby,Claudio Silva,Red,Welterweight
+07/16/2022,Yair Rodriguez,Brian Ortega,Red,Featherweight
+07/16/2022,Michelle Waterson-Gomez,Amanda Lemos,Blue,Women's Strawweight
+07/16/2022,Li Jingliang,Muslim Salikhov,Red,Welterweight
+07/16/2022,Matt Schnell,Sumudaerji,Red,Flyweight
+07/16/2022,Charles Jourdain,Shane Burgos,Blue,Featherweight
+07/16/2022,Miesha Tate,Lauren Murphy,Blue,Women's Flyweight
+07/16/2022,Punahele Soriano,Dalcha Lungiambula,Red,Middleweight
+07/16/2022,Jack Shore,Ricky Simon,Blue,Bantamweight
+07/16/2022,Herbert Burns,Bill Algeo,Blue,Featherweight
+07/16/2022,Da Woon Jung,Dustin Jacoby,Blue,Light Heavyweight
+07/16/2022,Dustin Stoltzfus,Dwight Grant,Red,Middleweight
+07/16/2022,Jessica Penne,Emily Ducote,Blue,Women's Strawweight
+07/09/2022,Rafael Dos Anjos,Rafael Fiziev,Blue,Lightweight
+07/09/2022,Caio Borralho,Armen Petrosyan,Red,Middleweight
+07/09/2022,Said Nurmagomedov,Douglas Silva de Andrade,Red,Bantamweight
+07/09/2022,Jared Vanderaa,Chase Sherman,Blue,Heavyweight
+07/09/2022,Ricky Turcios,Aiemann Zahabi,Blue,Bantamweight
+07/09/2022,Jamie Mullarkey,Michael Johnson,Red,Lightweight
+07/09/2022,Cody Brundage,Tresean Gore,Red,Middleweight
+07/09/2022,Cortney Casey,Antonina Shevchenko,Blue,Women's Flyweight
+07/09/2022,David Onama,Garrett Armfield,Red,Featherweight
+07/09/2022,Kennedy Nzechukwu,Karl Roberson,Red,Light Heavyweight
+07/09/2022,Ronnie Lawrence,Saidyokub Kakhramonov,Blue,Bantamweight
+07/02/2022,Israel Adesanya,Jared Cannonier,Red,UFC Middleweight Title
+07/02/2022,Alexander Volkanovski,Max Holloway,Red,UFC Featherweight Title
+07/02/2022,Alex Pereira,Sean Strickland,Red,Middleweight
+07/02/2022,Bryan Barberena,Robbie Lawler,Red,Welterweight
+07/02/2022,Brad Riddell,Jalin Turner,Blue,Lightweight
+07/02/2022,Donald Cerrone,Jim Miller,Blue,Welterweight
+07/02/2022,Gabe Green,Ian Machado Garry,Blue,Welterweight
+07/02/2022,Dricus Du Plessis,Brad Tavares,Red,Middleweight
+07/02/2022,Uriah Hall,Andre Muniz,Blue,Middleweight
+07/02/2022,Maycee Barber,Jessica Eye,Red,Women's Flyweight
+07/02/2022,Jessica-Rose Clark,Julija Stoliarenko,Blue,Women's Bantamweight
+06/25/2022,Mateusz Gamrot,Arman Tsarukyan,Red,Lightweight
+06/25/2022,Neil Magny,Shavkat Rakhmonov,Blue,Welterweight
+06/25/2022,Josh Parisian,Alan Baudot,Red,Heavyweight
+06/25/2022,Christos Giagos,Thiago Moises,Blue,Lightweight
+06/25/2022,Nate Maness,Umar Nurmagomedov,Blue,Bantamweight
+06/25/2022,Chris Curtis,Rodolfo Vieira,Red,Middleweight
+06/25/2022,Tafon Nchukwi,Carlos Ulberg,Blue,Light Heavyweight
+06/25/2022,Shayilan Nuerdanbieke,TJ Brown,Red,Featherweight
+06/25/2022,Raulian Paiva,Sergey Morozov,Blue,Bantamweight
+06/25/2022,Cody Durden,JP Buys,Red,Flyweight
+06/25/2022,Mario Bautista,Brian Kelleher,Red,Bantamweight
+06/25/2022,Jinh Yu Frey,Vanessa Demopoulos,Blue,Women's Strawweight
+06/18/2022,Calvin Kattar,Josh Emmett,Blue,Featherweight
+06/18/2022,Tim Means,Kevin Holland,Blue,Welterweight
+06/18/2022,Joaquin Buckley,Albert Duraev,Red,Middleweight
+06/18/2022,Damir Ismagulov,Guram Kutateladze,Red,Lightweight
+06/18/2022,Gregory Rodrigues,Julian Marquez,Red,Middleweight
+06/18/2022,Adrian Yanez,Tony Kelley,Red,Bantamweight
+06/18/2022,Natalia Silva,Jasmine Jasudavicius,Red,Women's Flyweight
+06/18/2022,Court McGee,Jeremiah Wells,Blue,Welterweight
+06/18/2022,Ricardo Ramos,Danny Chavez,Red,Featherweight
+06/18/2022,Maria Oliveira,Gloria de Paula,Red,Women's Strawweight
+06/18/2022,Cody Stamann,Eddie Wineland,Red,Bantamweight
+06/18/2022,Deron Winn,Phil Hawes,Blue,Middleweight
+06/18/2022,Kyle Daukaus,Roman Dolidze,Blue,Middleweight
+06/11/2022,Jiri Prochazka,Glover Teixeira,Red,UFC Light Heavyweight Title
+06/11/2022,Taila Santos,Valentina Shevchenko,Blue,UFC Women's Flyweight Title
+06/11/2022,Joanna Jedrzejczyk,Zhang Weili,Blue,Women's Strawweight
+06/11/2022,Andre Fialho,Jake Matthews,Blue,Welterweight
+06/11/2022,Ramazan Emeev,Jack Della Maddalena,Blue,Welterweight
+06/11/2022,Josh Culibao,SeungWoo Choi,Red,Featherweight
+06/11/2022,Steve Garcia,Maheshate,Blue,Lightweight
+06/11/2022,Jacob Malkoun,Brendan Allen,Blue,Middleweight
+06/11/2022,Batgerel Danaa,Kyung Ho Kang,Blue,Bantamweight
+06/11/2022,Liang Na,Silvana Gomez Juarez,Blue,Women's Strawweight
+06/11/2022,Joselyne Edwards,Ramona Pascual,Red,Women's Featherweight
+06/04/2022,Jairzinho Rozenstruik,Alexander Volkov,Blue,Heavyweight
+06/04/2022,Movsar Evloev,Dan Ige,Red,Featherweight
+06/04/2022,Michael Trizano,Lucas Almeida,Blue,Featherweight
+06/04/2022,Karine Silva,Poliana Botelho,Red,Women's Flyweight
+06/04/2022,Ode Osbourne,Zarrukh Adashev,Red,Flyweight
+06/04/2022,Askar Mozharov,Alonzo Menifield,Blue,Light Heavyweight
+06/04/2022,Felice Herrig,Karolina Kowalkiewicz,Blue,Women's Strawweight
+06/04/2022,Alex Da Silva,Joe Solecki,Blue,Lightweight
+06/04/2022,Damon Jackson,Dan Argueta,Red,Featherweight
+06/04/2022,Niklas Stolze,Benoit Saint Denis,Blue,Lightweight
+06/04/2022,Johnny Munoz,Tony Gravely,Blue,Bantamweight
+06/04/2022,Zhalgas Zhumagulov,Jeff Molina,Blue,Flyweight
+06/04/2022,Andreas Michailidis,Rinat Fakhretdinov,Blue,Welterweight
+06/04/2022,Erin Blanchfield,JJ Aldrich,Red,Women's Flyweight
+05/21/2022,Ketlen Vieira,Holly Holm,Red,Women's Bantamweight
+05/21/2022,Michel Pereira,Santiago Ponzinibbio,Red,Welterweight
+05/21/2022,Dusko Todorovic,Chidi Njokuani,Blue,Middleweight
+05/21/2022,Tabatha Ricci,Polyana Viana,Red,Women's Strawweight
+05/21/2022,Eryk Anders,JunYong Park,Blue,Middleweight
+05/21/2022,Joseph Holmes,Alen Amedovski,Red,Middleweight
+05/21/2022,Jailton Almeida,Parker Porter,Red,Heavyweight
+05/21/2022,Uros Medic,Omar Morales,Red,Lightweight
+05/21/2022,Vince Morales,Jonathan Martinez,Blue,Bantamweight
+05/21/2022,Felipe Colares,Chase Hooper,Blue,Featherweight
+05/21/2022,Sam Hughes,Elise Reed,Red,Women's Strawweight
+05/14/2022,Jan Blachowicz,Aleksandar Rakic,Red,Light Heavyweight
+05/14/2022,Ion Cutelaba,Ryan Spann,Blue,Light Heavyweight
+05/14/2022,Davey Grant,Louis Smolka,Red,Bantamweight
+05/14/2022,Amanda Ribas,Katlyn Cerminara,Blue,Women's Flyweight
+05/14/2022,Frank Camacho,Manuel Torres,Blue,Lightweight
+05/14/2022,Allan Nascimento,Jake Hadley,Red,Flyweight
+05/14/2022,Andrea Lee,Viviane Araujo,Blue,Women's Flyweight
+05/14/2022,Alan Patrick,Michael Johnson,Blue,Lightweight
+05/14/2022,Virna Jandiroba,Angela Hill,Red,Women's Strawweight
+05/14/2022,Tatsuro Taira,Carlos Candelario,Red,Flyweight
+05/14/2022,Andre Petroski,Nick Maximov,Red,Middleweight
+05/07/2022,Justin Gaethje,Charles Oliveira,Blue,Lightweight
+05/07/2022,Rose Namajunas,Carla Esparza,Blue,UFC Women's Strawweight Title
+05/07/2022,Michael Chandler,Tony Ferguson,Red,Lightweight
+05/07/2022,Mauricio Rua,Ovince Saint Preux,Blue,Light Heavyweight
+05/07/2022,Khaos Williams,Randy Brown,Blue,Welterweight
+05/07/2022,Danny Roberts,Francisco Trinaldo,Blue,Welterweight
+05/07/2022,Norma Dumont,Macy Chiasson,Blue,Women's Featherweight
+05/07/2022,Brandon Royval,Matt Schnell,Red,Flyweight
+05/07/2022,Marcos Rogerio de Lima,Blagoy Ivanov,Blue,Heavyweight
+05/07/2022,Cameron VanCamp,Andre Fialho,Blue,Welterweight
+05/07/2022,Melissa Gatto,Tracy Cortez,Blue,Women's Flyweight
+05/07/2022,Kleydson Rodrigues,CJ Vergara,Blue,Flyweight
+05/07/2022,Loopy Godinez,Ariane Carnelossi,Red,Women's Strawweight
+05/07/2022,Journey Newson,Fernie Garcia,Red,Bantamweight
+04/30/2022,Rob Font,Marlon Vera,Blue,Bantamweight
+04/30/2022,Jake Collier,Andrei Arlovski,Blue,Heavyweight
+04/30/2022,Joanderson Brito,Andre Fili,Red,Featherweight
+04/30/2022,Jared Gordon,Grant Dawson,Blue,Lightweight
+04/30/2022,Tristan Connelly,Darren Elkins,Blue,Featherweight
+04/30/2022,Krzysztof Jotko,Gerald Meerschaert,Red,Middleweight
+04/30/2022,Chase Sherman,Alexandr Romanov,Blue,Heavyweight
+04/30/2022,Francisco Figueiredo,Daniel Lacerda,Red,Flyweight
+04/30/2022,Gabe Green,Yohan Lainesse,Red,Welterweight
+04/30/2022,Mike Breeden,Natan Levy,Blue,Lightweight
+04/30/2022,Shanna Young,Gina Mazany,Red,Women's Flyweight
+04/23/2022,Amanda Lemos,Jessica Andrade,Blue,Women's Strawweight
+04/23/2022,Claudio Puelles,Clay Guida,Red,Lightweight
+04/23/2022,Montana De La Rosa,Maycee Barber,Blue,Women's Flyweight
+04/23/2022,Lando Vannata,Charles Jourdain,Blue,Featherweight
+04/23/2022,Jordan Wright,Marc-Andre Barriault,Blue,Catch Weight
+04/23/2022,Sergey Khandozhko,Dwight Grant,Red,Welterweight
+04/23/2022,Tyson Pedro,Ike Villanueva,Red,Light Heavyweight
+04/23/2022,Aoriqileng,Cameron Else,Red,Bantamweight
+04/23/2022,Evan Elder,Preston Parsons,Blue,Welterweight
+04/23/2022,Marcin Prachnio,Philipe Lins,Blue,Light Heavyweight
+04/23/2022,Mike Jackson,Dean Barry,Red,Welterweight
+04/16/2022,Belal Muhammad,Vicente Luque,Red,Welterweight
+04/16/2022,Gadzhi Omargadzhiev,Caio Borralho,Blue,Middleweight
+04/16/2022,Andre Fialho,Miguel Baeza,Red,Welterweight
+04/16/2022,Wu Yanan,Mayra Bueno Silva,Blue,Women's Bantamweight
+04/16/2022,Pat Sabatini,TJ Laramie,Red,Featherweight
+04/16/2022,Ange Loosa,Mounir Lazzez,Blue,Welterweight
+04/16/2022,Devin Clark,William Knight,Red,Heavyweight
+04/16/2022,Lina Lansberg,Pannie Kianzad,Blue,Women's Bantamweight
+04/16/2022,Drakkar Klose,Brandon Jenkins,Red,Lightweight
+04/16/2022,Jesse Ronson,Rafa Garcia,Blue,Lightweight
+04/16/2022,Chris Barnett,Martin Buday,Blue,Heavyweight
+04/16/2022,Jordan Leavitt,Trey Ogden,Red,Lightweight
+04/16/2022,Istela Nunes,Sam Hughes,Blue,Women's Strawweight
+04/16/2022,Alatengheili,Kevin Croom,Red,Bantamweight
+04/09/2022,Alexander Volkanovski,Chan Sung Jung,Red,UFC Featherweight Title
+04/09/2022,Aljamain Sterling,Petr Yan,Red,UFC Bantamweight Title
+04/09/2022,Gilbert Burns,Khamzat Chimaev,Blue,Welterweight
+04/09/2022,Mackenzie Dern,Tecia Torres,Red,Women's Strawweight
+04/09/2022,Vinc Pichel,Mark Madsen,Blue,Lightweight
+04/09/2022,Darian Weeks,Ian Machado Garry,Blue,Welterweight
+04/09/2022,Josh Fremd,Anthony Hernandez,Blue,Middleweight
+04/09/2022,Aspen Ladd,Raquel Pennington,Blue,Women's Bantamweight
+04/09/2022,Mike Malott,Mickey Gall,Red,Welterweight
+04/09/2022,Aleksei Oleinik,Jared Vanderaa,Red,Heavyweight
+04/09/2022,Kay Hansen,Piera Rodriguez,Blue,Women's Strawweight
+04/09/2022,Daniel Santos,Julio Arce,Blue,Bantamweight
+03/26/2022,Chris Daukaus,Curtis Blaydes,Blue,Heavyweight
+03/26/2022,Alexa Grasso,Joanne Wood,Red,Women's Flyweight
+03/26/2022,Bryan Barberena,Matt Brown,Red,Welterweight
+03/26/2022,Askar Askarov,Kai Kara-France,Blue,Flyweight
+03/26/2022,Max Griffin,Neil Magny,Blue,Welterweight
+03/26/2022,Marc Diakiese,Viacheslav Borshchev,Red,Lightweight
+03/26/2022,Karol Rosa,Sara McMann,Blue,Women's Bantamweight
+03/26/2022,Batgerel Danaa,Chris Gutierrez,Blue,Bantamweight
+03/26/2022,Denis Tiuliulin,Aliaskhab Khizriev,Blue,Middleweight
+03/26/2022,Manon Fiorot,Jennifer Maia,Red,Women's Flyweight
+03/26/2022,Matheus Nicolau,David Dvorak,Red,Flyweight
+03/26/2022,Luis Saldana,Bruno Souza,Red,Featherweight
+03/19/2022,Alexander Volkov,Tom Aspinall,Blue,Heavyweight
+03/19/2022,Arnold Allen,Dan Hooker,Red,Featherweight
+03/19/2022,Kazula Vargas,Paddy Pimblett,Blue,Lightweight
+03/19/2022,Takashi Sato,Gunnar Nelson,Blue,Welterweight
+03/19/2022,Molly McCann,Luana Carolina,Red,Women's Flyweight
+03/19/2022,Jai Herbert,Ilia Topuria,Blue,Lightweight
+03/19/2022,Makwan Amirkhani,Mike Grundy,Red,Featherweight
+03/19/2022,Shamil Abdurakhimov,Sergei Pavlovich,Blue,Heavyweight
+03/19/2022,Paul Craig,Nikita Krylov,Red,Light Heavyweight
+03/19/2022,Jack Shore,Timur Valiev,Red,Bantamweight
+03/19/2022,Elise Reed,Cory McKenna,Red,Women's Strawweight
+03/19/2022,Muhammad Mokaev,Cody Durden,Red,Flyweight
+03/12/2022,Thiago Santos,Magomed Ankalaev,Blue,Light Heavyweight
+03/12/2022,Song Yadong,Marlon Moraes,Red,Bantamweight
+03/12/2022,Alex Caceres,Sodiq Yusuff,Blue,Featherweight
+03/12/2022,Karl Roberson,Khalil Rountree Jr.,Blue,Light Heavyweight
+03/12/2022,Terrance McKinney,Drew Dober,Blue,Lightweight
+03/12/2022,Bruno Silva,Alex Pereira,Blue,Middleweight
+03/12/2022,Matthew Semelsberger,AJ Fletcher,Red,Welterweight
+03/12/2022,JJ Aldrich,Gillian Robertson,Red,Women's Flyweight
+03/12/2022,Trevin Jones,Javid Basharat,Blue,Bantamweight
+03/12/2022,Damon Jackson,Kamuela Kirk,Red,Featherweight
+03/12/2022,Miranda Maverick,Sabina Mazo,Red,Women's Flyweight
+03/12/2022,Dalcha Lungiambula,Cody Brundage,Blue,Middleweight
+03/12/2022,Kris Moutinho,Guido Cannetti,Blue,Bantamweight
+03/12/2022,Azamat Murzakanov,Tafon Nchukwi,Red,Light Heavyweight
+03/05/2022,Jorge Masvidal,Colby Covington,Blue,Welterweight
+03/05/2022,Rafael Dos Anjos,Renato Moicano,Red,Catch Weight
+03/05/2022,Bryce Mitchell,Edson Barboza,Red,Featherweight
+03/05/2022,Kevin Holland,Alex Oliveira,Red,Welterweight
+03/05/2022,Serghei Spivac,Greg Hardy,Red,Heavyweight
+03/05/2022,Jamie Mullarkey,Jalin Turner,Blue,Lightweight
+03/05/2022,Marina Rodriguez,Yan Xiaonan,Red,Women's Strawweight
+03/05/2022,Nicolae Negumereanu,Kennedy Nzechukwu,Red,Light Heavyweight
+03/05/2022,Mariya Agapova,Maryna Moroz,Blue,Women's Flyweight
+03/05/2022,Brian Kelleher,Umar Nurmagomedov,Blue,Featherweight
+03/05/2022,Tim Elliott,Tagir Ulanbekov,Red,Flyweight
+03/05/2022,Ludovit Klein,Devonte Smith,Red,Lightweight
+03/05/2022,Dustin Jacoby,Michal Oleksiejczuk,Red,Light Heavyweight
+02/26/2022,Islam Makhachev,Bobby Green,Red,Catch Weight
+02/26/2022,Wellington Turman,Misha Cirkunov,Red,Middleweight
+02/26/2022,Ji Yeon Kim,Priscila Cachoeira,Blue,Women's Flyweight
+02/26/2022,Joel Alvarez,Arman Tsarukyan,Blue,Lightweight
+02/26/2022,Armen Petrosyan,Gregory Rodrigues,Red,Middleweight
+02/26/2022,Ignacio Bahamondes,Rongzhu,Red,Lightweight
+02/26/2022,Ramona Pascual,Josiane Nunes,Blue,Women's Featherweight
+02/26/2022,Terrance McKinney,Fares Ziam,Red,Lightweight
+02/26/2022,Jonathan Martinez,Alejandro Perez,Red,Featherweight
+02/26/2022,Ramiz Brahimaj,Micheal Gillmore,Red,Welterweight
+02/26/2022,Carlos Hernandez,Victor Altamirano,Red,Flyweight
+02/19/2022,Jamahal Hill,Johnny Walker,Red,Light Heavyweight
+02/19/2022,Jamie Pickett,Kyle Daukaus,Blue,Catch Weight
+02/19/2022,Alan Baudot,Parker Porter,Blue,Heavyweight
+02/19/2022,Nikolas Motta,Jim Miller,Blue,Lightweight
+02/19/2022,Joaquin Buckley,Abdul Razak Alhassan,Red,Middleweight
+02/19/2022,David Onama,Gabriel Benitez,Red,Featherweight
+02/19/2022,Jessica-Rose Clark,Stephanie Egger,Blue,Women's Bantamweight
+02/19/2022,Mark Striegl,Chas Skelly,Blue,Featherweight
+02/19/2022,Gloria de Paula,Diana Belbita,Red,Women's Strawweight
+02/19/2022,Chad Anheliger,Jesse Strader,Red,Bantamweight
+02/19/2022,Christian Rodriguez,Jonathan Pearce,Blue,Featherweight
+02/19/2022,Mario Bautista,Jay Perrin,Red,Bantamweight
+02/12/2022,Israel Adesanya,Robert Whittaker,Red,UFC Middleweight Title
+02/12/2022,Tai Tuivasa,Derrick Lewis,Red,Heavyweight
+02/12/2022,Derek Brunson,Jared Cannonier,Blue,Middleweight
+02/12/2022,Alexander Hernandez,Renato Moicano,Blue,Lightweight
+02/12/2022,Nasrat Haqparast,Bobby Green,Blue,Lightweight
+02/12/2022,Jared Vanderaa,Andrei Arlovski,Blue,Heavyweight
+02/12/2022,Casey O'Neill,Roxanne Modafferi,Red,Women's Flyweight
+02/12/2022,Marcelo Rojo,Kyler Phillips,Blue,Bantamweight
+02/12/2022,Fabio Cherant,Carlos Ulberg,Blue,Light Heavyweight
+02/12/2022,Ronnie Lawrence,Mana Martinez,Red,Bantamweight
+02/12/2022,Jacob Malkoun,AJ Dobson,Red,Middleweight
+02/12/2022,Douglas Silva de Andrade,Sergey Morozov,Red,Bantamweight
+02/12/2022,Blood Diamond,Jeremiah Wells,Blue,Welterweight
+02/12/2022,William Knight,Maxim Grishin,Blue,Heavyweight
+02/05/2022,Sean Strickland,Jack Hermansson,Red,Middleweight
+02/05/2022,Punahele Soriano,Nick Maximov,Blue,Middleweight
+02/05/2022,Carlston Harris,Shavkat Rakhmonov,Blue,Welterweight
+02/05/2022,Brendan Allen,Sam Alvey,Red,Light Heavyweight
+02/05/2022,Tresean Gore,Bryan Battle,Blue,Middleweight
+02/05/2022,Steven Peterson,Julian Erosa,Blue,Featherweight
+02/05/2022,Miles Johns,John Castaneda,Blue,Bantamweight
+02/05/2022,Michael Trizano,Hakeem Dawodu,Blue,Featherweight
+02/05/2022,Marc-Andre Barriault,Chidi Njokuani,Blue,Middleweight
+02/05/2022,Alexis Davis,Julija Stoliarenko,Red,Women's Bantamweight
+02/05/2022,Danilo Marques,Jailton Almeida,Blue,Light Heavyweight
+02/05/2022,Phil Rowe,Jason Witt,Red,Welterweight
+02/05/2022,Denys Bondar,Malcolm Gordon,Blue,Flyweight
+01/22/2022,Francis Ngannou,Ciryl Gane,Red,UFC Heavyweight Title
+01/22/2022,Deiveson Figueiredo,Brandon Moreno,Red,UFC Flyweight Title
+01/22/2022,Michel Pereira,Andre Fialho,Red,Welterweight
+01/22/2022,Said Nurmagomedov,Cody Stamann,Red,Bantamweight
+01/22/2022,Trevin Giles,Michael Morales,Blue,Welterweight
+01/22/2022,Raoni Barcelos,Victor Henry,Blue,Bantamweight
+01/22/2022,Jack Della Maddalena,Pete Rodriguez,Red,Welterweight
+01/22/2022,Tony Gravely,Saimon Oliveira,Red,Bantamweight
+01/22/2022,Genaro Valdez,Matt Frevola,Blue,Lightweight
+01/22/2022,Vanessa Demopoulos,Silvana Gomez Juarez,Red,Women's Strawweight
+01/22/2022,Jasmine Jasudavicius,Kay Hansen,Red,Women's Flyweight
+01/15/2022,Giga Chikadze,Calvin Kattar,Blue,Featherweight
+01/15/2022,Jake Collier,Chase Sherman,Red,Heavyweight
+01/15/2022,Rogerio Bontorin,Brandon Royval,Blue,Flyweight
+01/15/2022,Jennifer Maia,Katlyn Cerminara,Blue,Women's Flyweight
+01/15/2022,Dakota Bush,Viacheslav Borshchev,Blue,Lightweight
+01/15/2022,Bill Algeo,Joanderson Brito,Red,Featherweight
+01/15/2022,Joseph Holmes,Jamie Pickett,Blue,Middleweight
+01/15/2022,Court McGee,Ramiz Brahimaj,Red,Welterweight
+01/15/2022,Brian Kelleher,Kevin Croom,Red,Featherweight
+01/15/2022,TJ Brown,Charles Rosa,Red,Lightweight
+12/18/2021,Chris Daukaus,Derrick Lewis,Blue,Heavyweight
+12/18/2021,Belal Muhammad,Stephen Thompson,Red,Welterweight
+12/18/2021,Angela Hill,Amanda Lemos,Blue,Women's Strawweight
+12/18/2021,Raphael Assuncao,Ricky Simon,Blue,Bantamweight
+12/18/2021,Diego Ferreira,Mateusz Gamrot,Blue,Lightweight
+12/18/2021,Darren Elkins,Cub Swanson,Blue,Featherweight
+12/18/2021,Dustin Stoltzfus,Gerald Meerschaert,Blue,Middleweight
+12/18/2021,Justin Tafa,Harry Hunsucker,Red,Heavyweight
+12/18/2021,Melissa Gatto,Sijara Eubanks,Red,Women's Flyweight
+12/18/2021,Charles Jourdain,Andre Ewell,Red,Featherweight
+12/18/2021,Raquel Pennington,Macy Chiasson,Red,Women's Featherweight
+12/18/2021,Don'Tale Mayes,Josh Parisian,Red,Heavyweight
+12/18/2021,Matt Sayles,Jordan Leavitt,Blue,Lightweight
+12/11/2021,Dustin Poirier,Charles Oliveira,Blue,UFC Lightweight Title
+12/11/2021,Amanda Nunes,Julianna Pena,Blue,UFC Women's Bantamweight Title
+12/11/2021,Geoff Neal,Santiago Ponzinibbio,Red,Welterweight
+12/11/2021,Cody Garbrandt,Kai Kara-France,Blue,Flyweight
+12/11/2021,Raulian Paiva,Sean O'Malley,Blue,Bantamweight
+12/11/2021,Josh Emmett,Dan Ige,Red,Featherweight
+12/11/2021,Dominick Cruz,Pedro Munhoz,Red,Bantamweight
+12/11/2021,Tai Tuivasa,Augusto Sakai,Red,Heavyweight
+12/11/2021,Jordan Wright,Bruno Silva,Blue,Middleweight
+12/11/2021,Andre Muniz,Eryk Anders,Red,Middleweight
+12/11/2021,Miranda Maverick,Erin Blanchfield,Blue,Women's Flyweight
+12/11/2021,Darrick Minner,Ryan Hall,Blue,Featherweight
+12/11/2021,Randy Costa,Tony Kelley,Blue,Bantamweight
+12/11/2021,Gillian Robertson,Priscila Cachoeira,Red,Women's Flyweight
+12/04/2021,Rob Font,Jose Aldo,Blue,Bantamweight
+12/04/2021,Rafael Fiziev,Brad Riddell,Red,Lightweight
+12/04/2021,Jamahal Hill,Jimmy Crute,Red,Light Heavyweight
+12/04/2021,Leonardo Santos,Clay Guida,Blue,Lightweight
+12/04/2021,Brendan Allen,Chris Curtis,Blue,Middleweight
+12/04/2021,Alex Morono,Mickey Gall,Red,Welterweight
+12/04/2021,Dusko Todorovic,Maki Pitolo,Red,Middleweight
+12/04/2021,Zhalgas Zhumagulov,Manel Kape,Blue,Flyweight
+12/04/2021,Bryan Barberena,Darian Weeks,Red,Welterweight
+12/04/2021,Cheyanne Vlismas,Mallory Martin,Red,Women's Strawweight
+12/04/2021,Alonzo Menifield,William Knight,Blue,Light Heavyweight
+12/04/2021,Claudio Puelles,Chris Gruetzemacher,Red,Lightweight
+12/04/2021,Louis Smolka,Vince Morales,Blue,Bantamweight
+11/20/2021,Miesha Tate,Ketlen Vieira,Blue,Women's Bantamweight
+11/20/2021,Sean Brady,Michael Chiesa,Red,Welterweight
+11/20/2021,Joanne Wood,Taila Santos,Blue,Women's Flyweight
+11/20/2021,Kyung Ho Kang,Rani Yahya,Blue,Bantamweight
+11/20/2021,Adrian Yanez,Davey Grant,Red,Bantamweight
+11/20/2021,Tucker Lutz,Pat Sabatini,Blue,Featherweight
+11/20/2021,Rafa Garcia,Natan Levy,Red,Lightweight
+11/20/2021,Loopy Godinez,Loma Lookboonmee,Red,Women's Strawweight
+11/20/2021,Aoriqileng,Cody Durden,Blue,Flyweight
+11/20/2021,Shayilan Nuerdanbieke,Sean Soriano,Red,Featherweight
+11/20/2021,Sam Hughes,Luana Pinheiro,Blue,Women's Strawweight
+11/13/2021,Max Holloway,Yair Rodriguez,Red,Featherweight
+11/13/2021,Ben Rothwell,Marcos Rogerio de Lima,Blue,Heavyweight
+11/13/2021,Felicia Spencer,Leah Letson,Red,Women's Featherweight
+11/13/2021,Miguel Baeza,Khaos Williams,Blue,Welterweight
+11/13/2021,Song Yadong,Julio Arce,Red,Bantamweight
+11/13/2021,Thiago Moises,Joel Alvarez,Blue,Lightweight
+11/13/2021,Andrea Lee,Cynthia Calvillo,Red,Women's Flyweight
+11/13/2021,Collin Anglin,Sean Woodson,Blue,Featherweight
+11/13/2021,Liana Jojua,Cortney Casey,Blue,Women's Flyweight
+11/13/2021,Rafael Alves,Marc Diakiese,Red,Lightweight
+11/13/2021,Da Woon Jung,Kennedy Nzechukwu,Red,Light Heavyweight
+11/06/2021,Kamaru Usman,Colby Covington,Red,UFC Welterweight Title
+11/06/2021,Zhang Weili,Rose Namajunas,Blue,UFC Women's Strawweight Title
+11/06/2021,Frankie Edgar,Marlon Vera,Blue,Bantamweight
+11/06/2021,Billy Quarantillo,Shane Burgos,Blue,Featherweight
+11/06/2021,Michael Chandler,Justin Gaethje,Blue,Lightweight
+11/06/2021,Andreas Michailidis,Alex Pereira,Blue,Middleweight
+11/06/2021,Bobby Green,Al Iaquinta,Red,Lightweight
+11/06/2021,Chris Curtis,Phil Hawes,Red,Middleweight
+11/06/2021,Nassourdine Imavov,Edmen Shahbazyan,Red,Middleweight
+11/06/2021,Ian Machado Garry,Jordan Williams,Red,Welterweight
+11/06/2021,Gian Villante,Chris Barnett,Blue,Heavyweight
+11/06/2021,Dustin Jacoby,John Allan,Red,Light Heavyweight
+11/06/2021,Melsik Baghdasaryan,Bruno Souza,Red,Featherweight
+11/06/2021,CJ Vergara,Ode Osbourne,Blue,Flyweight
+10/30/2021,Jan Blachowicz,Glover Teixeira,Blue,UFC Light Heavyweight Title
+10/30/2021,Petr Yan,Cory Sandhagen,Red,UFC Interim Bantamweight Title
+10/30/2021,Dan Hooker,Islam Makhachev,Blue,Lightweight
+10/30/2021,Marcin Tybura,Alexander Volkov,Blue,Heavyweight
+10/30/2021,Khamzat Chimaev,Li Jingliang,Red,Welterweight
+10/30/2021,Magomed Ankalaev,Volkan Oezdemir,Red,Light Heavyweight
+10/30/2021,Amanda Ribas,Virna Jandiroba,Red,Women's Strawweight
+10/30/2021,Zubaira Tukhugov,Ricardo Ramos,Red,Featherweight
+10/30/2021,Albert Duraev,Roman Kopylov,Red,Middleweight
+10/30/2021,Elizeu Zaleski dos Santos,Benoit Saint Denis,Red,Welterweight
+10/30/2021,Michal Oleksiejczuk,Shamil Gamzatov,Red,Light Heavyweight
+10/30/2021,Makwan Amirkhani,Lerone Murphy,Blue,Featherweight
+10/30/2021,Hu Yaozong,Andre Petroski,Blue,Middleweight
+10/30/2021,Allan Nascimento,Tagir Ulanbekov,Blue,Flyweight
+10/23/2021,Paulo Costa,Marvin Vettori,Blue,Light Heavyweight
+10/23/2021,Joselyne Edwards,Jessica-Rose Clark,Blue,Women's Bantamweight
+10/23/2021,SeungWoo Choi,Alex Caceres,Blue,Featherweight
+10/23/2021,Francisco Trinaldo,Dwight Grant,Red,Welterweight
+10/23/2021,Ike Villanueva,Nicolae Negumereanu,Blue,Light Heavyweight
+10/23/2021,Gregory Rodrigues,JunYong Park,Red,Middleweight
+10/23/2021,Mason Jones,David Onama,Red,Lightweight
+10/23/2021,Tabatha Ricci,Maria Oliveira,Red,Women's Strawweight
+10/23/2021,Jamie Pickett,Laureano Staropoli,Red,Middleweight
+10/23/2021,Khama Worthy,Jai Herbert,Blue,Lightweight
+10/23/2021,Daniel Lacerda,Jeff Molina,Blue,Flyweight
+10/23/2021,Livinha Souza,Randa Markos,Blue,Women's Strawweight
+10/23/2021,Jonathan Martinez,Zviad Lazishvili,Red,Bantamweight
+10/16/2021,Norma Dumont,Aspen Ladd,Red,Women's Featherweight
+10/16/2021,Andrei Arlovski,Carlos Felipe,Red,Heavyweight
+10/16/2021,Erick Gonzalez,Jim Miller,Blue,Lightweight
+10/16/2021,Manon Fiorot,Mayra Bueno Silva,Red,Women's Flyweight
+10/16/2021,Ludovit Klein,Nate Landwehr,Blue,Featherweight
+10/16/2021,Bruno Silva,Andrew Sanchez,Red,Middleweight
+10/16/2021,Danny Roberts,Ramazan Emeev,Red,Welterweight
+10/16/2021,Loopy Godinez,Luana Carolina,Blue,Women's Flyweight
+10/16/2021,Brandon Davis,Batgerel Danaa,Blue,Bantamweight
+10/16/2021,Ariane Carnelossi,Istela Nunes,Red,Women's Strawweight
+10/09/2021,Mackenzie Dern,Marina Rodriguez,Blue,Women's Strawweight
+10/09/2021,Jared Gooden,Randy Brown,Blue,Welterweight
+10/09/2021,Tim Elliott,Matheus Nicolau,Blue,Flyweight
+10/09/2021,Sabina Mazo,Mariya Agapova,Blue,Women's Flyweight
+10/09/2021,Chris Gutierrez,Felipe Colares,Red,Bantamweight
+10/09/2021,Alexandr Romanov,Jared Vanderaa,Red,Heavyweight
+10/09/2021,Damon Jackson,Charles Rosa,Red,Featherweight
+10/09/2021,Silvana Gomez Juarez,Loopy Godinez,Blue,Women's Strawweight
+10/09/2021,Charlie Ontiveros,Steve Garcia,Blue,Lightweight
+10/02/2021,Thiago Santos,Johnny Walker,Red,Light Heavyweight
+10/02/2021,Alex Oliveira,Niko Price,Blue,Welterweight
+10/02/2021,Krzysztof Jotko,Misha Cirkunov,Red,Middleweight
+10/02/2021,Mike Breeden,Alexander Hernandez,Blue,Lightweight
+10/02/2021,Joe Solecki,Jared Gordon,Blue,Lightweight
+10/02/2021,Antonina Shevchenko,Casey O'Neill,Blue,Women's Flyweight
+10/02/2021,Bethe Correia,Karol Rosa,Blue,Women's Bantamweight
+10/02/2021,Jamie Mullarkey,Devonte Smith,Red,Lightweight
+10/02/2021,Douglas Silva de Andrade,Gaetano Pirrello,Red,Bantamweight
+10/02/2021,Shanna Young,Stephanie Egger,Blue,Women's Bantamweight
+10/02/2021,Alejandro Perez,Johnny Eduardo,Red,Bantamweight
+09/25/2021,Brian Ortega,Alexander Volkanovski,Blue,UFC Featherweight Title
+09/25/2021,Valentina Shevchenko,Lauren Murphy,Red,UFC Women's Flyweight Title
+09/25/2021,Nick Diaz,Robbie Lawler,Blue,Middleweight
+09/25/2021,Jairzinho Rozenstruik,Curtis Blaydes,Blue,Heavyweight
+09/25/2021,Cynthia Calvillo,Jessica Andrade,Blue,Women's Flyweight
+09/25/2021,Merab Dvalishvili,Marlon Moraes,Red,Bantamweight
+09/25/2021,Dan Hooker,Nasrat Haqparast,Red,Lightweight
+09/25/2021,Shamil Abdurakhimov,Chris Daukaus,Blue,Heavyweight
+09/25/2021,Taila Santos,Roxanne Modafferi,Red,Women's Flyweight
+09/25/2021,Jalin Turner,Uros Medic,Red,Lightweight
+09/25/2021,Cody Brundage,Nick Maximov,Blue,Middleweight
+09/25/2021,Matthew Semelsberger,Martin Sano,Red,Welterweight
+09/25/2021,Jonathan Pearce,Omar Morales,Red,Featherweight
+09/18/2021,Anthony Smith,Ryan Spann,Red,Light Heavyweight
+09/18/2021,Devin Clark,Ion Cutelaba,Blue,Light Heavyweight
+09/18/2021,Ariane Lipski,Mandy Bohm,Red,Women's Flyweight
+09/18/2021,Christos Giagos,Arman Tsarukyan,Blue,Lightweight
+09/18/2021,Tony Gravely,Nate Maness,Blue,Bantamweight
+09/18/2021,Antonio Arroyo,Joaquin Buckley,Blue,Middleweight
+09/18/2021,Mike Rodriguez,Tafon Nchukwi,Blue,Light Heavyweight
+09/18/2021,Raquel Pennington,Pannie Kianzad,Red,Women's Bantamweight
+09/18/2021,Brandon Jenkins,Rongzhu,Blue,Lightweight
+09/18/2021,JP Buys,Montel Jackson,Blue,Bantamweight
+09/18/2021,Erin Blanchfield,Sarah Alpar,Red,Women's Flyweight
+09/18/2021,Carlston Harris,Impa Kasanganay,Red,Welterweight
+09/18/2021,Emily Whitmire,Hannah Goldy,Blue,Women's Flyweight
+09/04/2021,Darren Till,Derek Brunson,Blue,Middleweight
+09/04/2021,Serghei Spivac,Tom Aspinall,Blue,Heavyweight
+09/04/2021,David Zawada,Alex Morono,Blue,Welterweight
+09/04/2021,Modestas Bukauskas,Khalil Rountree Jr.,Blue,Light Heavyweight
+09/04/2021,Luigi Vendramini,Paddy Pimblett,Blue,Lightweight
+09/04/2021,Ji Yeon Kim,Molly McCann,Blue,Women's Flyweight
+09/04/2021,Liudvik Sholinian,Jack Shore,Blue,Bantamweight
+09/04/2021,Julian Erosa,Charles Jourdain,Red,Catch Weight
+09/04/2021,Marc-Andre Barriault,Dalcha Lungiambula,Red,Middleweight
+08/28/2021,Edson Barboza,Giga Chikadze,Blue,Featherweight
+08/28/2021,Bryan Battle,Gilbert Urbina,Red,Middleweight
+08/28/2021,Brady Hiestand,Ricky Turcios,Blue,Bantamweight
+08/28/2021,Kevin Lee,Daniel Rodriguez,Blue,Welterweight
+08/28/2021,Micheal Gillmore,Andre Petroski,Blue,Middleweight
+08/28/2021,Makhmud Muradov,Gerald Meerschaert,Blue,Middleweight
+08/28/2021,Abdul Razak Alhassan,Alessio Di Chirico,Red,Middleweight
+08/28/2021,Wellington Turman,Sam Alvey,Red,Middleweight
+08/28/2021,Dustin Jacoby,Darren Stewart,Red,Light Heavyweight
+08/28/2021,Vanessa Demopoulos,JJ Aldrich,Blue,Women's Flyweight
+08/28/2021,Jamall Emmers,Pat Sabatini,Blue,Featherweight
+08/28/2021,Mana Martinez,Guido Cannetti,Red,Bantamweight
+08/21/2021,Jared Cannonier,Kelvin Gastelum,Red,Middleweight
+08/21/2021,Mark Madsen,Clay Guida,Red,Lightweight
+08/21/2021,Chase Sherman,Parker Porter,Blue,Heavyweight
+08/21/2021,Saidyokub Kakhramonov,Trevin Jones,Red,Bantamweight
+08/21/2021,Austin Hubbard,Vinc Pichel,Blue,Lightweight
+08/21/2021,Alexandre Pantoja,Brandon Royval,Red,Flyweight
+08/21/2021,Austin Lingo,Luis Saldana,Red,Featherweight
+08/21/2021,Domingo Pilarte,Brian Kelleher,Blue,Bantamweight
+08/21/2021,Josiane Nunes,Bea Malecki,Red,Women's Bantamweight
+08/21/2021,Fabio Cherant,William Knight,Blue,Light Heavyweight
+08/21/2021,Ignacio Bahamondes,Roosevelt Roberts,Red,Lightweight
+08/21/2021,Ramiz Brahimaj,Sasha Palatnikov,Red,Welterweight
+08/07/2021,Ciryl Gane,Derrick Lewis,Red,UFC Interim Heavyweight Title
+08/07/2021,Pedro Munhoz,Jose Aldo,Blue,Bantamweight
+08/07/2021,Michael Chiesa,Vicente Luque,Blue,Welterweight
+08/07/2021,Angela Hill,Tecia Torres,Blue,Women's Strawweight
+08/07/2021,Song Yadong,Casey Kenney,Red,Bantamweight
+08/07/2021,Rafael Fiziev,Bobby Green,Red,Lightweight
+08/07/2021,Drako Rodriguez,Vince Morales,Blue,Bantamweight
+08/07/2021,Alonzo Menifield,Ed Herman,Red,Light Heavyweight
+08/07/2021,Karolina Kowalkiewicz,Jessica Penne,Blue,Women's Strawweight
+08/07/2021,Manel Kape,Ode Osbourne,Red,Flyweight
+08/07/2021,Miles Johns,Anderson Dos Santos,Red,Bantamweight
+08/07/2021,Melissa Gatto,Victoria Leonardo,Red,Women's Flyweight
+08/07/2021,Johnny Munoz,Jamey Simmons,Red,Bantamweight
+07/31/2021,Uriah Hall,Sean Strickland,Blue,Middleweight
+07/31/2021,Cheyanne Vlismas,Gloria de Paula,Red,Women's Strawweight
+07/31/2021,Niklas Stolze,Jared Gooden,Blue,Welterweight
+07/31/2021,Collin Anglin,Melsik Baghdasaryan,Blue,Featherweight
+07/31/2021,Jason Witt,Bryan Barberena,Red,Welterweight
+07/31/2021,Rafa Garcia,Chris Gruetzemacher,Blue,Lightweight
+07/31/2021,Jinh Yu Frey,Ashley Yoder,Red,Women's Strawweight
+07/31/2021,Zarrukh Adashev,Ryan Benoit,Red,Flyweight
+07/31/2021,Phil Rowe,Orion Cosce,Red,Welterweight
+07/24/2021,Cory Sandhagen,TJ Dillashaw,Blue,Bantamweight
+07/24/2021,Raulian Paiva,Kyler Phillips,Red,Bantamweight
+07/24/2021,Darrick Minner,Darren Elkins,Blue,Featherweight
+07/24/2021,Maycee Barber,Miranda Maverick,Red,Women's Flyweight
+07/24/2021,Randy Costa,Adrian Yanez,Blue,Bantamweight
+07/24/2021,Punahele Soriano,Brendan Allen,Blue,Middleweight
+07/24/2021,Nassourdine Imavov,Ian Heinisch,Red,Middleweight
+07/24/2021,Jordan Williams,Mickey Gall,Blue,Welterweight
+07/24/2021,Julio Arce,Andre Ewell,Red,Bantamweight
+07/24/2021,Elise Reed,Sijara Eubanks,Blue,Women's Flyweight
+07/24/2021,Diana Belbita,Hannah Goldy,Red,Women's Strawweight
+07/17/2021,Islam Makhachev,Thiago Moises,Red,Lightweight
+07/17/2021,Marion Reneau,Miesha Tate,Blue,Women's Bantamweight
+07/17/2021,Mateusz Gamrot,Jeremy Stephens,Red,Lightweight
+07/17/2021,Dustin Stoltzfus,Rodolfo Vieira,Blue,Middleweight
+07/17/2021,Billy Quarantillo,Gabriel Benitez,Red,Featherweight
+07/17/2021,Preston Parsons,Daniel Rodriguez,Blue,Welterweight
+07/17/2021,Montserrat Conejo Ruiz,Amanda Lemos,Blue,Women's Strawweight
+07/17/2021,Sergey Morozov,Khalid Taha,Red,Bantamweight
+07/17/2021,Malcolm Gordon,Francisco Figueiredo,Red,Flyweight
+07/10/2021,Conor McGregor,Dustin Poirier,Blue,Lightweight
+07/10/2021,Stephen Thompson,Gilbert Burns,Blue,Welterweight
+07/10/2021,Tai Tuivasa,Greg Hardy,Red,Heavyweight
+07/10/2021,Irene Aldana,Yana Santos,Red,Women's Bantamweight
+07/10/2021,Sean O'Malley,Kris Moutinho,Red,Bantamweight
+07/10/2021,Carlos Condit,Max Griffin,Blue,Welterweight
+07/10/2021,Niko Price,Michel Pereira,Blue,Welterweight
+07/10/2021,Ilia Topuria,Ryan Hall,Red,Featherweight
+07/10/2021,Trevin Giles,Dricus Du Plessis,Blue,Middleweight
+07/10/2021,Jennifer Maia,Jessica Eye,Red,Women's Flyweight
+07/10/2021,Omari Akhmedov,Brad Tavares,Blue,Middleweight
+07/10/2021,Jerome Rivera,Zhalgas Zhumagulov,Blue,Flyweight
+06/26/2021,Ciryl Gane,Alexander Volkov,Red,Heavyweight
+06/26/2021,Tanner Boser,Ovince Saint Preux,Red,Heavyweight
+06/26/2021,Timur Valiev,Raoni Barcelos,Red,Bantamweight
+06/26/2021,Tim Means,Nicolas Dalby,Red,Welterweight
+06/26/2021,Renato Moicano,Jai Herbert,Red,Lightweight
+06/26/2021,Danilo Marques,Kennedy Nzechukwu,Blue,Light Heavyweight
+06/26/2021,Shavkat Rakhmonov,Michel Prazeres,Red,Welterweight
+06/26/2021,Jeremiah Wells,Warlley Alves,Red,Welterweight
+06/26/2021,Marcin Prachnio,Ike Villanueva,Red,Light Heavyweight
+06/26/2021,Julia Avila,Julija Stoliarenko,Red,Women's Bantamweight
+06/26/2021,Justin Jaynes,Charles Rosa,Blue,Featherweight
+06/26/2021,Damir Hadzovic,Yancy Medeiros,Red,Lightweight
+06/19/2021,Dan Ige,Chan Sung Jung,Blue,Featherweight
+06/19/2021,Aleksei Oleinik,Serghei Spivac,Blue,Heavyweight
+06/19/2021,Marlon Vera,Davey Grant,Red,Bantamweight
+06/19/2021,Julian Erosa,SeungWoo Choi,Blue,Featherweight
+06/19/2021,Bruno Silva,Wellington Turman,Red,Middleweight
+06/19/2021,Dhiego Lima,Matt Brown,Blue,Welterweight
+06/19/2021,Aleksa Camur,Nicolae Negumereanu,Blue,Light Heavyweight
+06/19/2021,Virna Jandiroba,Kanako Murata,Red,Women's Strawweight
+06/19/2021,Khaos Williams,Matthew Semelsberger,Red,Welterweight
+06/19/2021,Roque Martinez,Josh Parisian,Blue,Heavyweight
+06/19/2021,Joaquim Silva,Ricky Glenn,Blue,Lightweight
+06/19/2021,Lara Procopio,Casey O'Neill,Blue,Women's Flyweight
+06/12/2021,Israel Adesanya,Marvin Vettori,Red,UFC Middleweight Title
+06/12/2021,Brandon Moreno,Deiveson Figueiredo,Red,UFC Flyweight Title
+06/12/2021,Nate Diaz,Leon Edwards,Blue,Welterweight
+06/12/2021,Belal Muhammad,Demian Maia,Red,Welterweight
+06/12/2021,Paul Craig,Jamahal Hill,Red,Light Heavyweight
+06/12/2021,Drew Dober,Brad Riddell,Blue,Lightweight
+06/12/2021,Darren Stewart,Eryk Anders,Blue,Light Heavyweight
+06/12/2021,Lauren Murphy,Joanne Wood,Red,Women's Flyweight
+06/12/2021,Movsar Evloev,Hakeem Dawodu,Red,Featherweight
+06/12/2021,Pannie Kianzad,Alexis Davis,Red,Women's Bantamweight
+06/12/2021,Matt Frevola,Terrance McKinney,Blue,Lightweight
+06/12/2021,Steven Peterson,Chase Hooper,Red,Featherweight
+06/12/2021,Fares Ziam,Luigi Vendramini,Red,Lightweight
+06/12/2021,Carlos Felipe,Jake Collier,Red,Heavyweight
+06/05/2021,Jairzinho Rozenstruik,Augusto Sakai,Red,Heavyweight
+06/05/2021,Walt Harris,Marcin Tybura,Blue,Heavyweight
+06/05/2021,Roman Dolidze,Laureano Staropoli,Red,Middleweight
+06/05/2021,Santiago Ponzinibbio,Miguel Baeza,Red,Welterweight
+06/05/2021,Gregory Rodrigues,Dusko Todorovic,Red,Middleweight
+06/05/2021,Ariane Lipski,Montana De La Rosa,Blue,Women's Flyweight
+06/05/2021,Ilir Latifi,Tanner Boser,Red,Heavyweight
+06/05/2021,Francisco Trinaldo,Muslim Salikhov,Blue,Welterweight
+06/05/2021,Kamuela Kirk,Makwan Amirkhani,Red,Featherweight
+06/05/2021,Tabatha Ricci,Manon Fiorot,Blue,Women's Flyweight
+06/05/2021,Youssef Zalal,Sean Woodson,Blue,Featherweight
+06/05/2021,Claudio Puelles,Jordan Leavitt,Red,Lightweight
+05/22/2021,Cody Garbrandt,Rob Font,Blue,Bantamweight
+05/22/2021,Carla Esparza,Yan Xiaonan,Red,Women's Strawweight
+05/22/2021,Jared Vanderaa,Justin Tafa,Red,Heavyweight
+05/22/2021,Felicia Spencer,Norma Dumont,Blue,Women's Featherweight
+05/22/2021,Ricardo Ramos,Bill Algeo,Red,Featherweight
+05/22/2021,Edmen Shahbazyan,Jack Hermansson,Blue,Middleweight
+05/22/2021,Chris Barnett,Ben Rothwell,Blue,Heavyweight
+05/22/2021,Claudio Silva,Court McGee,Blue,Welterweight
+05/22/2021,Bruno Silva,Victor Rodriguez,Red,Flyweight
+05/22/2021,Shayilan Nuerdanbieke,Josh Culibao,Blue,Featherweight
+05/22/2021,Juancamilo Ronderos,David Dvorak,Blue,Flyweight
+05/22/2021,Damir Ismagulov,Rafael Alves,Red,Lightweight
+05/15/2021,Michael Chandler,Charles Oliveira,Blue,UFC Lightweight Title
+05/15/2021,Beneil Dariush,Tony Ferguson,Red,Lightweight
+05/15/2021,Viviane Araujo,Katlyn Cerminara,Blue,Women's Flyweight
+05/15/2021,Edson Barboza,Shane Burgos,Red,Featherweight
+05/15/2021,Andre Muniz,Jacare Souza,Red,Middleweight
+05/15/2021,Lando Vannata,Mike Grundy,Red,Featherweight
+05/15/2021,Jamie Pickett,Jordan Wright,Blue,Middleweight
+05/15/2021,Antonina Shevchenko,Andrea Lee,Blue,Women's Flyweight
+05/15/2021,Priscila Cachoeira,Gina Mazany,Red,Women's Flyweight
+05/15/2021,Tucker Lutz,Kevin Aguilar,Red,Featherweight
+05/15/2021,Christos Giagos,Sean Soriano,Red,Lightweight
+05/08/2021,Michelle Waterson-Gomez,Marina Rodriguez,Blue,Women's Flyweight
+05/08/2021,Donald Cerrone,Alex Morono,Blue,Welterweight
+05/08/2021,Geoff Neal,Neil Magny,Blue,Welterweight
+05/08/2021,Maurice Greene,Marcos Rogerio de Lima,Blue,Heavyweight
+05/08/2021,Gregor Gillespie,Diego Ferreira,Red,Lightweight
+05/08/2021,Kyle Daukaus,Phil Hawes,Blue,Middleweight
+05/08/2021,Ludovit Klein,Michael Trizano,Blue,Featherweight
+05/08/2021,Tafon Nchukwi,JunYong Park,Blue,Middleweight
+05/08/2021,Christian Aguilera,Carlston Harris,Blue,Welterweight
+05/01/2021,Jiri Prochazka,Dominick Reyes,Red,Light Heavyweight
+05/01/2021,Giga Chikadze,Cub Swanson,Red,Featherweight
+05/01/2021,Sean Strickland,Krzysztof Jotko,Red,Middleweight
+05/01/2021,Cody Stamann,Merab Dvalishvili,Blue,Bantamweight
+05/01/2021,Luana Pinheiro,Randa Markos,Red,Women's Strawweight
+05/01/2021,Kai Kamaka,TJ Brown,Blue,Featherweight
+05/01/2021,Poliana Botelho,Luana Carolina,Blue,Women's Flyweight
+05/01/2021,Loma Lookboonmee,Sam Hughes,Red,Women's Strawweight
+05/01/2021,KB Bhullar,Andreas Michailidis,Blue,Middleweight
+05/01/2021,Luke Sanders,Felipe Colares,Blue,Featherweight
+04/24/2021,Jorge Masvidal,Kamaru Usman,Blue,UFC Welterweight Title
+04/24/2021,Zhang Weili,Rose Namajunas,Blue,UFC Women's Strawweight Title
+04/24/2021,Jessica Andrade,Valentina Shevchenko,Blue,UFC Women's Flyweight Title
+04/24/2021,Chris Weidman,Uriah Hall,Blue,Middleweight
+04/24/2021,Jimmy Crute,Anthony Smith,Blue,Light Heavyweight
+04/24/2021,Randy Brown,Alex Oliveira,Red,Welterweight
+04/24/2021,Dwight Grant,Stefan Sekulic,Red,Welterweight
+04/24/2021,Karl Roberson,Brendan Allen,Blue,Middleweight
+04/24/2021,Pat Sabatini,Tristan Connelly,Red,Featherweight
+04/24/2021,Batgerel Danaa,Kevin Natividad,Red,Bantamweight
+04/24/2021,Kazula Vargas,Rongzhu,Red,Lightweight
+04/24/2021,Jeff Molina,Aoriqileng,Red,Flyweight
+04/24/2021,Liang Na,Ariane Carnelossi,Blue,Women's Strawweight
+04/17/2021,Kelvin Gastelum,Robert Whittaker,Blue,Middleweight
+04/17/2021,Andrei Arlovski,Chase Sherman,Red,Heavyweight
+04/17/2021,Abdul Razak Alhassan,Jacob Malkoun,Blue,Middleweight
+04/17/2021,Tracy Cortez,Justine Kish,Red,Women's Flyweight
+04/17/2021,Alexander Munoz,Luis Pena,Blue,Lightweight
+04/17/2021,Juan Espino,Alexandr Romanov,Blue,Heavyweight
+04/17/2021,Jessica Penne,Loopy Godinez,Red,Women's Strawweight
+04/17/2021,Gerald Meerschaert,Bartosz Fabinski,Red,Middleweight
+04/17/2021,Dakota Bush,Austin Hubbard,Blue,Lightweight
+04/17/2021,Anthony Birchak,Tony Gravely,Blue,Bantamweight
+04/10/2021,Kevin Holland,Marvin Vettori,Blue,Middleweight
+04/10/2021,Arnold Allen,Sodiq Yusuff,Red,Featherweight
+04/10/2021,Sam Alvey,Julian Marquez,Blue,Middleweight
+04/10/2021,Nina Nunes,Mackenzie Dern,Blue,Women's Strawweight
+04/10/2021,Mike Perry,Daniel Rodriguez,Blue,Welterweight
+04/10/2021,Joe Solecki,Jim Miller,Red,Lightweight
+04/10/2021,Mateusz Gamrot,Scott Holtzman,Red,Lightweight
+04/10/2021,John Makdessi,Ignacio Bahamondes,Red,Lightweight
+04/10/2021,Jarjis Danho,Yorgan De Castro,Red,Heavyweight
+04/10/2021,Jack Shore,Hunter Azure,Red,Bantamweight
+04/10/2021,Jordan Griffin,Luis Saldana,Blue,Featherweight
+04/10/2021,Da Woon Jung,William Knight,Red,Light Heavyweight
+04/10/2021,Impa Kasanganay,Sasha Palatnikov,Red,Welterweight
+03/27/2021,Francis Ngannou,Stipe Miocic,Red,UFC Heavyweight Title
+03/27/2021,Tyron Woodley,Vicente Luque,Blue,Welterweight
+03/27/2021,Thomas Almeida,Sean O'Malley,Blue,Bantamweight
+03/27/2021,Gillian Robertson,Miranda Maverick,Blue,Women's Flyweight
+03/27/2021,Khama Worthy,Jamie Mullarkey,Blue,Lightweight
+03/27/2021,Alonzo Menifield,Fabio Cherant,Red,Light Heavyweight
+03/27/2021,Jared Gooden,Abubakar Nurmagomedov,Blue,Welterweight
+03/27/2021,Modestas Bukauskas,Michal Oleksiejczuk,Blue,Light Heavyweight
+03/27/2021,Shane Young,Omar Morales,Blue,Featherweight
+03/27/2021,Abu Azaitar,Marc-Andre Barriault,Blue,Middleweight
+03/20/2021,Kevin Holland,Derek Brunson,Blue,Middleweight
+03/20/2021,Max Griffin,Song Kenan,Red,Welterweight
+03/20/2021,Cheyanne Vlismas,Montserrat Conejo Ruiz,Blue,Women's Strawweight
+03/20/2021,Gustavo Lopez,Adrian Yanez,Blue,Bantamweight
+03/20/2021,Tai Tuivasa,Harry Hunsucker,Red,Heavyweight
+03/20/2021,Macy Chiasson,Marion Reneau,Red,Women's Bantamweight
+03/20/2021,Leonardo Santos,Grant Dawson,Blue,Lightweight
+03/20/2021,Trevin Giles,Roman Dolidze,Red,Middleweight
+03/20/2021,Jesse Strader,Montel Jackson,Blue,Bantamweight
+03/20/2021,Bruno Silva,JP Buys,Red,Flyweight
+03/13/2021,Misha Cirkunov,Ryan Spann,Blue,Light Heavyweight
+03/13/2021,Gavin Tucker,Dan Ige,Blue,Featherweight
+03/13/2021,Jonathan Martinez,Davey Grant,Blue,Bantamweight
+03/13/2021,Manel Kape,Matheus Nicolau,Blue,Flyweight
+03/13/2021,Angela Hill,Ashley Yoder,Red,Women's Strawweight
+03/13/2021,Marcelo Rojo,Charles Jourdain,Blue,Featherweight
+03/13/2021,Ray Rodriguez,Rani Yahya,Blue,Bantamweight
+03/13/2021,Rafa Garcia,Nasrat Haqparast,Blue,Lightweight
+03/13/2021,Cortney Casey,JJ Aldrich,Blue,Women's Flyweight
+03/13/2021,Gloria de Paula,Jinh Yu Frey,Blue,Women's Strawweight
+03/13/2021,Matthew Semelsberger,Jason Witt,Red,Welterweight
+03/06/2021,Israel Adesanya,Jan Blachowicz,Blue,UFC Light Heavyweight Title
+03/06/2021,Amanda Nunes,Megan Anderson,Red,UFC Women's Featherweight Title
+03/06/2021,Aljamain Sterling,Petr Yan,Red,UFC Bantamweight Title
+03/06/2021,Islam Makhachev,Drew Dober,Red,Lightweight
+03/06/2021,Thiago Santos,Aleksandar Rakic,Blue,Light Heavyweight
+03/06/2021,Casey Kenney,Dominick Cruz,Blue,Bantamweight
+03/06/2021,Kyler Phillips,Song Yadong,Red,Bantamweight
+03/06/2021,Askar Askarov,Joseph Benavidez,Red,Flyweight
+03/06/2021,Kai Kara-France,Rogerio Bontorin,Red,Flyweight
+03/06/2021,Tim Elliott,Jordan Espinosa,Red,Flyweight
+03/06/2021,Kennedy Nzechukwu,Carlos Ulberg,Red,Light Heavyweight
+03/06/2021,Sean Brady,Jake Matthews,Red,Welterweight
+03/06/2021,Livinha Souza,Amanda Lemos,Blue,Women's Strawweight
+03/06/2021,Aalon Cruz,Uros Medic,Blue,Lightweight
+03/06/2021,Trevin Jones,Mario Bautista,Red,Bantamweight
+02/27/2021,Jairzinho Rozenstruik,Ciryl Gane,Blue,Heavyweight
+02/27/2021,Magomed Ankalaev,Nikita Krylov,Red,Light Heavyweight
+02/27/2021,Jimmie Rivera,Pedro Munhoz,Blue,Bantamweight
+02/27/2021,Kevin Croom,Alex Caceres,Blue,Featherweight
+02/27/2021,Alexander Hernandez,Thiago Moises,Blue,Lightweight
+02/27/2021,Sabina Mazo,Alexis Davis,Blue,Women's Bantamweight
+02/27/2021,Vince Cachero,Ronnie Lawrence,Blue,Bantamweight
+02/27/2021,Maxim Grishin,Dustin Jacoby,Blue,Light Heavyweight
+02/20/2021,Derrick Lewis,Curtis Blaydes,Red,Heavyweight
+02/20/2021,Yana Santos,Ketlen Vieira,Red,Women's Bantamweight
+02/20/2021,Darrick Minner,Charles Rosa,Red,Featherweight
+02/20/2021,Chris Daukaus,Aleksei Oleinik,Red,Heavyweight
+02/20/2021,Nassourdine Imavov,Phil Hawes,Blue,Middleweight
+02/20/2021,Andrei Arlovski,Tom Aspinall,Blue,Heavyweight
+02/20/2021,Danny Chavez,Jared Gordon,Blue,Featherweight
+02/20/2021,John Castaneda,Eddie Wineland,Red,Bantamweight
+02/20/2021,Julian Erosa,Nate Landwehr,Red,Featherweight
+02/20/2021,Shana Dobson,Casey O'Neill,Blue,Women's Flyweight
+02/20/2021,Aiemann Zahabi,Drako Rodriguez,Red,Bantamweight
+02/20/2021,Jared Vanderaa,Serghei Spivac,Blue,Heavyweight
+02/13/2021,Kamaru Usman,Gilbert Burns,Red,UFC Welterweight Title
+02/13/2021,Alexa Grasso,Maycee Barber,Red,Women's Flyweight
+02/13/2021,Kelvin Gastelum,Ian Heinisch,Red,Middleweight
+02/13/2021,Brian Kelleher,Ricky Simon,Blue,Featherweight
+02/13/2021,Maki Pitolo,Julian Marquez,Blue,Middleweight
+02/13/2021,Anthony Hernandez,Rodolfo Vieira,Red,Middleweight
+02/13/2021,Dhiego Lima,Belal Muhammad,Blue,Welterweight
+02/13/2021,Polyana Viana,Mallory Martin,Red,Women's Strawweight
+02/13/2021,Chris Gutierrez,Andre Ewell,Red,Catch Weight
+02/13/2021,Phil Rowe,Gabe Green,Blue,Welterweight
+02/06/2021,Alistair Overeem,Alexander Volkov,Blue,Heavyweight
+02/06/2021,Frankie Edgar,Cory Sandhagen,Blue,Bantamweight
+02/06/2021,Clay Guida,Michael Johnson,Red,Lightweight
+02/06/2021,Alexandre Pantoja,Manel Kape,Red,Flyweight
+02/06/2021,Beneil Dariush,Diego Ferreira,Red,Lightweight
+02/06/2021,Mike Rodriguez,Danilo Marques,Blue,Light Heavyweight
+02/06/2021,Devonte Smith,Justin Jaynes,Red,Catch Weight
+02/06/2021,Joselyne Edwards,Karol Rosa,Blue,Women's Bantamweight
+02/06/2021,Molly McCann,Lara Procopio,Blue,Women's Flyweight
+02/06/2021,Youssef Zalal,SeungWoo Choi,Blue,Featherweight
+02/06/2021,Martin Day,Timur Valiev,Blue,Featherweight
+02/06/2021,Jerome Rivera,Ode Osbourne,Blue,Featherweight
+01/23/2021,Dustin Poirier,Conor McGregor,Red,Lightweight
+01/23/2021,Michael Chandler,Dan Hooker,Red,Lightweight
+01/23/2021,Jessica Eye,Joanne Wood,Blue,Women's Flyweight
+01/23/2021,Makhmud Muradov,Andrew Sanchez,Red,Middleweight
+01/23/2021,Marina Rodriguez,Amanda Ribas,Red,Women's Strawweight
+01/23/2021,Arman Tsarukyan,Matt Frevola,Red,Lightweight
+01/23/2021,Antonio Carlos Junior,Brad Tavares,Blue,Middleweight
+01/23/2021,Sara McMann,Julianna Pena,Blue,Women's Bantamweight
+01/23/2021,Khalil Rountree Jr.,Marcin Prachnio,Blue,Light Heavyweight
+01/23/2021,Movsar Evloev,Nik Lentz,Red,Catch Weight
+01/23/2021,Zhalgas Zhumagulov,Amir Albazi,Blue,Flyweight
+01/20/2021,Neil Magny,Michael Chiesa,Blue,Welterweight
+01/20/2021,Warlley Alves,Mounir Lazzez,Red,Welterweight
+01/20/2021,Vinicius Moreira,Ike Villanueva,Blue,Light Heavyweight
+01/20/2021,Roxanne Modafferi,Viviane Araujo,Blue,Women's Flyweight
+01/20/2021,Matt Schnell,Tyson Nam,Red,Flyweight
+01/20/2021,Lerone Murphy,Douglas Silva de Andrade,Red,Featherweight
+01/20/2021,Tom Breese,Omari Akhmedov,Blue,Middleweight
+01/20/2021,Ricky Simon,Gaetano Pirrello,Red,Bantamweight
+01/20/2021,Sumudaerji,Zarrukh Adashev,Red,Flyweight
+01/20/2021,Dalcha Lungiambula,Markus Perez,Red,Middleweight
+01/20/2021,Jerome Rivera,Francisco Figueiredo,Blue,Flyweight
+01/20/2021,Mason Jones,Mike Davis,Blue,Lightweight
+01/20/2021,Sergey Morozov,Umar Nurmagomedov,Blue,Bantamweight
+01/20/2021,Victoria Leonardo,Manon Fiorot,Blue,Women's Flyweight
+01/16/2021,Calvin Kattar,Max Holloway,Blue,Featherweight
+01/16/2021,Carlos Condit,Matt Brown,Red,Welterweight
+01/16/2021,Santiago Ponzinibbio,Li Jingliang,Blue,Welterweight
+01/16/2021,Alessio Di Chirico,Joaquin Buckley,Red,Middleweight
+01/16/2021,Dusko Todorovic,Punahele Soriano,Blue,Middleweight
+01/16/2021,Wu Yanan,Joselyne Edwards,Blue,Women's Bantamweight
+01/16/2021,Justin Tafa,Carlos Felipe,Blue,Heavyweight
+01/16/2021,David Zawada,Ramazan Emeev,Blue,Welterweight
+01/16/2021,Sarah Moras,Vanessa Melo,Blue,Women's Bantamweight
+01/16/2021,Jacob Kilburn,Austin Lingo,Blue,Featherweight
+12/19/2020,Geoff Neal,Stephen Thompson,Blue,Welterweight
+12/19/2020,Marlon Vera,Jose Aldo,Blue,Bantamweight
+12/19/2020,Michel Pereira,Khaos Williams,Red,Welterweight
+12/19/2020,Marlon Moraes,Rob Font,Blue,Bantamweight
+12/19/2020,Greg Hardy,Marcin Tybura,Blue,Heavyweight
+12/19/2020,Anthony Pettis,Alex Morono,Red,Welterweight
+12/19/2020,Pannie Kianzad,Sijara Eubanks,Red,Women's Bantamweight
+12/19/2020,Antonio Arroyo,Deron Winn,Blue,Catch Weight
+12/19/2020,Gillian Robertson,Taila Santos,Blue,Women's Flyweight
+12/19/2020,Jamie Pickett,Tafon Nchukwi,Blue,Middleweight
+12/19/2020,Cody Durden,Jimmy Flick,Blue,Flyweight
+12/19/2020,Christos Giagos,Carlton Minus,Red,Catch Weight
+12/12/2020,Charles Oliveira,Tony Ferguson,Red,Lightweight
+12/12/2020,Virna Jandiroba,Mackenzie Dern,Blue,Women's Strawweight
+12/12/2020,Kevin Holland,Jacare Souza,Red,Middleweight
+12/12/2020,Ciryl Gane,Junior Dos Santos,Red,Heavyweight
+12/12/2020,Daniel Pineda,Cub Swanson,Blue,Featherweight
+12/12/2020,Rafael Fiziev,Renato Moicano,Red,Lightweight
+12/12/2020,Billy Quarantillo,Gavin Tucker,Blue,Featherweight
+12/12/2020,Sam Hughes,Tecia Torres,Blue,Women's Strawweight
+12/12/2020,Chase Hooper,Peter Barrett,Red,Featherweight
+12/05/2020,Jack Hermansson,Marvin Vettori,Blue,Middleweight
+12/05/2020,Jamahal Hill,Ovince Saint Preux,Red,Light Heavyweight
+12/05/2020,Gabriel Benitez,Justin Jaynes,Red,Lightweight
+12/05/2020,Roman Dolidze,John Allan,Red,Light Heavyweight
+12/05/2020,Matt Wiman,Jordan Leavitt,Blue,Lightweight
+12/05/2020,Louis Smolka,Jose Quinonez,Red,Bantamweight
+12/05/2020,Damon Jackson,Ilia Topuria,Blue,Featherweight
+12/05/2020,Jake Collier,Gian Villante,Red,Heavyweight
+11/28/2020,Anthony Smith,Devin Clark,Red,Light Heavyweight
+11/28/2020,Takashi Sato,Miguel Baeza,Blue,Welterweight
+11/28/2020,Parker Porter,Josh Parisian,Red,Heavyweight
+11/28/2020,Bill Algeo,Spike Carlyle,Red,Featherweight
+11/28/2020,Ashlee Evans-Smith,Norma Dumont,Blue,Women's Bantamweight
+11/28/2020,Jonathan Pearce,Kai Kamaka,Red,Featherweight
+11/28/2020,Martin Day,Anderson Dos Santos,Blue,Bantamweight
+11/28/2020,Gina Mazany,Rachael Ostovich,Red,Women's Flyweight
+11/28/2020,Sumudaerji,Malcolm Gordon,Red,Flyweight
+11/28/2020,Luke Sanders,Nate Maness,Blue,Catch Weight
+11/21/2020,Deiveson Figueiredo,Alex Perez,Red,UFC Flyweight Title
+11/21/2020,Valentina Shevchenko,Jennifer Maia,Red,UFC Women's Flyweight Title
+11/21/2020,Mike Perry,Tim Means,Blue,Welterweight
+11/21/2020,Cynthia Calvillo,Katlyn Cerminara,Blue,Women's Flyweight
+11/21/2020,Mauricio Rua,Paul Craig,Blue,Light Heavyweight
+11/21/2020,Brandon Royval,Brandon Moreno,Blue,Flyweight
+11/21/2020,Jordan Wright,Joaquin Buckley,Blue,Middleweight
+11/21/2020,Ariane Lipski,Antonina Shevchenko,Blue,Women's Flyweight
+11/21/2020,Daniel Rodriguez,Nicolas Dalby,Blue,Welterweight
+11/21/2020,Jared Gooden,Alan Jouban,Blue,Welterweight
+11/21/2020,Kyle Daukaus,Dustin Stoltzfus,Red,Middleweight
+11/21/2020,Sasha Palatnikov,Louis Cosce,Red,Welterweight
+11/14/2020,Rafael Dos Anjos,Paul Felder,Red,Lightweight
+11/14/2020,Khaos Williams,Abdul Razak Alhassan,Red,Welterweight
+11/14/2020,Miranda Granger,Ashley Yoder,Blue,Women's Strawweight
+11/14/2020,Sean Strickland,Brendan Allen,Red,Catch Weight
+11/14/2020,Kay Hansen,Cory McKenna,Blue,Women's Strawweight
+11/14/2020,Kanako Murata,Randa Markos,Red,Women's Strawweight
+11/14/2020,Geraldo de Freitas,Tony Gravely,Blue,Bantamweight
+11/14/2020,Rhys McKee,Alex Morono,Blue,Welterweight
+11/14/2020,Don'Tale Mayes,Roque Martinez,Red,Heavyweight
+11/07/2020,Thiago Santos,Glover Teixeira,Blue,Light Heavyweight
+11/07/2020,Andrei Arlovski,Tanner Boser,Red,Heavyweight
+11/07/2020,Khalid Taha,Raoni Barcelos,Blue,Bantamweight
+11/07/2020,Jamey Simmons,Giga Chikadze,Blue,Featherweight
+11/07/2020,Yan Xiaonan,Claudia Gadelha,Red,Women's Strawweight
+11/07/2020,Trevin Giles,Bevon Lewis,Red,Middleweight
+11/07/2020,Alexandr Romanov,Marcos Rogerio de Lima,Red,Heavyweight
+11/07/2020,Darren Elkins,Eduardo Garagorri,Red,Featherweight
+11/07/2020,Ramiz Brahimaj,Max Griffin,Blue,Welterweight
+11/07/2020,Anthony Birchak,Gustavo Lopez,Blue,Bantamweight
+10/31/2020,Uriah Hall,Anderson Silva,Red,Middleweight
+10/31/2020,Bryce Mitchell,Andre Fili,Red,Featherweight
+10/31/2020,Maurice Greene,Greg Hardy,Blue,Heavyweight
+10/31/2020,Charlie Ontiveros,Kevin Holland,Blue,Middleweight
+10/31/2020,Bobby Green,Thiago Moises,Blue,Lightweight
+10/31/2020,Chris Gruetzemacher,Alexander Hernandez,Blue,Lightweight
+10/31/2020,Victor Rodriguez,Adrian Yanez,Blue,Bantamweight
+10/31/2020,Sean Strickland,Jack Marshman,Red,Middleweight
+10/31/2020,Jason Witt,Cole Williams,Red,Welterweight
+10/31/2020,Dustin Jacoby,Justin Ledet,Red,Light Heavyweight
+10/31/2020,Kevin Natividad,Miles Johns,Blue,Bantamweight
+10/24/2020,Khabib Nurmagomedov,Justin Gaethje,Red,UFC Lightweight Title
+10/24/2020,Jared Cannonier,Robert Whittaker,Blue,Middleweight
+10/24/2020,Alexander Volkov,Walt Harris,Red,Heavyweight
+10/24/2020,Phil Hawes,Jacob Malkoun,Red,Middleweight
+10/24/2020,Lauren Murphy,Liliya Shakirova,Red,Women's Flyweight
+10/24/2020,Magomed Ankalaev,Ion Cutelaba,Red,Light Heavyweight
+10/24/2020,Stefan Struve,Tai Tuivasa,Blue,Heavyweight
+10/24/2020,Nathaniel Wood,Casey Kenney,Blue,Catch Weight
+10/24/2020,Alex Oliveira,Shavkat Rakhmonov,Blue,Welterweight
+10/24/2020,Miranda Maverick,Liana Jojua,Red,Women's Flyweight
+10/24/2020,Alexander Yakovlev,Joel Alvarez,Blue,Lightweight
+10/17/2020,Brian Ortega,Chan Sung Jung,Red,Featherweight
+10/17/2020,Katlyn Cerminara,Jessica Andrade,Blue,Women's Flyweight
+10/17/2020,Jimmy Crute,Modestas Bukauskas,Red,Light Heavyweight
+10/17/2020,James Krause,Claudio Silva,Red,Welterweight
+10/17/2020,Thomas Almeida,Jonathan Martinez,Blue,Featherweight
+10/17/2020,Guram Kutateladze,Mateusz Gamrot,Red,Lightweight
+10/17/2020,Gillian Robertson,Poliana Botelho,Red,Women's Flyweight
+10/17/2020,JunYong Park,John Phillips,Red,Middleweight
+10/17/2020,Fares Ziam,Jamie Mullarkey,Red,Lightweight
+10/17/2020,Maxim Grishin,Gadzhimurad Antigulov,Red,Light Heavyweight
+10/17/2020,Said Nurmagomedov,Mark Striegl,Red,Bantamweight
+10/10/2020,Marlon Moraes,Cory Sandhagen,Blue,Bantamweight
+10/10/2020,Makwan Amirkhani,Edson Barboza,Blue,Featherweight
+10/10/2020,Ben Rothwell,Marcin Tybura,Blue,Heavyweight
+10/10/2020,Dricus Du Plessis,Markus Perez,Red,Middleweight
+10/10/2020,Alan Baudot,Tom Aspinall,Blue,Heavyweight
+10/10/2020,Ilia Topuria,Youssef Zalal,Red,Featherweight
+10/10/2020,KB Bhullar,Tom Breese,Blue,Middleweight
+10/10/2020,Rodrigo Nascimento,Chris Daukaus,Blue,Heavyweight
+10/10/2020,Impa Kasanganay,Joaquin Buckley,Blue,Middleweight
+10/10/2020,Ali AlQaisi,Tony Kelley,Blue,Bantamweight
+10/10/2020,Omar Morales,Giga Chikadze,Blue,Featherweight
+10/10/2020,Tracy Cortez,Stephanie Egger,Red,Women's Bantamweight
+10/10/2020,Tagir Ulanbekov,Bruno Silva,Red,Flyweight
+10/03/2020,Holly Holm,Irene Aldana,Red,Women's Bantamweight
+10/03/2020,Carlos Felipe,Yorgan De Castro,Red,Heavyweight
+10/03/2020,Germaine de Randamie,Julianna Pena,Red,Women's Bantamweight
+10/03/2020,Kyler Phillips,Cameron Else,Red,Bantamweight
+10/03/2020,Dusko Todorovic,Dequan Townsend,Red,Middleweight
+10/03/2020,Carlos Condit,Court McGee,Red,Welterweight
+10/03/2020,Nassourdine Imavov,Jordan Williams,Red,Middleweight
+10/03/2020,Jinh Yu Frey,Loma Lookboonmee,Blue,Women's Strawweight
+10/03/2020,Alatengheili,Casey Kenney,Blue,Bantamweight
+10/03/2020,Jessin Ayari,Luigi Vendramini,Blue,Lightweight
+09/26/2020,Paulo Costa,Israel Adesanya,Blue,UFC Middleweight Title
+09/26/2020,Dominick Reyes,Jan Blachowicz,Blue,UFC Light Heavyweight Title
+09/26/2020,Brandon Royval,Kai Kara-France,Red,Flyweight
+09/26/2020,Ketlen Vieira,Sijara Eubanks,Red,Women's Bantamweight
+09/26/2020,Hakeem Dawodu,Zubaira Tukhugov,Red,Featherweight
+09/26/2020,Alex Da Silva,Brad Riddell,Blue,Lightweight
+09/26/2020,Jake Matthews,Diego Sanchez,Red,Welterweight
+09/26/2020,Ludovit Klein,Shane Young,Red,Featherweight
+09/26/2020,Aleksa Camur,William Knight,Blue,Light Heavyweight
+09/26/2020,Jeff Hughes,Juan Espino,Blue,Heavyweight
+09/26/2020,Danilo Marques,Khadis Ibragimov,Red,Light Heavyweight
+09/19/2020,Colby Covington,Tyron Woodley,Red,Welterweight
+09/19/2020,Gerald Meerschaert,Khamzat Chimaev,Blue,Middleweight
+09/19/2020,Ryan Spann,Johnny Walker,Blue,Light Heavyweight
+09/19/2020,Randa Markos,Mackenzie Dern,Blue,Women's Strawweight
+09/19/2020,Darren Stewart,Kevin Holland,Blue,Middleweight
+09/19/2020,David Dvorak,Jordan Espinosa,Red,Flyweight
+09/19/2020,Mirsad Bektic,Damon Jackson,Blue,Featherweight
+09/19/2020,Mara Romero Borella,Mayra Bueno Silva,Blue,Women's Flyweight
+09/19/2020,Jessica-Rose Clark,Sarah Alpar,Red,Women's Bantamweight
+09/19/2020,Darrick Minner,TJ Laramie,Red,Featherweight
+09/19/2020,Randy Costa,Journey Newson,Red,Bantamweight
+09/19/2020,Andre Ewell,Irwin Rivera,Red,Bantamweight
+09/19/2020,Tyson Nam,Jerome Rivera,Red,Bantamweight
+09/12/2020,Angela Hill,Michelle Waterson-Gomez,Blue,Women's Strawweight
+09/12/2020,Khama Worthy,Ottman Azaitar,Blue,Lightweight
+09/12/2020,Andrea Lee,Roxanne Modafferi,Blue,Women's Flyweight
+09/12/2020,Ed Herman,Mike Rodriguez,Red,Light Heavyweight
+09/12/2020,Alan Patrick,Bobby Green,Blue,Lightweight
+09/12/2020,Billy Quarantillo,Kyle Nelson,Red,Featherweight
+09/12/2020,Sijara Eubanks,Julia Avila,Red,Women's Bantamweight
+09/12/2020,Alexandr Romanov,Roque Martinez,Red,Heavyweight
+09/12/2020,Brok Weaver,Jalin Turner,Blue,Catch Weight
+09/12/2020,Anthony Ivy,Bryan Barberena,Blue,Welterweight
+09/12/2020,Sabina Mazo,Justine Kish,Red,Women's Flyweight
+09/05/2020,Augusto Sakai,Alistair Overeem,Blue,Heavyweight
+09/05/2020,Alonzo Menifield,Ovince Saint Preux,Blue,Light Heavyweight
+09/05/2020,Michel Pereira,Zelim Imadaev,Red,Welterweight
+09/05/2020,Bartosz Fabinski,Andre Muniz,Blue,Middleweight
+09/05/2020,Brian Kelleher,Ray Rodriguez,Red,Featherweight
+09/05/2020,Montana De La Rosa,Viviane Araujo,Blue,Women's Flyweight
+09/05/2020,Cole Smith,Hunter Azure,Blue,Bantamweight
+08/29/2020,Anthony Smith,Aleksandar Rakic,Blue,Light Heavyweight
+08/29/2020,Neil Magny,Robbie Lawler,Red,Welterweight
+08/29/2020,Ji Yeon Kim,Alexa Grasso,Blue,Women's Flyweight
+08/29/2020,Bill Algeo,Ricardo Lamas,Blue,Featherweight
+08/29/2020,Maki Pitolo,Impa Kasanganay,Blue,Middleweight
+08/29/2020,Zak Cummings,Alessio Di Chirico,Red,Middleweight
+08/29/2020,Alex Caceres,Austin Springer,Red,Featherweight
+08/29/2020,Sean Brady,Christian Aguilera,Red,Welterweight
+08/29/2020,Emily Whitmire,Polyana Viana,Blue,Women's Strawweight
+08/29/2020,Hannah Cifers,Mallory Martin,Blue,Women's Strawweight
+08/22/2020,Pedro Munhoz,Frankie Edgar,Blue,Bantamweight
+08/22/2020,Marcin Prachnio,Mike Rodriguez,Blue,Light Heavyweight
+08/22/2020,Joe Solecki,Austin Hubbard,Red,Lightweight
+08/22/2020,Mariya Agapova,Shana Dobson,Blue,Women's Flyweight
+08/22/2020,Dwight Grant,Daniel Rodriguez,Blue,Welterweight
+08/22/2020,Amanda Lemos,Mizuki,Red,Women's Strawweight
+08/22/2020,Jordan Wright,Ike Villanueva,Red,Light Heavyweight
+08/22/2020,Carlton Minus,Matthew Semelsberger,Blue,Welterweight
+08/15/2020,Daniel Cormier,Stipe Miocic,Blue,UFC Heavyweight Title
+08/15/2020,Sean O'Malley,Marlon Vera,Blue,Bantamweight
+08/15/2020,Junior Dos Santos,Jairzinho Rozenstruik,Blue,Heavyweight
+08/15/2020,Herbert Burns,Daniel Pineda,Blue,Featherweight
+08/15/2020,John Dodson,Merab Dvalishvili,Blue,Bantamweight
+08/15/2020,Vinc Pichel,Jim Miller,Red,Lightweight
+08/15/2020,Felice Herrig,Virna Jandiroba,Blue,Women's Strawweight
+08/15/2020,TJ Brown,Danny Chavez,Blue,Featherweight
+08/15/2020,Livinha Souza,Ashley Yoder,Red,Women's Strawweight
+08/15/2020,Parker Porter,Chris Daukaus,Blue,Heavyweight
+08/15/2020,Kai Kamaka,Tony Kelley,Red,Featherweight
+08/08/2020,Aleksei Oleinik,Derrick Lewis,Blue,Heavyweight
+08/08/2020,Chris Weidman,Omari Akhmedov,Red,Middleweight
+08/08/2020,Maki Pitolo,Darren Stewart,Blue,Middleweight
+08/08/2020,Julija Stoliarenko,Yana Santos,Blue,Women's Bantamweight
+08/08/2020,Scott Holtzman,Beneil Dariush,Blue,Lightweight
+08/08/2020,Tim Means,Laureano Staropoli,Red,Welterweight
+08/08/2020,Joaquin Buckley,Kevin Holland,Blue,Middleweight
+08/08/2020,Alexander Munoz,Nasrat Haqparast,Blue,Lightweight
+08/08/2020,Andrew Sanchez,Wellington Turman,Red,Middleweight
+08/08/2020,Gavin Tucker,Justin Jaynes,Red,Featherweight
+08/08/2020,Youssef Zalal,Peter Barrett,Red,Featherweight
+08/08/2020,Ali AlQaisi,Irwin Rivera,Blue,Bantamweight
+08/01/2020,Edmen Shahbazyan,Derek Brunson,Blue,Middleweight
+08/01/2020,Joanne Wood,Jennifer Maia,Blue,Women's Flyweight
+08/01/2020,Vicente Luque,Randy Brown,Red,Welterweight
+08/01/2020,Lando Vannata,Bobby Green,Blue,Lightweight
+08/01/2020,Jonathan Martinez,Frankie Saenz,Red,Bantamweight
+08/01/2020,Nate Maness,Johnny Munoz,Red,Featherweight
+08/01/2020,Vince Cachero,Jamall Emmers,Blue,Featherweight
+07/25/2020,Robert Whittaker,Darren Till,Red,Middleweight
+07/25/2020,Rogerio Nogueira,Mauricio Rua,Blue,Light Heavyweight
+07/25/2020,Alexander Gustafsson,Fabricio Werdum,Blue,Heavyweight
+07/25/2020,Marina Rodriguez,Carla Esparza,Blue,Women's Strawweight
+07/25/2020,Paul Craig,Gadzhimurad Antigulov,Red,Light Heavyweight
+07/25/2020,Peter Sobotta,Alex Oliveira,Blue,Welterweight
+07/25/2020,Khamzat Chimaev,Rhys McKee,Red,Welterweight
+07/25/2020,Jai Herbert,Francisco Trinaldo,Blue,Lightweight
+07/25/2020,Tom Aspinall,Jake Collier,Red,Heavyweight
+07/25/2020,Mike Grundy,Movsar Evloev,Blue,Featherweight
+07/25/2020,Tanner Boser,Raphael Pessoa,Red,Heavyweight
+07/25/2020,Pannie Kianzad,Bethe Correia,Red,Women's Bantamweight
+07/25/2020,Niklas Stolze,Ramazan Emeev,Blue,Welterweight
+07/25/2020,John Castaneda,Nathaniel Wood,Blue,Bantamweight
+07/18/2020,Deiveson Figueiredo,Joseph Benavidez,Red,UFC Flyweight Title
+07/18/2020,Kelvin Gastelum,Jack Hermansson,Blue,Middleweight
+07/18/2020,Marc Diakiese,Rafael Fiziev,Blue,Lightweight
+07/18/2020,Ariane Lipski,Luana Carolina,Red,Women's Flyweight
+07/18/2020,Askar Askarov,Alexandre Pantoja,Red,Flyweight
+07/18/2020,Khadis Ibragimov,Roman Dolidze,Blue,Light Heavyweight
+07/18/2020,Grant Dawson,Nad Narimani,Red,Catch Weight
+07/18/2020,Joel Alvarez,Joe Duffy,Red,Lightweight
+07/18/2020,Brett Johns,Montel Jackson,Red,Bantamweight
+07/18/2020,Malcolm Gordon,Amir Albazi,Blue,Bantamweight
+07/18/2020,Davi Ramos,Arman Tsarukyan,Blue,Lightweight
+07/18/2020,Carlos Felipe,Serghei Spivac,Blue,Heavyweight
+07/15/2020,Dan Ige,Calvin Kattar,Blue,Featherweight
+07/15/2020,Ryan Benoit,Tim Elliott,Blue,Flyweight
+07/15/2020,Cody Stamann,Jimmie Rivera,Blue,Featherweight
+07/15/2020,Molly McCann,Taila Santos,Blue,Women's Flyweight
+07/15/2020,Abdul Razak Alhassan,Mounir Lazzez,Blue,Welterweight
+07/15/2020,John Phillips,Khamzat Chimaev,Blue,Middleweight
+07/15/2020,Lerone Murphy,Ricardo Ramos,Red,Featherweight
+07/15/2020,Modestas Bukauskas,Andreas Michailidis,Red,Light Heavyweight
+07/15/2020,Chris Fishgold,Jared Gordon,Blue,Featherweight
+07/15/2020,Liana Jojua,Diana Belbita,Red,Women's Flyweight
+07/15/2020,Jack Shore,Aaron Phillips,Red,Bantamweight
+07/11/2020,Jorge Masvidal,Kamaru Usman,Blue,UFC Welterweight Title
+07/11/2020,Max Holloway,Alexander Volkanovski,Blue,UFC Featherweight Title
+07/11/2020,Jose Aldo,Petr Yan,Blue,UFC Bantamweight Title
+07/11/2020,Rose Namajunas,Jessica Andrade,Red,Women's Strawweight
+07/11/2020,Paige VanZant,Amanda Ribas,Blue,Women's Flyweight
+07/11/2020,Volkan Oezdemir,Jiri Prochazka,Blue,Light Heavyweight
+07/11/2020,Elizeu Zaleski dos Santos,Muslim Salikhov,Blue,Welterweight
+07/11/2020,Makwan Amirkhani,Danny Henry,Red,Featherweight
+07/11/2020,Roman Bogatov,Leonardo Santos,Blue,Lightweight
+07/11/2020,Maxim Grishin,Marcin Tybura,Blue,Heavyweight
+07/11/2020,Raulian Paiva,Zhalgas Zhumagulov,Red,Flyweight
+07/11/2020,Vanessa Melo,Karol Rosa,Blue,Women's Bantamweight
+07/11/2020,Martin Day,Davey Grant,Blue,Bantamweight
+06/27/2020,Dan Hooker,Dustin Poirier,Blue,Lightweight
+06/27/2020,Mickey Gall,Mike Perry,Blue,Welterweight
+06/27/2020,Maurice Greene,Gian Villante,Red,Heavyweight
+06/27/2020,Brendan Allen,Kyle Daukaus,Red,Middleweight
+06/27/2020,Takashi Sato,Jason Witt,Red,Welterweight
+06/27/2020,Julian Erosa,Sean Woodson,Red,Catch Weight
+06/27/2020,Khama Worthy,Luis Pena,Red,Lightweight
+06/27/2020,Philipe Lins,Tanner Boser,Blue,Heavyweight
+06/27/2020,Kay Hansen,Jinh Yu Frey,Red,Women's Strawweight
+06/27/2020,Youssef Zalal,Jordan Griffin,Red,Featherweight
+06/20/2020,Curtis Blaydes,Alexander Volkov,Red,Heavyweight
+06/20/2020,Josh Emmett,Shane Burgos,Red,Featherweight
+06/20/2020,Raquel Pennington,Marion Reneau,Red,Women's Bantamweight
+06/20/2020,Lyman Good,Belal Muhammad,Blue,Welterweight
+06/20/2020,Roosevelt Roberts,Jim Miller,Blue,Catch Weight
+06/20/2020,Clay Guida,Bobby Green,Blue,Lightweight
+06/20/2020,Brianna Fortino,Tecia Torres,Blue,Women's Strawweight
+06/20/2020,Gillian Robertson,Cortney Casey,Red,Women's Flyweight
+06/20/2020,Frank Camacho,Justin Jaynes,Blue,Lightweight
+06/20/2020,Lauren Murphy,Roxanne Modafferi,Red,Women's Flyweight
+06/20/2020,Max Rohskopf,Austin Hubbard,Blue,Lightweight
+06/13/2020,Jessica Eye,Cynthia Calvillo,Blue,Women's Flyweight
+06/13/2020,Karl Roberson,Marvin Vettori,Blue,Middleweight
+06/13/2020,Charles Rosa,Kevin Aguilar,Red,Lightweight
+06/13/2020,Andre Fili,Charles Jourdain,Red,Featherweight
+06/13/2020,Mark De La Rosa,Jordan Espinosa,Blue,Bantamweight
+06/13/2020,Mariya Agapova,Hannah Cifers,Red,Women's Flyweight
+06/13/2020,Merab Dvalishvili,Gustavo Lopez,Red,Catch Weight
+06/13/2020,Julia Avila,Gina Mazany,Red,Women's Bantamweight
+06/13/2020,Zarrukh Adashev,Tyson Nam,Blue,Bantamweight
+06/13/2020,Anthony Ivy,Christian Aguilera,Blue,Welterweight
+06/06/2020,Felicia Spencer,Amanda Nunes,Blue,UFC Women's Featherweight Title
+06/06/2020,Cody Garbrandt,Raphael Assuncao,Red,Bantamweight
+06/06/2020,Cory Sandhagen,Aljamain Sterling,Blue,Bantamweight
+06/06/2020,Anthony Rocco Martin,Neil Magny,Blue,Welterweight
+06/06/2020,Sean O'Malley,Eddie Wineland,Red,Bantamweight
+06/06/2020,Chase Hooper,Alex Caceres,Blue,Featherweight
+06/06/2020,Gerald Meerschaert,Ian Heinisch,Blue,Middleweight
+06/06/2020,Brian Kelleher,Cody Stamann,Blue,Featherweight
+06/06/2020,Maki Pitolo,Charles Byrd,Red,Middleweight
+06/06/2020,Jussier Formiga,Alex Perez,Blue,Flyweight
+06/06/2020,Alonzo Menifield,Devin Clark,Blue,Light Heavyweight
+06/06/2020,Herbert Burns,Evan Dunham,Red,Catch Weight
+05/30/2020,Tyron Woodley,Gilbert Burns,Blue,Welterweight
+05/30/2020,Augusto Sakai,Blagoy Ivanov,Red,Heavyweight
+05/30/2020,Billy Quarantillo,Spike Carlyle,Red,Catch Weight
+05/30/2020,Roosevelt Roberts,Brok Weaver,Red,Lightweight
+05/30/2020,Hannah Cifers,Mackenzie Dern,Blue,Women's Strawweight
+05/30/2020,Antonina Shevchenko,Katlyn Cerminara,Blue,Women's Flyweight
+05/30/2020,Daniel Rodriguez,Gabe Green,Red,Welterweight
+05/30/2020,Tim Elliott,Brandon Royval,Blue,Flyweight
+05/30/2020,Casey Kenney,Louis Smolka,Red,Bantamweight
+05/30/2020,Chris Gutierrez,Vince Morales,Red,Featherweight
+05/16/2020,Walt Harris,Alistair Overeem,Blue,Heavyweight
+05/16/2020,Angela Hill,Claudia Gadelha,Blue,Women's Strawweight
+05/16/2020,Dan Ige,Edson Barboza,Red,Featherweight
+05/16/2020,Eryk Anders,Krzysztof Jotko,Blue,Middleweight
+05/16/2020,Marlon Vera,Song Yadong,Blue,Featherweight
+05/16/2020,Miguel Baeza,Matt Brown,Red,Welterweight
+05/16/2020,Anthony Hernandez,Kevin Holland,Blue,Middleweight
+05/16/2020,Giga Chikadze,Irwin Rivera,Red,Featherweight
+05/16/2020,Nate Landwehr,Darren Elkins,Red,Featherweight
+05/16/2020,Cortney Casey,Mara Romero Borella,Red,Women's Flyweight
+05/16/2020,Don'Tale Mayes,Rodrigo Nascimento,Blue,Heavyweight
+05/13/2020,Anthony Smith,Glover Teixeira,Blue,Light Heavyweight
+05/13/2020,Ovince Saint Preux,Ben Rothwell,Blue,Heavyweight
+05/13/2020,Drew Dober,Alexander Hernandez,Red,Lightweight
+05/13/2020,Ray Borg,Ricky Simon,Blue,Bantamweight
+05/13/2020,Andrei Arlovski,Philipe Lins,Red,Heavyweight
+05/13/2020,Thiago Moises,Michael Johnson,Red,Lightweight
+05/13/2020,Sijara Eubanks,Sarah Moras,Red,Women's Bantamweight
+05/13/2020,Gabriel Benitez,Omar Morales,Blue,Lightweight
+05/13/2020,Brian Kelleher,Hunter Azure,Red,Featherweight
+05/13/2020,Ike Villanueva,Chase Sherman,Blue,Heavyweight
+05/09/2020,Tony Ferguson,Justin Gaethje,Blue,UFC Interim Lightweight Title
+05/09/2020,Henry Cejudo,Dominick Cruz,Red,UFC Bantamweight Title
+05/09/2020,Jairzinho Rozenstruik,Francis Ngannou,Blue,Heavyweight
+05/09/2020,Calvin Kattar,Jeremy Stephens,Red,Featherweight
+05/09/2020,Greg Hardy,Yorgan De Castro,Red,Heavyweight
+05/09/2020,Donald Cerrone,Anthony Pettis,Blue,Welterweight
+05/09/2020,Fabricio Werdum,Aleksei Oleinik,Blue,Heavyweight
+05/09/2020,Carla Esparza,Michelle Waterson-Gomez,Red,Women's Strawweight
+05/09/2020,Niko Price,Vicente Luque,Blue,Welterweight
+05/09/2020,Bryce Mitchell,Charles Rosa,Red,Featherweight
+05/09/2020,Ryan Spann,Sam Alvey,Red,Light Heavyweight
+03/14/2020,Kevin Lee,Charles Oliveira,Blue,Lightweight
+03/14/2020,Gilbert Burns,Demian Maia,Red,Welterweight
+03/14/2020,Damir Hadzovic,Renato Moicano,Blue,Lightweight
+03/14/2020,Nikita Krylov,Johnny Walker,Red,Light Heavyweight
+03/14/2020,John Makdessi,Francisco Trinaldo,Blue,Lightweight
+03/14/2020,Jussier Formiga,Brandon Moreno,Blue,Flyweight
+03/14/2020,Randa Markos,Amanda Ribas,Blue,Women's Strawweight
+03/14/2020,Aleksei Kunchenko,Elizeu Zaleski dos Santos,Blue,Welterweight
+03/14/2020,Mayra Bueno Silva,Maryna Moroz,Blue,Women's Flyweight
+03/14/2020,Bruno Silva,David Dvorak,Blue,Flyweight
+03/14/2020,Bea Malecki,Veronica Hardy,Red,Women's Bantamweight
+03/07/2020,Yoel Romero,Israel Adesanya,Blue,UFC Middleweight Title
+03/07/2020,Zhang Weili,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+03/07/2020,Drakkar Klose,Beneil Dariush,Blue,Lightweight
+03/07/2020,Li Jingliang,Neil Magny,Blue,Welterweight
+03/07/2020,Alex Oliveira,Max Griffin,Red,Welterweight
+03/07/2020,Jose Quinonez,Sean O'Malley,Blue,Bantamweight
+03/07/2020,Mark Madsen,Austin Hubbard,Red,Lightweight
+03/07/2020,Rodolfo Vieira,Saparbeg Safarov,Red,Middleweight
+03/07/2020,Deron Winn,Gerald Meerschaert,Blue,Middleweight
+03/07/2020,Jamall Emmers,Giga Chikadze,Blue,Featherweight
+03/07/2020,Batgerel Danaa,Guido Cannetti,Red,Bantamweight
+02/29/2020,Joseph Benavidez,Deiveson Figueiredo,Blue,Flyweight
+02/29/2020,Zarah Fairn,Felicia Spencer,Blue,Women's Featherweight
+02/29/2020,Ion Cutelaba,Magomed Ankalaev,Blue,Light Heavyweight
+02/29/2020,Megan Anderson,Norma Dumont,Red,Women's Featherweight
+02/29/2020,Darrick Minner,Grant Dawson,Blue,Featherweight
+02/29/2020,Kyler Phillips,Gabriel Silva,Red,Bantamweight
+02/29/2020,Tom Breese,Brendan Allen,Blue,Middleweight
+02/29/2020,Serghei Spivac,Marcin Tybura,Blue,Heavyweight
+02/29/2020,Steve Garcia,Luis Pena,Blue,Lightweight
+02/29/2020,TJ Brown,Jordan Griffin,Blue,Featherweight
+02/29/2020,Spike Carlyle,Aalon Cruz,Red,Featherweight
+02/29/2020,Ismail Naurdiev,Sean Brady,Blue,Welterweight
+02/22/2020,Dan Hooker,Paul Felder,Red,Lightweight
+02/22/2020,Jimmy Crute,Michal Oleksiejczuk,Red,Light Heavyweight
+02/22/2020,Yan Xiaonan,Karolina Kowalkiewicz,Red,Women's Strawweight
+02/22/2020,Marcos Rogerio de Lima,Ben Sosoli,Red,Heavyweight
+02/22/2020,Magomed Mustafaev,Brad Riddell,Blue,Lightweight
+02/22/2020,Zubaira Tukhugov,Kevin Aguilar,Red,Featherweight
+02/22/2020,Jalin Turner,Josh Culibao,Red,Lightweight
+02/22/2020,Jake Matthews,Emil Meek,Red,Welterweight
+02/22/2020,Callan Potter,Song Kenan,Blue,Welterweight
+02/22/2020,Kai Kara-France,Tyson Nam,Red,Flyweight
+02/22/2020,Angela Hill,Loma Lookboonmee,Red,Women's Strawweight
+02/22/2020,Shana Dobson,Priscila Cachoeira,Blue,Women's Flyweight
+02/15/2020,Jan Blachowicz,Corey Anderson,Red,Light Heavyweight
+02/15/2020,Michel Pereira,Diego Sanchez,Blue,Welterweight
+02/15/2020,Mara Romero Borella,Montana De La Rosa,Blue,Women's Flyweight
+02/15/2020,Kazula Vargas,Brok Weaver,Blue,Lightweight
+02/15/2020,Ray Borg,Rogerio Bontorin,Red,Flyweight
+02/15/2020,Lando Vannata,Yancy Medeiros,Red,Lightweight
+02/15/2020,Daniel Rodriguez,Tim Means,Red,Welterweight
+02/15/2020,Nathaniel Wood,John Dodson,Blue,Bantamweight
+02/15/2020,Jim Miller,Scott Holtzman,Blue,Lightweight
+02/15/2020,Devin Clark,Dequan Townsend,Red,Light Heavyweight
+02/15/2020,Casey Kenney,Merab Dvalishvili,Blue,Bantamweight
+02/15/2020,Macy Chiasson,Shanna Young,Red,Women's Bantamweight
+02/15/2020,Mark De La Rosa,Raulian Paiva,Blue,Flyweight
+02/08/2020,Jon Jones,Dominick Reyes,Red,UFC Light Heavyweight Title
+02/08/2020,Valentina Shevchenko,Katlyn Cerminara,Red,UFC Women's Flyweight Title
+02/08/2020,Juan Adams,Justin Tafa,Blue,Heavyweight
+02/08/2020,Dan Ige,Mirsad Bektic,Red,Featherweight
+02/08/2020,Derrick Lewis,Ilir Latifi,Red,Heavyweight
+02/08/2020,James Krause,Trevin Giles,Blue,Middleweight
+02/08/2020,Lauren Murphy,Andrea Lee,Red,Women's Flyweight
+02/08/2020,Alex Morono,Khaos Williams,Blue,Welterweight
+02/08/2020,Mario Bautista,Miles Johns,Red,Bantamweight
+02/08/2020,Andre Ewell,Jonathan Martinez,Red,Bantamweight
+02/08/2020,Austin Lingo,Youssef Zalal,Blue,Featherweight
+01/25/2020,Junior Dos Santos,Curtis Blaydes,Blue,Heavyweight
+01/25/2020,Michael Chiesa,Rafael Dos Anjos,Red,Welterweight
+01/25/2020,Alex Perez,Jordan Espinosa,Red,Flyweight
+01/25/2020,Angela Hill,Hannah Cifers,Red,Women's Strawweight
+01/25/2020,Darko Stosic,Jamahal Hill,Blue,Light Heavyweight
+01/25/2020,Dequan Townsend,Bevon Lewis,Blue,Middleweight
+01/25/2020,Arnold Allen,Nik Lentz,Red,Featherweight
+01/25/2020,Justine Kish,Lucie Pudilova,Red,Women's Flyweight
+01/25/2020,Felipe Colares,Montel Jackson,Blue,Bantamweight
+01/25/2020,Sara McMann,Lina Lansberg,Red,Women's Bantamweight
+01/25/2020,Tony Gravely,Brett Johns,Blue,Bantamweight
+01/25/2020,Nate Landwehr,Herbert Burns,Blue,Featherweight
+01/18/2020,Donald Cerrone,Conor McGregor,Blue,Welterweight
+01/18/2020,Raquel Pennington,Holly Holm,Blue,Women's Bantamweight
+01/18/2020,Aleksei Oleinik,Maurice Greene,Red,Heavyweight
+01/18/2020,Brian Kelleher,Ode Osbourne,Red,Bantamweight
+01/18/2020,Anthony Pettis,Diego Ferreira,Blue,Lightweight
+01/18/2020,Maycee Barber,Roxanne Modafferi,Blue,Women's Flyweight
+01/18/2020,Andre Fili,Sodiq Yusuff,Blue,Featherweight
+01/18/2020,Tim Elliott,Askar Askarov,Blue,Flyweight
+01/18/2020,Drew Dober,Nasrat Haqparast,Red,Lightweight
+01/18/2020,Justin Ledet,Aleksa Camur,Blue,Light Heavyweight
+01/18/2020,JJ Aldrich,Sabina Mazo,Blue,Women's Flyweight
+12/21/2019,Frankie Edgar,Chan Sung Jung,Blue,Featherweight
+12/21/2019,Volkan Oezdemir,Aleksandar Rakic,Red,Light Heavyweight
+12/21/2019,Dooho Choi,Charles Jourdain,Blue,Featherweight
+12/21/2019,Mike Rodriguez,Da Woon Jung,Blue,Light Heavyweight
+12/21/2019,JunYong Park,Marc-Andre Barriault,Red,Middleweight
+12/21/2019,Pingyuan Liu,Kyung Ho Kang,Blue,Bantamweight
+12/21/2019,Ciryl Gane,Tanner Boser,Red,Heavyweight
+12/21/2019,Suman Mokhtarian,SeungWoo Choi,Blue,Featherweight
+12/21/2019,Omar Morales,Dong Hyun Ma,Red,Lightweight
+12/21/2019,Alexandre Pantoja,Matt Schnell,Red,Flyweight
+12/21/2019,Raoni Barcelos,Said Nurmagomedov,Red,Bantamweight
+12/21/2019,Amanda Lemos,Miranda Granger,Red,Women's Strawweight
+12/21/2019,Alatengheili,Ryan Benoit,Red,Bantamweight
+12/14/2019,Colby Covington,Kamaru Usman,Blue,UFC Welterweight Title
+12/14/2019,Max Holloway,Alexander Volkanovski,Blue,UFC Featherweight Title
+12/14/2019,Amanda Nunes,Germaine de Randamie,Red,UFC Women's Bantamweight Title
+12/14/2019,Marlon Moraes,Jose Aldo,Red,Bantamweight
+12/14/2019,Urijah Faber,Petr Yan,Blue,Bantamweight
+12/14/2019,Geoff Neal,Mike Perry,Red,Welterweight
+12/14/2019,Irene Aldana,Ketlen Vieira,Red,Women's Bantamweight
+12/14/2019,Omari Akhmedov,Ian Heinisch,Red,Middleweight
+12/14/2019,Matt Brown,Ben Saunders,Red,Welterweight
+12/14/2019,Daniel Teymur,Chase Hooper,Blue,Featherweight
+12/14/2019,Brandon Moreno,Kai Kara-France,Red,Flyweight
+12/14/2019,Jessica Eye,Viviane Araujo,Red,Women's Flyweight
+12/14/2019,Oskar Piechota,Punahele Soriano,Blue,Middleweight
+12/07/2019,Alistair Overeem,Jairzinho Rozenstruik,Blue,Heavyweight
+12/07/2019,Ben Rothwell,Stefan Struve,Red,Heavyweight
+12/07/2019,Aspen Ladd,Yana Santos,Red,Women's Bantamweight
+12/07/2019,Rob Font,Ricky Simon,Red,Bantamweight
+12/07/2019,Thiago Alves,Tim Means,Blue,Welterweight
+12/07/2019,Billy Quarantillo,Jacob Kilburn,Red,Featherweight
+12/07/2019,Bryce Mitchell,Matt Sayles,Red,Featherweight
+12/07/2019,Matt Wiman,Joe Solecki,Blue,Lightweight
+12/07/2019,Mallory Martin,Virna Jandiroba,Blue,Women's Strawweight
+12/07/2019,Trevor Smith,Makhmud Muradov,Blue,Middleweight
+11/16/2019,Jacare Souza,Jan Blachowicz,Blue,Light Heavyweight
+11/16/2019,Charles Oliveira,Jared Gordon,Red,Lightweight
+11/16/2019,Andre Muniz,Antonio Arroyo,Red,Middleweight
+11/16/2019,Wellington Turman,Markus Perez,Red,Middleweight
+11/16/2019,Sergio Moraes,James Krause,Blue,Welterweight
+11/16/2019,Eduardo Garagorri,Ricardo Ramos,Blue,Featherweight
+11/16/2019,Bobby Green,Francisco Trinaldo,Blue,Lightweight
+11/16/2019,Warlley Alves,Randy Brown,Blue,Welterweight
+11/16/2019,Renan Barao,Douglas Silva de Andrade,Blue,Featherweight
+11/16/2019,Isabela de Padua,Ariane Lipski,Blue,Women's Flyweight
+11/16/2019,Tracy Cortez,Vanessa Melo,Red,Women's Bantamweight
+11/09/2019,Calvin Kattar,Zabit Magomedsharipov,Blue,Featherweight
+11/09/2019,Greg Hardy,Alexander Volkov,Blue,Heavyweight
+11/09/2019,Zelim Imadaev,Danny Roberts,Blue,Welterweight
+11/09/2019,Ed Herman,Khadis Ibragimov,Red,Light Heavyweight
+11/09/2019,Anthony Rocco Martin,Ramazan Emeev,Red,Welterweight
+11/09/2019,Klidson Abreu,Shamil Gamzatov,Blue,Light Heavyweight
+11/09/2019,Magomed Ankalaev,Dalcha Lungiambula,Red,Light Heavyweight
+11/09/2019,Rustam Khabilov,Sergey Khandozhko,Red,Welterweight
+11/09/2019,Roman Kopylov,Karl Roberson,Blue,Middleweight
+11/09/2019,Abubakar Nurmagomedov,David Zawada,Blue,Welterweight
+11/09/2019,Roosevelt Roberts,Alexander Yakovlev,Red,Lightweight
+11/09/2019,Jessica-Rose Clark,Pannie Kianzad,Blue,Women's Bantamweight
+11/09/2019,Davey Grant,Grigory Popov,Red,Bantamweight
+11/02/2019,Nate Diaz,Jorge Masvidal,Blue,Welterweight
+11/02/2019,Kelvin Gastelum,Darren Till,Blue,Middleweight
+11/02/2019,Vicente Luque,Stephen Thompson,Blue,Welterweight
+11/02/2019,Blagoy Ivanov,Derrick Lewis,Blue,Heavyweight
+11/02/2019,Kevin Lee,Gregor Gillespie,Red,Lightweight
+11/02/2019,Johnny Walker,Corey Anderson,Blue,Light Heavyweight
+11/02/2019,Makwan Amirkhani,Shane Burgos,Blue,Featherweight
+11/02/2019,Edmen Shahbazyan,Brad Tavares,Red,Middleweight
+11/02/2019,Andrei Arlovski,Jairzinho Rozenstruik,Blue,Heavyweight
+11/02/2019,Katlyn Cerminara,Jennifer Maia,Red,Women's Flyweight
+11/02/2019,Lyman Good,Chance Rencountre,Red,Welterweight
+11/02/2019,Hakeem Dawodu,Julio Arce,Red,Featherweight
+10/26/2019,Demian Maia,Ben Askren,Red,Welterweight
+10/26/2019,Stevie Ray,Michael Johnson,Red,Lightweight
+10/26/2019,Frank Camacho,Beneil Dariush,Blue,Lightweight
+10/26/2019,Don'Tale Mayes,Ciryl Gane,Blue,Heavyweight
+10/26/2019,Laureano Staropoli,Muslim Salikhov,Blue,Welterweight
+10/26/2019,Ashley Yoder,Randa Markos,Blue,Women's Strawweight
+10/26/2019,Rafael Fiziev,Alex White,Red,Lightweight
+10/26/2019,Enrique Barzola,Movsar Evloev,Blue,Featherweight
+10/26/2019,Sergei Pavlovich,Maurice Greene,Red,Heavyweight
+10/26/2019,Loma Lookboonmee,Aleksandra Albu,Red,Women's Strawweight
+10/26/2019,Raphael Pessoa,Jeff Hughes,Red,Heavyweight
+10/18/2019,Chris Weidman,Dominick Reyes,Blue,Light Heavyweight
+10/18/2019,Yair Rodriguez,Jeremy Stephens,Red,Featherweight
+10/18/2019,Jonathan Pearce,Joe Lauzon,Blue,Lightweight
+10/18/2019,Gillian Robertson,Maycee Barber,Blue,Women's Flyweight
+10/18/2019,Deron Winn,Darren Stewart,Blue,Middleweight
+10/18/2019,Manny Bermudez,Charles Rosa,Blue,Featherweight
+10/18/2019,Molly McCann,Diana Belbita,Red,Women's Flyweight
+10/18/2019,Kyle Bochniak,Sean Woodson,Blue,Featherweight
+10/18/2019,Randy Costa,Boston Salmon,Red,Bantamweight
+10/18/2019,Sean Brady,Court McGee,Red,Welterweight
+10/18/2019,Kevin Holland,Brendan Allen,Blue,Middleweight
+10/18/2019,Daniel Spitz,Tanner Boser,Blue,Heavyweight
+10/12/2019,Joanna Jedrzejczyk,Michelle Waterson-Gomez,Red,Women's Strawweight
+10/12/2019,Cub Swanson,Kron Gracie,Red,Featherweight
+10/12/2019,James Vick,Niko Price,Blue,Welterweight
+10/12/2019,Mackenzie Dern,Amanda Ribas,Blue,Women's Strawweight
+10/12/2019,Luis Pena,Matt Frevola,Blue,Lightweight
+10/12/2019,Eryk Anders,Gerald Meerschaert,Red,Middleweight
+10/12/2019,Devin Clark,Ryan Spann,Blue,Light Heavyweight
+10/12/2019,Mike Davis,Thomas Gifford,Red,Lightweight
+10/12/2019,Alex Morono,Max Griffin,Red,Welterweight
+10/12/2019,Deiveson Figueiredo,Tim Elliott,Red,Flyweight
+10/12/2019,Andre Ewell,Marlon Vera,Blue,Bantamweight
+10/12/2019,Miguel Baeza,Hector Aldana,Red,Welterweight
+10/12/2019,Marvin Vettori,Andrew Sanchez,Red,Middleweight
+10/12/2019,Lauren Mueller,JJ Aldrich,Blue,Women's Flyweight
+10/05/2019,Israel Adesanya,Robert Whittaker,Red,UFC Middleweight Title
+10/05/2019,Al Iaquinta,Dan Hooker,Blue,Lightweight
+10/05/2019,Tai Tuivasa,Serghei Spivac,Blue,Heavyweight
+10/05/2019,Luke Jumeau,Dhiego Lima,Blue,Welterweight
+10/05/2019,Yorgan De Castro,Justin Tafa,Red,Heavyweight
+10/05/2019,Jake Matthews,Rostem Akman,Red,Welterweight
+10/05/2019,Maki Pitolo,Callan Potter,Blue,Welterweight
+10/05/2019,Jamie Mullarkey,Brad Riddell,Blue,Lightweight
+10/05/2019,Zarah Fairn,Megan Anderson,Blue,Women's Featherweight
+10/05/2019,Ji Yeon Kim,Nadia Kassem,Red,Women's Flyweight
+09/28/2019,Jared Cannonier,Jack Hermansson,Red,Middleweight
+09/28/2019,Mark Madsen,Danilo Belluardo,Red,Lightweight
+09/28/2019,Gilbert Burns,Gunnar Nelson,Red,Welterweight
+09/28/2019,Khalil Rountree Jr.,Ion Cutelaba,Blue,Light Heavyweight
+09/28/2019,Michal Oleksiejczuk,Ovince Saint Preux,Blue,Light Heavyweight
+09/28/2019,Nicolas Dalby,Alex Oliveira,Red,Welterweight
+09/28/2019,Alen Amedovski,John Phillips,Blue,Middleweight
+09/28/2019,Makhmud Muradov,Alessio Di Chirico,Red,Middleweight
+09/28/2019,Ismail Naurdiev,Siyar Bahadurzada,Red,Welterweight
+09/28/2019,Giga Chikadze,Brandon Davis,Red,Featherweight
+09/28/2019,Lina Lansberg,Macy Chiasson,Red,Women's Bantamweight
+09/28/2019,Marc Diakiese,Lando Vannata,Red,Lightweight
+09/28/2019,Jack Shore,Nohelin Hernandez,Red,Bantamweight
+09/21/2019,Carla Esparza,Alexa Grasso,Red,Women's Strawweight
+09/21/2019,Irene Aldana,Vanessa Melo,Red,Women's Bantamweight
+09/21/2019,Steven Peterson,Martin Bravo,Red,Featherweight
+09/21/2019,Carlos Huachin,Jose Quinonez,Blue,Bantamweight
+09/21/2019,Marco Polo Reyes,Kyle Nelson,Blue,Featherweight
+09/21/2019,Ariane Carnelossi,Angela Hill,Blue,Women's Strawweight
+09/21/2019,Sergio Pettis,Tyson Nam,Red,Flyweight
+09/21/2019,Paul Craig,Vinicius Moreira,Red,Light Heavyweight
+09/21/2019,Sijara Eubanks,Bethe Correia,Blue,Women's Bantamweight
+09/21/2019,Claudio Puelles,Marcos Mariano,Red,Lightweight
+09/14/2019,Justin Gaethje,Donald Cerrone,Red,Lightweight
+09/14/2019,Nikita Krylov,Glover Teixeira,Blue,Light Heavyweight
+09/14/2019,Michel Pereira,Tristan Connelly,Blue,Welterweight
+09/14/2019,Antonio Carlos Junior,Uriah Hall,Blue,Middleweight
+09/14/2019,Jimmy Crute,Misha Cirkunov,Blue,Light Heavyweight
+09/14/2019,Augusto Sakai,Marcin Tybura,Red,Heavyweight
+09/14/2019,Miles Johns,Cole Smith,Red,Bantamweight
+09/14/2019,Hunter Azure,Brad Katona,Red,Bantamweight
+09/14/2019,Chas Skelly,Jordan Griffin,Red,Featherweight
+09/14/2019,Ryan MacDonald,Louis Smolka,Blue,Bantamweight
+09/14/2019,Austin Hubbard,Kyle Prepolec,Red,Lightweight
+09/07/2019,Dustin Poirier,Khabib Nurmagomedov,Blue,UFC Lightweight Title
+09/07/2019,Edson Barboza,Paul Felder,Blue,Lightweight
+09/07/2019,Islam Makhachev,Davi Ramos,Red,Lightweight
+09/07/2019,Curtis Blaydes,Shamil Abdurakhimov,Red,Heavyweight
+09/07/2019,Diego Ferreira,Mairbek Taisumov,Red,Lightweight
+09/07/2019,Andrea Lee,Joanne Wood,Blue,Women's Flyweight
+09/07/2019,Sarah Moras,Liana Jojua,Red,Women's Bantamweight
+09/07/2019,Ottman Azaitar,Teemu Packalen,Red,Lightweight
+09/07/2019,Takashi Sato,Belal Muhammad,Blue,Welterweight
+09/07/2019,Muslim Salikhov,Nordine Taleb,Red,Welterweight
+09/07/2019,Zak Cummings,Omari Akhmedov,Blue,Middleweight
+09/07/2019,Fares Ziam,Don Madge,Blue,Lightweight
+08/31/2019,Jessica Andrade,Zhang Weili,Blue,UFC Women's Strawweight Title
+08/31/2019,Elizeu Zaleski dos Santos,Li Jingliang,Blue,Welterweight
+08/31/2019,Mark De La Rosa,Kai Kara-France,Blue,Flyweight
+08/31/2019,Song Kenan,Derrick Krantz,Red,Welterweight
+08/31/2019,Wu Yanan,Mizuki,Blue,Women's Flyweight
+08/31/2019,JunYong Park,Anthony Hernandez,Blue,Middleweight
+08/31/2019,Sumudaerji,Andre Soukhamthath,Red,Bantamweight
+08/31/2019,Khadis Ibragimov,Da Woon Jung,Blue,Light Heavyweight
+08/31/2019,Damir Ismagulov,Thiago Moises,Red,Lightweight
+08/31/2019,Batgerel Danaa,Alatengheili,Blue,Bantamweight
+08/31/2019,Lara Procopio,Karol Rosa,Blue,Women's Bantamweight
+08/17/2019,Stipe Miocic,Daniel Cormier,Red,UFC Heavyweight Title
+08/17/2019,Anthony Pettis,Nate Diaz,Blue,Welterweight
+08/17/2019,Yoel Romero,Paulo Costa,Blue,Middleweight
+08/17/2019,Gabriel Benitez,Sodiq Yusuff,Blue,Featherweight
+08/17/2019,Derek Brunson,Ian Heinisch,Red,Middleweight
+08/17/2019,Devonte Smith,Khama Worthy,Blue,Lightweight
+08/17/2019,Raphael Assuncao,Cory Sandhagen,Blue,Bantamweight
+08/17/2019,Christos Giagos,Drakkar Klose,Blue,Lightweight
+08/17/2019,Manny Bermudez,Casey Kenney,Blue,Catch Weight
+08/17/2019,Jodie Esquibel,Hannah Cifers,Blue,Women's Strawweight
+08/17/2019,Kyung Ho Kang,Brandon Davis,Red,Bantamweight
+08/17/2019,Sabina Mazo,Shana Dobson,Red,Women's Flyweight
+08/10/2019,Valentina Shevchenko,Liz Carmouche,Red,UFC Women's Flyweight Title
+08/10/2019,Vicente Luque,Mike Perry,Red,Welterweight
+08/10/2019,Humberto Bandenay,Eduardo Garagorri,Blue,Featherweight
+08/10/2019,Volkan Oezdemir,Ilir Latifi,Red,Light Heavyweight
+08/10/2019,Oskar Piechota,Rodolfo Vieira,Blue,Middleweight
+08/10/2019,Bobby Moffett,Enrique Barzola,Blue,Featherweight
+08/10/2019,Gilbert Burns,Aleksei Kunchenko,Red,Welterweight
+08/10/2019,Ciryl Gane,Raphael Pessoa,Red,Heavyweight
+08/10/2019,Marina Rodriguez,Tecia Torres,Red,Women's Strawweight
+08/10/2019,Raulian Paiva,Rogerio Bontorin,Blue,Flyweight
+08/10/2019,Chris Gutierrez,Geraldo de Freitas,Red,Bantamweight
+08/10/2019,Kazula Vargas,Alex Da Silva,Blue,Lightweight
+08/10/2019,Veronica Hardy,Polyana Viana,Red,Women's Flyweight
+08/03/2019,Colby Covington,Robbie Lawler,Red,Welterweight
+08/03/2019,Clay Guida,Jim Miller,Blue,Lightweight
+08/03/2019,Joaquim Silva,Nasrat Haqparast,Blue,Lightweight
+08/03/2019,Gerald Meerschaert,Trevin Giles,Red,Middleweight
+08/03/2019,Scott Holtzman,Dong Hyun Ma,Red,Lightweight
+08/03/2019,Kennedy Nzechukwu,Darko Stosic,Red,Light Heavyweight
+08/03/2019,Salim Touahri,Mickey Gall,Blue,Welterweight
+08/03/2019,Antonina Shevchenko,Lucie Pudilova,Red,Women's Flyweight
+08/03/2019,Jordan Espinosa,Matt Schnell,Blue,Flyweight
+08/03/2019,Lauren Murphy,Mara Romero Borella,Red,Women's Flyweight
+08/03/2019,Claudio Silva,Cole Williams,Red,Welterweight
+08/03/2019,Miranda Granger,Hannah Goldy,Red,Women's Flyweight
+07/27/2019,Max Holloway,Frankie Edgar,Red,UFC Featherweight Title
+07/27/2019,Felicia Spencer,Cristiane Justino,Blue,Women's Featherweight
+07/27/2019,Niko Price,Geoff Neal,Blue,Welterweight
+07/27/2019,Olivier Aubin-Mercier,Arman Tsarukyan,Blue,Lightweight
+07/27/2019,Marc-Andre Barriault,Krzysztof Jotko,Blue,Middleweight
+07/27/2019,Viviane Araujo,Alexis Davis,Red,Women's Flyweight
+07/27/2019,Hakeem Dawodu,Yoshinori Horie,Red,Featherweight
+07/27/2019,Gavin Tucker,SeungWoo Choi,Red,Featherweight
+07/27/2019,Alexandre Pantoja,Deiveson Figueiredo,Blue,Flyweight
+07/27/2019,Sarah Frota,Gillian Robertson,Blue,Women's Flyweight
+07/27/2019,Kyle Stewart,Erik Koch,Blue,Welterweight
+07/20/2019,Leon Edwards,Rafael Dos Anjos,Red,Welterweight
+07/20/2019,Walt Harris,Aleksei Oleinik,Red,Heavyweight
+07/20/2019,Greg Hardy,Juan Adams,Red,Heavyweight
+07/20/2019,James Vick,Dan Hooker,Blue,Lightweight
+07/20/2019,Francisco Trinaldo,Alexander Hernandez,Blue,Lightweight
+07/20/2019,Andrei Arlovski,Ben Rothwell,Red,Heavyweight
+07/20/2019,Steven Peterson,Alex Caceres,Blue,Featherweight
+07/20/2019,Irene Aldana,Raquel Pennington,Blue,Women's Bantamweight
+07/20/2019,Sam Alvey,Klidson Abreu,Blue,Light Heavyweight
+07/20/2019,Jennifer Maia,Roxanne Modafferi,Red,Women's Flyweight
+07/20/2019,Ray Borg,Gabriel Silva,Red,Bantamweight
+07/20/2019,Jin Soo Son,Mario Bautista,Blue,Bantamweight
+07/20/2019,Felipe Colares,Domingo Pilarte,Red,Bantamweight
+07/13/2019,Aspen Ladd,Germaine de Randamie,Blue,Women's Bantamweight
+07/13/2019,Ricky Simon,Urijah Faber,Blue,Bantamweight
+07/13/2019,Mirsad Bektic,Josh Emmett,Blue,Featherweight
+07/13/2019,Karl Roberson,Wellington Turman,Red,Middleweight
+07/13/2019,Cezar Ferreira,Marvin Vettori,Blue,Middleweight
+07/13/2019,Sheymon Moraes,Andre Fili,Blue,Featherweight
+07/13/2019,Nicco Montano,Julianna Pena,Blue,Women's Bantamweight
+07/13/2019,Ryan Hall,Darren Elkins,Red,Featherweight
+07/13/2019,Jonathan Martinez,Pingyuan Liu,Red,Bantamweight
+07/13/2019,Brianna Fortino,Livinha Souza,Red,Women's Strawweight
+07/13/2019,Vince Morales,Benito Lopez,Blue,Bantamweight
+07/06/2019,Thiago Santos,Jon Jones,Blue,UFC Light Heavyweight Title
+07/06/2019,Amanda Nunes,Holly Holm,Red,UFC Women's Bantamweight Title
+07/06/2019,Ben Askren,Jorge Masvidal,Blue,Welterweight
+07/06/2019,Luke Rockhold,Jan Blachowicz,Blue,Light Heavyweight
+07/06/2019,Diego Sanchez,Michael Chiesa,Blue,Welterweight
+07/06/2019,Gilbert Melendez,Arnold Allen,Blue,Featherweight
+07/06/2019,Nohelin Hernandez,Marlon Vera,Blue,Bantamweight
+07/06/2019,Claudia Gadelha,Randa Markos,Red,Women's Strawweight
+07/06/2019,Alejandro Perez,Song Yadong,Blue,Bantamweight
+07/06/2019,Edmen Shahbazyan,Jack Marshman,Red,Middleweight
+07/06/2019,Ismail Naurdiev,Chance Rencountre,Blue,Welterweight
+07/06/2019,Julia Avila,Pannie Kianzad,Red,Women's Bantamweight
+06/29/2019,Junior Dos Santos,Francis Ngannou,Blue,Heavyweight
+06/29/2019,Joseph Benavidez,Jussier Formiga,Red,Flyweight
+06/29/2019,Anthony Rocco Martin,Demian Maia,Blue,Welterweight
+06/29/2019,Vinc Pichel,Roosevelt Roberts,Red,Lightweight
+06/29/2019,Drew Dober,Marco Polo Reyes,Red,Lightweight
+06/29/2019,Paul Craig,Alonzo Menifield,Blue,Light Heavyweight
+06/29/2019,Journey Newson,Ricardo Ramos,Blue,Bantamweight
+06/29/2019,Eryk Anders,Vinicius Moreira,Red,Light Heavyweight
+06/29/2019,Jared Gordon,Dan Moret,Red,Lightweight
+06/29/2019,Dalcha Lungiambula,Dequan Townsend,Red,Light Heavyweight
+06/29/2019,Emily Whitmire,Amanda Ribas,Blue,Women's Strawweight
+06/29/2019,Maurice Greene,Junior Albini,Red,Heavyweight
+06/22/2019,Renato Moicano,Chan Sung Jung,Blue,Featherweight
+06/22/2019,Bryan Barberena,Randy Brown,Blue,Welterweight
+06/22/2019,Anderson Dos Santos,Andre Ewell,Blue,Bantamweight
+06/22/2019,Andrea Lee,Montana De La Rosa,Red,Women's Flyweight
+06/22/2019,Kevin Holland,Alessio Di Chirico,Red,Middleweight
+06/22/2019,Dan Ige,Kevin Aguilar,Red,Featherweight
+06/22/2019,Ashley Yoder,Syuri Kondo,Red,Women's Strawweight
+06/22/2019,Luis Pena,Matt Wiman,Red,Lightweight
+06/22/2019,Allen Crowder,Jairzinho Rozenstruik,Blue,Heavyweight
+06/22/2019,Molly McCann,Ariane Lipski,Red,Women's Flyweight
+06/22/2019,Eric Spicely,Deron Winn,Blue,Middleweight
+06/08/2019,Marlon Moraes,Henry Cejudo,Blue,UFC Bantamweight Title
+06/08/2019,Valentina Shevchenko,Jessica Eye,Red,UFC Women's Flyweight Title
+06/08/2019,Donald Cerrone,Tony Ferguson,Blue,Lightweight
+06/08/2019,Petr Yan,Jimmie Rivera,Red,Bantamweight
+06/08/2019,Tai Tuivasa,Blagoy Ivanov,Blue,Heavyweight
+06/08/2019,Tatiana Suarez,Nina Nunes,Red,Women's Strawweight
+06/08/2019,Pedro Munhoz,Aljamain Sterling,Blue,Bantamweight
+06/08/2019,Karolina Kowalkiewicz,Alexa Grasso,Blue,Women's Strawweight
+06/08/2019,Ricardo Lamas,Calvin Kattar,Blue,Featherweight
+06/08/2019,Angela Hill,Yan Xiaonan,Blue,Women's Strawweight
+06/08/2019,Darren Stewart,Bevon Lewis,Red,Middleweight
+06/08/2019,Grigory Popov,Eddie Wineland,Blue,Bantamweight
+06/08/2019,Katlyn Cerminara,Joanne Wood,Red,Women's Flyweight
+06/01/2019,Anthony Smith,Alexander Gustafsson,Red,Light Heavyweight
+06/01/2019,Aleksandar Rakic,Jimi Manuwa,Red,Light Heavyweight
+06/01/2019,Makwan Amirkhani,Chris Fishgold,Red,Featherweight
+06/01/2019,Christos Giagos,Damir Hadzovic,Red,Lightweight
+06/01/2019,Sung Bin Jo,Daniel Teymur,Blue,Featherweight
+06/01/2019,Sergey Khandozhko,Rostem Akman,Red,Welterweight
+06/01/2019,Lina Lansberg,Tonya Evinger,Red,Women's Bantamweight
+06/01/2019,Leonardo Santos,Stevie Ray,Red,Lightweight
+06/01/2019,Nick Hein,Frank Camacho,Blue,Lightweight
+06/01/2019,Bea Malecki,Duda Santana,Red,Women's Bantamweight
+06/01/2019,Darko Stosic,Devin Clark,Blue,Light Heavyweight
+06/01/2019,Danilo Belluardo,Joel Alvarez,Blue,Lightweight
+05/18/2019,Kevin Lee,Rafael Dos Anjos,Blue,Welterweight
+05/18/2019,Antonio Carlos Junior,Ian Heinisch,Blue,Middleweight
+05/18/2019,Megan Anderson,Felicia Spencer,Blue,Women's Featherweight
+05/18/2019,Vicente Luque,Derrick Krantz,Red,Welterweight
+05/18/2019,Nik Lentz,Charles Oliveira,Blue,Lightweight
+05/18/2019,Davi Ramos,Austin Hubbard,Red,Lightweight
+05/18/2019,Aspen Ladd,Sijara Eubanks,Red,Women's Bantamweight
+05/18/2019,Charles Jourdain,Desmond Green,Blue,Lightweight
+05/18/2019,Danny Roberts,Michel Pereira,Blue,Welterweight
+05/18/2019,Michael Trizano,Grant Dawson,Blue,Featherweight
+05/18/2019,Patrick Cummins,Ed Herman,Blue,Light Heavyweight
+05/18/2019,Zak Cummings,Trevin Giles,Red,Middleweight
+05/18/2019,Julian Erosa,Julio Arce,Blue,Featherweight
+05/11/2019,Jessica Andrade,Rose Namajunas,Red,UFC Women's Strawweight Title
+05/11/2019,Anderson Silva,Jared Cannonier,Blue,Middleweight
+05/11/2019,Alexander Volkanovski,Jose Aldo,Red,Featherweight
+05/11/2019,Thiago Alves,Laureano Staropoli,Blue,Welterweight
+05/11/2019,Bethe Correia,Irene Aldana,Blue,Women's Bantamweight
+05/11/2019,Ryan Spann,Rogerio Nogueira,Red,Light Heavyweight
+05/11/2019,Thiago Moises,Kurt Holobaugh,Red,Lightweight
+05/11/2019,Warlley Alves,Sergio Moraes,Red,Welterweight
+05/11/2019,Clay Guida,BJ Penn,Red,Lightweight
+05/11/2019,Priscila Cachoeira,Luana Carolina,Blue,Women's Flyweight
+05/11/2019,Carlos Huachin,Raoni Barcelos,Blue,Bantamweight
+05/11/2019,Talita Bernardo,Viviane Araujo,Blue,Women's Bantamweight
+05/04/2019,Donald Cerrone,Al Iaquinta,Red,Lightweight
+05/04/2019,Elias Theodorou,Derek Brunson,Blue,Middleweight
+05/04/2019,Cub Swanson,Shane Burgos,Blue,Featherweight
+05/04/2019,Merab Dvalishvili,Brad Katona,Red,Bantamweight
+05/04/2019,Serghei Spivac,Walt Harris,Blue,Heavyweight
+05/04/2019,Andrew Sanchez,Marc-Andre Barriault,Red,Middleweight
+05/04/2019,Sarah Moras,Macy Chiasson,Blue,Women's Bantamweight
+05/04/2019,Aiemann Zahabi,Vince Morales,Blue,Bantamweight
+05/04/2019,Kyle Prepolec,Nordine Taleb,Blue,Welterweight
+05/04/2019,Matt Sayles,Kyle Nelson,Red,Featherweight
+05/04/2019,Juan Adams,Arjan Bhullar,Blue,Heavyweight
+05/04/2019,Mitch Gagnon,Cole Smith,Blue,Bantamweight
+04/27/2019,Jack Hermansson,Jacare Souza,Red,Middleweight
+04/27/2019,Greg Hardy,Dmitrii Smoliakov,Red,Heavyweight
+04/27/2019,Mike Perry,Alex Oliveira,Red,Welterweight
+04/27/2019,Ion Cutelaba,Glover Teixeira,Blue,Light Heavyweight
+04/27/2019,John Lineker,Cory Sandhagen,Blue,Bantamweight
+04/27/2019,Roosevelt Roberts,Thomas Gifford,Red,Lightweight
+04/27/2019,Takashi Sato,Ben Saunders,Red,Welterweight
+04/27/2019,Andrei Arlovski,Augusto Sakai,Blue,Heavyweight
+04/27/2019,Virna Jandiroba,Carla Esparza,Blue,Women's Strawweight
+04/27/2019,Gilbert Burns,Mike Davis,Red,Lightweight
+04/27/2019,Jason Gonzalez,Jim Miller,Blue,Lightweight
+04/27/2019,Jodie Esquibel,Angela Hill,Blue,Women's Strawweight
+04/27/2019,Dhiego Lima,Court McGee,Red,Welterweight
+04/20/2019,Aleksei Oleinik,Alistair Overeem,Blue,Heavyweight
+04/20/2019,Arman Tsarukyan,Islam Makhachev,Blue,Lightweight
+04/20/2019,Sergei Pavlovich,Marcelo Golm,Red,Heavyweight
+04/20/2019,Antonina Shevchenko,Roxanne Modafferi,Blue,Women's Flyweight
+04/20/2019,Krzysztof Jotko,Alen Amedovski,Red,Middleweight
+04/20/2019,Movsar Evloev,SeungWoo Choi,Red,Featherweight
+04/20/2019,Sultan Aliev,Keita Nakamura,Red,Welterweight
+04/20/2019,Alexander Yakovlev,Alex Da Silva,Red,Lightweight
+04/20/2019,Marcin Tybura,Shamil Abdurakhimov,Blue,Heavyweight
+04/20/2019,Gadzhimurad Antigulov,Michal Oleksiejczuk,Blue,Light Heavyweight
+04/20/2019,Magomed Mustafaev,Rafael Fiziev,Red,Lightweight
+04/13/2019,Max Holloway,Dustin Poirier,Blue,UFC Interim Lightweight Title
+04/13/2019,Kelvin Gastelum,Israel Adesanya,Blue,UFC Interim Middleweight Title
+04/13/2019,Eryk Anders,Khalil Rountree Jr.,Blue,Light Heavyweight
+04/13/2019,Alan Jouban,Dwight Grant,Blue,Welterweight
+04/13/2019,Nikita Krylov,Ovince Saint Preux,Red,Light Heavyweight
+04/13/2019,Jalin Turner,Matt Frevola,Blue,Lightweight
+04/13/2019,Alexandre Pantoja,Wilson Reis,Red,Flyweight
+04/13/2019,Zelim Imadaev,Max Griffin,Blue,Welterweight
+04/13/2019,Khalid Taha,Boston Salmon,Red,Bantamweight
+04/13/2019,Belal Muhammad,Curtis Millender,Red,Welterweight
+04/13/2019,Andre Soukhamthath,Montel Jackson,Blue,Bantamweight
+04/13/2019,Poliana Botelho,Lauren Mueller,Red,Women's Flyweight
+04/13/2019,Brandon Davis,Randy Costa,Red,Bantamweight
+03/30/2019,Edson Barboza,Justin Gaethje,Blue,Lightweight
+03/30/2019,David Branch,Jack Hermansson,Blue,Middleweight
+03/30/2019,Josh Emmett,Michael Johnson,Red,Featherweight
+03/30/2019,Karolina Kowalkiewicz,Michelle Waterson-Gomez,Blue,Women's Strawweight
+03/30/2019,Paul Craig,Kennedy Nzechukwu,Red,Light Heavyweight
+03/30/2019,Sodiq Yusuff,Sheymon Moraes,Red,Featherweight
+03/30/2019,Jessica Aguilar,Marina Rodriguez,Blue,Women's Strawweight
+03/30/2019,Ross Pearson,Desmond Green,Blue,Lightweight
+03/30/2019,Enrique Barzola,Kevin Aguilar,Blue,Featherweight
+03/30/2019,Kevin Holland,Gerald Meerschaert,Red,Middleweight
+03/30/2019,Casey Kenney,Ray Borg,Red,Bantamweight
+03/30/2019,Sabina Mazo,Maryna Moroz,Blue,Women's Flyweight
+03/30/2019,Alex Perez,Mark De La Rosa,Red,Bantamweight
+03/23/2019,Stephen Thompson,Anthony Pettis,Blue,Welterweight
+03/23/2019,Justin Willis,Curtis Blaydes,Blue,Heavyweight
+03/23/2019,John Makdessi,Jesus Pinedo,Red,Lightweight
+03/23/2019,Deiveson Figueiredo,Jussier Formiga,Blue,Flyweight
+03/23/2019,Luis Pena,Steven Peterson,Red,Featherweight
+03/23/2019,JJ Aldrich,Maycee Barber,Blue,Women's Flyweight
+03/23/2019,Bobby Moffett,Bryce Mitchell,Blue,Featherweight
+03/23/2019,Frankie Saenz,Marlon Vera,Blue,Bantamweight
+03/23/2019,Jennifer Maia,Alexis Davis,Red,Women's Flyweight
+03/23/2019,Angela Hill,Randa Markos,Blue,Women's Strawweight
+03/23/2019,Ryan MacDonald,Chris Gutierrez,Blue,Bantamweight
+03/23/2019,Eric Shelton,Jordan Espinosa,Blue,Flyweight
+03/16/2019,Jorge Masvidal,Darren Till,Red,Welterweight
+03/16/2019,Leon Edwards,Gunnar Nelson,Red,Welterweight
+03/16/2019,Volkan Oezdemir,Dominick Reyes,Blue,Light Heavyweight
+03/16/2019,Nathaniel Wood,Jose Quinonez,Red,Bantamweight
+03/16/2019,Danny Roberts,Claudio Silva,Blue,Welterweight
+03/16/2019,Jack Marshman,John Phillips,Red,Middleweight
+03/16/2019,Jordan Rinaldi,Arnold Allen,Blue,Featherweight
+03/16/2019,Marc Diakiese,Joe Duffy,Red,Lightweight
+03/16/2019,Nicolae Negumereanu,Saparbeg Safarov,Blue,Light Heavyweight
+03/16/2019,Danny Henry,Dan Ige,Blue,Featherweight
+03/16/2019,Molly McCann,Priscila Cachoeira,Red,Women's Flyweight
+03/16/2019,Mike Grundy,Nad Narimani,Red,Featherweight
+03/09/2019,Derrick Lewis,Junior Dos Santos,Blue,Heavyweight
+03/09/2019,Elizeu Zaleski dos Santos,Curtis Millender,Red,Welterweight
+03/09/2019,Niko Price,Tim Means,Red,Welterweight
+03/09/2019,Ben Rothwell,Blagoy Ivanov,Blue,Heavyweight
+03/09/2019,Beneil Dariush,Drew Dober,Red,Lightweight
+03/09/2019,Tim Boetsch,Omari Akhmedov,Blue,Middleweight
+03/09/2019,Sergio Moraes,Anthony Rocco Martin,Blue,Welterweight
+03/09/2019,Marion Reneau,Yana Santos,Blue,Women's Bantamweight
+03/09/2019,Grant Dawson,Julian Erosa,Red,Featherweight
+03/09/2019,Jeff Hughes,Maurice Greene,Blue,Heavyweight
+03/09/2019,Matt Schnell,Louis Smolka,Red,Bantamweight
+03/09/2019,Zak Ottow,Alex Morono,Blue,Welterweight
+03/09/2019,Alex White,Dan Moret,Red,Lightweight
+03/02/2019,Anthony Smith,Jon Jones,Blue,UFC Light Heavyweight Title
+03/02/2019,Kamaru Usman,Tyron Woodley,Red,UFC Welterweight Title
+03/02/2019,Ben Askren,Robbie Lawler,Red,Welterweight
+03/02/2019,Zhang Weili,Tecia Torres,Red,Women's Strawweight
+03/02/2019,Pedro Munhoz,Cody Garbrandt,Red,Bantamweight
+03/02/2019,Jeremy Stephens,Zabit Magomedsharipov,Blue,Featherweight
+03/02/2019,Johnny Walker,Misha Cirkunov,Red,Light Heavyweight
+03/02/2019,Cody Stamann,Alejandro Perez,Red,Bantamweight
+03/02/2019,Diego Sanchez,Mickey Gall,Red,Welterweight
+03/02/2019,Edmen Shahbazyan,Charles Byrd,Red,Middleweight
+03/02/2019,Gina Mazany,Macy Chiasson,Blue,Women's Bantamweight
+03/02/2019,Hannah Cifers,Polyana Viana,Red,Women's Strawweight
+02/23/2019,Jan Blachowicz,Thiago Santos,Blue,Light Heavyweight
+02/23/2019,Stefan Struve,Marcos Rogerio de Lima,Red,Heavyweight
+02/23/2019,Gian Villante,Michal Oleksiejczuk,Blue,Light Heavyweight
+02/23/2019,Liz Carmouche,Lucie Pudilova,Red,Women's Flyweight
+02/23/2019,Petr Yan,John Dodson,Red,Bantamweight
+02/23/2019,Klidson Abreu,Magomed Ankalaev,Blue,Light Heavyweight
+02/23/2019,Carlo Pedersoli Jr.,Dwight Grant,Blue,Welterweight
+02/23/2019,Chris Fishgold,Daniel Teymur,Red,Featherweight
+02/23/2019,Veronica Hardy,Gillian Robertson,Blue,Women's Flyweight
+02/23/2019,Marco Polo Reyes,Damir Hadzovic,Blue,Lightweight
+02/23/2019,Michel Prazeres,Ismail Naurdiev,Blue,Welterweight
+02/23/2019,Diego Ferreira,Rustam Khabilov,Red,Lightweight
+02/23/2019,Damir Ismagulov,Joel Alvarez,Red,Lightweight
+02/17/2019,Francis Ngannou,Cain Velasquez,Red,Heavyweight
+02/17/2019,James Vick,Paul Felder,Blue,Lightweight
+02/17/2019,Cynthia Calvillo,Cortney Casey,Red,Women's Strawweight
+02/17/2019,Kron Gracie,Alex Caceres,Red,Featherweight
+02/17/2019,Bryan Barberena,Vicente Luque,Blue,Welterweight
+02/17/2019,Myles Jury,Andre Fili,Blue,Featherweight
+02/17/2019,Aljamain Sterling,Jimmie Rivera,Red,Bantamweight
+02/17/2019,Benito Lopez,Manny Bermudez,Blue,Bantamweight
+02/17/2019,Ashlee Evans-Smith,Andrea Lee,Blue,Women's Flyweight
+02/17/2019,Scott Holtzman,Nik Lentz,Blue,Lightweight
+02/17/2019,Renan Barao,Luke Sanders,Blue,Bantamweight
+02/17/2019,Aleksandra Albu,Emily Whitmire,Blue,Women's Strawweight
+02/09/2019,Anderson Silva,Israel Adesanya,Blue,Middleweight
+02/09/2019,Lando Vannata,Marcos Mariano,Red,Lightweight
+02/09/2019,Ricky Simon,Rani Yahya,Red,Bantamweight
+02/09/2019,Montana De La Rosa,Nadia Kassem,Red,Women's Flyweight
+02/09/2019,Sam Alvey,Jimmy Crute,Blue,Light Heavyweight
+02/09/2019,Dong Hyun Ma,Devonte Smith,Blue,Lightweight
+02/09/2019,Austin Arnett,Shane Young,Blue,Featherweight
+02/09/2019,Kai Kara-France,Raulian Paiva,Red,Flyweight
+02/09/2019,Kyung Ho Kang,Teruto Ishihara,Red,Bantamweight
+02/09/2019,Callan Potter,Jalin Turner,Blue,Lightweight
+02/09/2019,Jonathan Martinez,Wulijiburen,Red,Bantamweight
+02/02/2019,Marlon Moraes,Raphael Assuncao,Red,Bantamweight
+02/02/2019,Renato Moicano,Jose Aldo,Blue,Featherweight
+02/02/2019,Lyman Good,Demian Maia,Blue,Welterweight
+02/02/2019,Charles Oliveira,David Teymur,Red,Lightweight
+02/02/2019,Johnny Walker,Justin Ledet,Red,Light Heavyweight
+02/02/2019,Sarah Frota,Livinha Souza,Blue,Women's Strawweight
+02/02/2019,Anthony Hernandez,Markus Perez,Blue,Middleweight
+02/02/2019,Mara Romero Borella,Taila Santos,Red,Women's Flyweight
+02/02/2019,Max Griffin,Thiago Alves,Blue,Welterweight
+02/02/2019,Jairzinho Rozenstruik,Junior Albini,Red,Heavyweight
+02/02/2019,Felipe Colares,Geraldo de Freitas,Blue,Featherweight
+02/02/2019,Said Nurmagomedov,Ricardo Ramos,Red,Bantamweight
+02/02/2019,Bibulatov Magomed,Rogerio Bontorin,Blue,Flyweight
+01/19/2019,Henry Cejudo,TJ Dillashaw,Red,UFC Flyweight Title
+01/19/2019,Allen Crowder,Greg Hardy,Red,Heavyweight
+01/19/2019,Yancy Medeiros,Gregor Gillespie,Blue,Lightweight
+01/19/2019,Joseph Benavidez,Dustin Ortiz,Red,Flyweight
+01/19/2019,Paige VanZant,Rachael Ostovich,Red,Women's Flyweight
+01/19/2019,Glover Teixeira,Karl Roberson,Red,Light Heavyweight
+01/19/2019,Alexander Hernandez,Donald Cerrone,Blue,Lightweight
+01/19/2019,Joanne Wood,Ariane Lipski,Red,Women's Flyweight
+01/19/2019,Alonzo Menifield,Vinicius Moreira,Red,Light Heavyweight
+01/19/2019,Mario Bautista,Cory Sandhagen,Blue,Bantamweight
+01/19/2019,Te Edwards,Dennis Bermudez,Blue,Lightweight
+01/19/2019,Geoff Neal,Belal Muhammad,Red,Welterweight
+01/19/2019,Kyle Stewart,Chance Rencountre,Blue,Welterweight
+12/29/2018,Alexander Gustafsson,Jon Jones,Blue,UFC Light Heavyweight Title
+12/29/2018,Cristiane Justino,Amanda Nunes,Blue,UFC Women's Featherweight Title
+12/29/2018,Michael Chiesa,Carlos Condit,Red,Welterweight
+12/29/2018,Ilir Latifi,Corey Anderson,Blue,Light Heavyweight
+12/29/2018,Alexander Volkanovski,Chad Mendes,Red,Featherweight
+12/29/2018,Megan Anderson,Cat Zingano,Red,Women's Featherweight
+12/29/2018,Petr Yan,Douglas Silva de Andrade,Red,Bantamweight
+12/29/2018,Ryan Hall,BJ Penn,Red,Lightweight
+12/29/2018,Andre Ewell,Nathaniel Wood,Blue,Bantamweight
+12/29/2018,Bevon Lewis,Uriah Hall,Blue,Middleweight
+12/29/2018,Siyar Bahadurzada,Curtis Millender,Blue,Welterweight
+12/29/2018,Montel Jackson,Brian Kelleher,Red,Bantamweight
+12/15/2018,Al Iaquinta,Kevin Lee,Red,Lightweight
+12/15/2018,Dan Hooker,Edson Barboza,Blue,Lightweight
+12/15/2018,Rob Font,Sergio Pettis,Red,Bantamweight
+12/15/2018,Charles Oliveira,Jim Miller,Red,Lightweight
+12/15/2018,Zak Ottow,Dwight Grant,Red,Welterweight
+12/15/2018,Drakkar Klose,Bobby Green,Red,Lightweight
+12/15/2018,Jared Gordon,Joaquim Silva,Blue,Lightweight
+12/15/2018,Jack Hermansson,Gerald Meerschaert,Red,Middleweight
+12/15/2018,Trevor Smith,Zak Cummings,Blue,Middleweight
+12/15/2018,Jordan Griffin,Dan Ige,Blue,Featherweight
+12/15/2018,Mike Rodriguez,Adam Milstead,Red,Light Heavyweight
+12/15/2018,Chris de la Rocha,Juan Adams,Blue,Heavyweight
+12/08/2018,Brian Ortega,Max Holloway,Blue,UFC Featherweight Title
+12/08/2018,Joanna Jedrzejczyk,Valentina Shevchenko,Blue,UFC Women's Flyweight Title
+12/08/2018,Gunnar Nelson,Alex Oliveira,Red,Welterweight
+12/08/2018,Kyle Bochniak,Hakeem Dawodu,Blue,Featherweight
+12/08/2018,Jimi Manuwa,Thiago Santos,Blue,Light Heavyweight
+12/08/2018,Claudia Gadelha,Nina Nunes,Blue,Women's Strawweight
+12/08/2018,Olivier Aubin-Mercier,Gilbert Burns,Blue,Lightweight
+12/08/2018,Jessica Eye,Katlyn Cerminara,Red,Women's Flyweight
+12/08/2018,Eryk Anders,Elias Theodorou,Blue,Middleweight
+12/08/2018,Brad Katona,Matthew Lopez,Red,Bantamweight
+12/08/2018,Chad Laprise,Dhiego Lima,Blue,Welterweight
+12/08/2018,Kyle Nelson,Diego Ferreira,Blue,Lightweight
+12/08/2018,Aleksandar Rakic,Devin Clark,Red,Light Heavyweight
+12/01/2018,Junior Dos Santos,Tai Tuivasa,Red,Heavyweight
+12/01/2018,Mauricio Rua,Tyson Pedro,Red,Light Heavyweight
+12/01/2018,Justin Willis,Mark Hunt,Red,Heavyweight
+12/01/2018,Jake Matthews,Anthony Rocco Martin,Blue,Welterweight
+12/01/2018,Suman Mokhtarian,Sodiq Yusuff,Blue,Featherweight
+12/01/2018,Paul Craig,Jimmy Crute,Blue,Light Heavyweight
+12/01/2018,Yushin Okami,Aleksei Kunchenko,Blue,Welterweight
+12/01/2018,Wilson Reis,Ben Nguyen,Red,Flyweight
+12/01/2018,Salim Touahri,Keita Nakamura,Blue,Welterweight
+12/01/2018,Elias Garcia,Kai Kara-France,Blue,Flyweight
+12/01/2018,Christos Giagos,Mizuto Hirota,Red,Lightweight
+12/01/2018,Alex Gorgees,Damir Ismagulov,Blue,Lightweight
+11/30/2018,Kamaru Usman,Rafael Dos Anjos,Red,Welterweight
+11/30/2018,Justin Frazier,Juan Espino,Blue,Ultimate Fighter 28 Heavyweight Tournament Title
+11/30/2018,Pannie Kianzad,Macy Chiasson,Blue,Ultimate Fighter 28 Women's Featherweight Tournament Title
+11/30/2018,Pedro Munhoz,Bryan Caraway,Red,Bantamweight
+11/30/2018,Edmen Shahbazyan,Darren Stewart,Red,Middleweight
+11/30/2018,Antonina Shevchenko,Ji Yeon Kim,Red,Women's Flyweight
+11/30/2018,Kevin Aguilar,Ricky Glenn,Red,Featherweight
+11/30/2018,Joseph Benavidez,Alex Perez,Red,Flyweight
+11/30/2018,Maurice Greene,Michel Batista,Red,Heavyweight
+11/30/2018,Julija Stoliarenko,Leah Letson,Blue,Women's Featherweight
+11/30/2018,Roosevelt Roberts,Darrell Horcher,Red,Lightweight
+11/30/2018,Tim Means,Ricky Rainey,Red,Welterweight
+11/30/2018,Chris Gutierrez,Raoni Barcelos,Blue,Bantamweight
+11/24/2018,Curtis Blaydes,Francis Ngannou,Blue,Heavyweight
+11/24/2018,Sergei Pavlovich,Alistair Overeem,Blue,Heavyweight
+11/24/2018,Song Yadong,Vince Morales,Red,Bantamweight
+11/24/2018,David Zawada,Li Jingliang,Blue,Welterweight
+11/24/2018,Alex Morono,Song Kenan,Red,Welterweight
+11/24/2018,Wu Yanan,Lauren Mueller,Red,Women's Flyweight
+11/24/2018,Hu Yaozong,Rashad Coulter,Blue,Light Heavyweight
+11/24/2018,Zhang Weili,Jessica Aguilar,Red,Women's Strawweight
+11/24/2018,Martin Day,Pingyuan Liu,Blue,Bantamweight
+11/24/2018,Syuri Kondo,Yan Xiaonan,Blue,Women's Strawweight
+11/24/2018,Kevin Holland,John Phillips,Red,Middleweight
+11/24/2018,Sumudaerji,Louis Smolka,Blue,Bantamweight
+11/17/2018,Santiago Ponzinibbio,Neil Magny,Red,Welterweight
+11/17/2018,Darren Elkins,Ricardo Lamas,Blue,Featherweight
+11/17/2018,Khalil Rountree Jr.,Johnny Walker,Blue,Light Heavyweight
+11/17/2018,Cezar Ferreira,Ian Heinisch,Blue,Middleweight
+11/17/2018,Guido Cannetti,Marlon Vera,Blue,Bantamweight
+11/17/2018,Cynthia Calvillo,Poliana Botelho,Red,Women's Strawweight
+11/17/2018,Bartosz Fabinski,Michel Prazeres,Blue,Welterweight
+11/17/2018,Alexandre Pantoja,Yuta Sasaki,Red,Flyweight
+11/17/2018,Humberto Bandenay,Austin Arnett,Blue,Featherweight
+11/17/2018,Laureano Staropoli,Hector Aldana,Red,Welterweight
+11/17/2018,Jesus Pinedo,Devin Powell,Red,Lightweight
+11/17/2018,Nad Narimani,Anderson Dos Santos,Red,Featherweight
+11/10/2018,Yair Rodriguez,Chan Sung Jung,Red,Featherweight
+11/10/2018,Donald Cerrone,Mike Perry,Red,Welterweight
+11/10/2018,Germaine de Randamie,Raquel Pennington,Red,Women's Bantamweight
+11/10/2018,Thiago Moises,Beneil Dariush,Blue,Lightweight
+11/10/2018,Maycee Barber,Hannah Cifers,Red,Women's Strawweight
+11/10/2018,Luis Pena,Michael Trizano,Blue,Lightweight
+11/10/2018,Ashley Yoder,Amanda Cooper,Red,Women's Strawweight
+11/10/2018,Davi Ramos,John Gunther,Red,Lightweight
+11/10/2018,Julian Erosa,Devonte Smith,Blue,Lightweight
+11/10/2018,Joseph Morales,Eric Shelton,Blue,Flyweight
+11/10/2018,Mark De La Rosa,Joby Sanchez,Red,Bantamweight
+11/03/2018,Daniel Cormier,Derrick Lewis,Red,UFC Heavyweight Title
+11/03/2018,Chris Weidman,Jacare Souza,Blue,Middleweight
+11/03/2018,David Branch,Jared Cannonier,Blue,Middleweight
+11/03/2018,Karl Roberson,Jack Marshman,Red,Middleweight
+11/03/2018,Derek Brunson,Israel Adesanya,Blue,Middleweight
+11/03/2018,Jordan Rinaldi,Jason Knight,Red,Featherweight
+11/03/2018,Sijara Eubanks,Roxanne Modafferi,Red,Women's Flyweight
+11/03/2018,Julio Arce,Sheymon Moraes,Blue,Featherweight
+11/03/2018,Ben Saunders,Lyman Good,Blue,Welterweight
+11/03/2018,Kurt Holobaugh,Shane Burgos,Blue,Featherweight
+11/03/2018,Marcos Rogerio de Lima,Adam Wieczorek,Red,Heavyweight
+10/27/2018,Volkan Oezdemir,Anthony Smith,Blue,Light Heavyweight
+10/27/2018,Artem Lobov,Michael Johnson,Blue,Featherweight
+10/27/2018,Patrick Cummins,Misha Cirkunov,Blue,Light Heavyweight
+10/27/2018,Andre Soukhamthath,Jonathan Martinez,Red,Bantamweight
+10/27/2018,Ed Herman,Gian Villante,Blue,Light Heavyweight
+10/27/2018,Court McGee,Alex Garcia,Red,Welterweight
+10/27/2018,Nordine Taleb,Sean Strickland,Blue,Welterweight
+10/27/2018,Thibault Gouti,Nasrat Haqparast,Blue,Lightweight
+10/27/2018,Calvin Kattar,Chris Fishgold,Red,Featherweight
+10/27/2018,Sarah Moras,Talita Bernardo,Blue,Women's Bantamweight
+10/27/2018,Te Edwards,Don Madge,Blue,Lightweight
+10/27/2018,Arjan Bhullar,Marcelo Golm,Red,Heavyweight
+10/27/2018,Jessin Ayari,Stevie Ray,Blue,Lightweight
+10/06/2018,Conor McGregor,Khabib Nurmagomedov,Blue,UFC Lightweight Title
+10/06/2018,Anthony Pettis,Tony Ferguson,Blue,Lightweight
+10/06/2018,Dominick Reyes,Ovince Saint Preux,Red,Light Heavyweight
+10/06/2018,Alexander Volkov,Derrick Lewis,Blue,Heavyweight
+10/06/2018,Felice Herrig,Michelle Waterson-Gomez,Blue,Women's Strawweight
+10/06/2018,Sergio Pettis,Jussier Formiga,Blue,Flyweight
+10/06/2018,Jalin Turner,Vicente Luque,Blue,Welterweight
+10/06/2018,Tonya Evinger,Aspen Ladd,Blue,Women's Bantamweight
+10/06/2018,Alan Patrick,Scott Holtzman,Blue,Lightweight
+10/06/2018,Yana Santos,Lina Lansberg,Red,Women's Bantamweight
+10/06/2018,Nik Lentz,Gray Maynard,Red,Lightweight
+10/06/2018,Anthony Rocco Martin,Ryan LaFlare,Red,Welterweight
+09/22/2018,Eryk Anders,Thiago Santos,Blue,Light Heavyweight
+09/22/2018,Carlo Pedersoli Jr.,Alex Oliveira,Blue,Welterweight
+09/22/2018,Sam Alvey,Rogerio Nogueira,Blue,Light Heavyweight
+09/22/2018,Andre Ewell,Renan Barao,Red,Bantamweight
+09/22/2018,Christos Giagos,Charles Oliveira,Blue,Lightweight
+09/22/2018,Evan Dunham,Francisco Trinaldo,Blue,Lightweight
+09/22/2018,Ryan Spann,Luis Henrique,Red,Light Heavyweight
+09/22/2018,Augusto Sakai,Chase Sherman,Red,Heavyweight
+09/22/2018,Ben Saunders,Sergio Moraes,Blue,Welterweight
+09/22/2018,Gillian Robertson,Mayra Bueno Silva,Blue,Women's Flyweight
+09/22/2018,Thales Leites,Hector Lombard,Red,Middleweight
+09/22/2018,Luigi Vendramini,Elizeu Zaleski dos Santos,Blue,Welterweight
+09/22/2018,Alex Chambers,Livinha Souza,Blue,Women's Strawweight
+09/15/2018,Aleksei Oleinik,Mark Hunt,Red,Heavyweight
+09/15/2018,Jan Blachowicz,Nikita Krylov,Red,Light Heavyweight
+09/15/2018,Shamil Abdurakhimov,Andrei Arlovski,Red,Heavyweight
+09/15/2018,Aleksei Kunchenko,Thiago Alves,Red,Welterweight
+09/15/2018,CB Dollaway,Khalid Murtazaliev,Blue,Middleweight
+09/15/2018,Jin Soo Son,Petr Yan,Blue,Bantamweight
+09/15/2018,Kajan Johnson,Rustam Khabilov,Blue,Lightweight
+09/15/2018,Mairbek Taisumov,Desmond Green,Red,Lightweight
+09/15/2018,Marcin Prachnio,Magomed Ankalaev,Blue,Light Heavyweight
+09/15/2018,Adam Yandiev,Jordan Johnson,Blue,Middleweight
+09/15/2018,Ramazan Emeev,Stefan Sekulic,Red,Welterweight
+09/15/2018,Merab Dvalishvili,Terrion Ware,Red,Bantamweight
+09/08/2018,Darren Till,Tyron Woodley,Blue,UFC Welterweight Title
+09/08/2018,Jessica Andrade,Karolina Kowalkiewicz,Red,Women's Strawweight
+09/08/2018,Zabit Magomedsharipov,Brandon Davis,Red,Featherweight
+09/08/2018,John Dodson,Jimmie Rivera,Blue,Bantamweight
+09/08/2018,Niko Price,Abdul Razak Alhassan,Blue,Welterweight
+09/08/2018,Carla Esparza,Tatiana Suarez,Blue,Women's Strawweight
+09/08/2018,Aljamain Sterling,Cody Stamann,Red,Bantamweight
+09/08/2018,Frank Camacho,Geoff Neal,Blue,Welterweight
+09/08/2018,Charles Byrd,Darren Stewart,Blue,Middleweight
+09/08/2018,Craig White,Diego Sanchez,Blue,Welterweight
+09/08/2018,Jim Miller,Alex White,Red,Lightweight
+09/08/2018,Lucie Pudilova,Irene Aldana,Blue,Women's Bantamweight
+09/08/2018,Robert Sanchez,Jarred Brooks,Blue,Flyweight
+08/25/2018,Justin Gaethje,James Vick,Red,Lightweight
+08/25/2018,Andre Fili,Michael Johnson,Blue,Featherweight
+08/25/2018,Cortney Casey,Angela Hill,Red,Women's Strawweight
+08/25/2018,Jake Ellenberger,Bryan Barberena,Blue,Welterweight
+08/25/2018,John Moraga,Deiveson Figueiredo,Blue,Flyweight
+08/25/2018,Tim Williams,Eryk Anders,Blue,Middleweight
+08/25/2018,James Krause,Warlley Alves,Red,Welterweight
+08/25/2018,Cory Sandhagen,Iuri Alcantara,Red,Bantamweight
+08/25/2018,Markus Perez,Andrew Sanchez,Blue,Middleweight
+08/25/2018,George Sullivan,Mickey Gall,Blue,Welterweight
+08/25/2018,Joanne Wood,Kalindra Faria,Red,Women's Flyweight
+08/25/2018,Drew Dober,Jon Tuck,Red,Lightweight
+08/25/2018,Luke Sanders,Rani Yahya,Blue,Bantamweight
+08/04/2018,Cody Garbrandt,TJ Dillashaw,Blue,UFC Bantamweight Title
+08/04/2018,Demetrious Johnson,Henry Cejudo,Blue,UFC Flyweight Title
+08/04/2018,Cub Swanson,Renato Moicano,Blue,Featherweight
+08/04/2018,Polyana Viana,JJ Aldrich,Blue,Women's Strawweight
+08/04/2018,Thiago Santos,Kevin Holland,Red,Middleweight
+08/04/2018,Brett Johns,Pedro Munhoz,Blue,Bantamweight
+08/04/2018,Montel Jackson,Ricky Simon,Blue,Bantamweight
+08/04/2018,Ricardo Ramos,Kyung Ho Kang,Red,Bantamweight
+08/04/2018,Sheymon Moraes,Matt Sayles,Red,Featherweight
+08/04/2018,Jose Torres,Alex Perez,Blue,Flyweight
+08/04/2018,Zhang Weili,Danielle Taylor,Red,Women's Strawweight
+08/04/2018,Wulijiburen,Marlon Vera,Blue,Bantamweight
+07/28/2018,Dustin Poirier,Eddie Alvarez,Red,Lightweight
+07/28/2018,Jose Aldo,Jeremy Stephens,Red,Featherweight
+07/28/2018,Joanna Jedrzejczyk,Tecia Torres,Red,Women's Strawweight
+07/28/2018,Olivier Aubin-Mercier,Alexander Hernandez,Blue,Lightweight
+07/28/2018,Jordan Mein,Alex Morono,Red,Welterweight
+07/28/2018,Hakeem Dawodu,Austin Arnett,Red,Featherweight
+07/28/2018,Islam Makhachev,Kajan Johnson,Red,Lightweight
+07/28/2018,Gadzhimurad Antigulov,Ion Cutelaba,Blue,Light Heavyweight
+07/28/2018,John Makdessi,Ross Pearson,Red,Lightweight
+07/28/2018,Katlyn Cerminara,Alexis Davis,Red,Women's Flyweight
+07/28/2018,Dustin Ortiz,Matheus Nicolau,Red,Flyweight
+07/28/2018,Randa Markos,Nina Nunes,Blue,Women's Strawweight
+07/28/2018,Devin Powell,Alvaro Herrera Mendoza,Red,Lightweight
+07/22/2018,Anthony Smith,Mauricio Rua,Red,Light Heavyweight
+07/22/2018,Glover Teixeira,Corey Anderson,Blue,Light Heavyweight
+07/22/2018,Abu Azaitar,Vitor Miranda,Red,Middleweight
+07/22/2018,Stefan Struve,Marcin Tybura,Blue,Heavyweight
+07/22/2018,Danny Roberts,David Zawada,Red,Welterweight
+07/22/2018,Marc Diakiese,Nasrat Haqparast,Blue,Lightweight
+07/22/2018,Nick Hein,Damir Hadzovic,Blue,Lightweight
+07/22/2018,Bartosz Fabinski,Emil Meek,Red,Welterweight
+07/22/2018,Nad Narimani,Khalid Taha,Red,Featherweight
+07/22/2018,Justin Ledet,Aleksandar Rakic,Blue,Light Heavyweight
+07/22/2018,Davey Grant,Manny Bermudez,Blue,Bantamweight
+07/22/2018,Darko Stosic,Jeremy Kimball,Red,Light Heavyweight
+07/22/2018,Damian Stasiak,Pingyuan Liu,Blue,Bantamweight
+07/14/2018,Blagoy Ivanov,Junior Dos Santos,Blue,Heavyweight
+07/14/2018,Sage Northcutt,Zak Ottow,Red,Welterweight
+07/14/2018,Dennis Bermudez,Ricky Glenn,Blue,Featherweight
+07/14/2018,Randy Brown,Niko Price,Blue,Welterweight
+07/14/2018,Chad Mendes,Myles Jury,Red,Featherweight
+07/14/2018,Marion Reneau,Cat Zingano,Blue,Women's Bantamweight
+07/14/2018,Eddie Wineland,Alejandro Perez,Blue,Bantamweight
+07/14/2018,Alexander Volkanovski,Darren Elkins,Red,Featherweight
+07/14/2018,Justin Scoggins,Said Nurmagomedov,Blue,Flyweight
+07/14/2018,Kurt Holobaugh,Raoni Barcelos,Blue,Featherweight
+07/14/2018,Jennifer Maia,Liz Carmouche,Blue,Women's Flyweight
+07/14/2018,Elias Garcia,Mark De La Rosa,Blue,Flyweight
+07/14/2018,Jodie Esquibel,Jessica Aguilar,Blue,Women's Strawweight
+07/07/2018,Daniel Cormier,Stipe Miocic,Red,UFC Heavyweight Title
+07/07/2018,Derrick Lewis,Francis Ngannou,Red,Heavyweight
+07/07/2018,Mike Perry,Paul Felder,Red,Welterweight
+07/07/2018,Michael Chiesa,Anthony Pettis,Blue,Lightweight
+07/07/2018,Gokhan Saki,Khalil Rountree Jr.,Blue,Light Heavyweight
+07/07/2018,Paulo Costa,Uriah Hall,Red,Middleweight
+07/07/2018,Rob Font,Raphael Assuncao,Blue,Bantamweight
+07/07/2018,Drakkar Klose,Lando Vannata,Red,Lightweight
+07/07/2018,Curtis Millender,Max Griffin,Red,Welterweight
+07/07/2018,Gilbert Burns,Dan Hooker,Blue,Lightweight
+07/07/2018,Emily Whitmire,Jamie Moyle,Red,Women's Strawweight
+07/06/2018,Israel Adesanya,Brad Tavares,Red,Middleweight
+07/06/2018,Joe Giannetti,Michael Trizano,Blue,Ultimate Fighter 27 Lightweight Tournament Title
+07/06/2018,Jay Cucciniello,Brad Katona,Blue,Ultimate Fighter 27 Featherweight Tournament Title
+07/06/2018,Alex Caceres,Martin Bravo,Red,Featherweight
+07/06/2018,Roxanne Modafferi,Barb Honchak,Red,Women's Flyweight
+07/06/2018,Alessio Di Chirico,Julian Marquez,Red,Middleweight
+07/06/2018,Rachael Ostovich,Montana De La Rosa,Blue,Women's Flyweight
+07/06/2018,Luis Pena,Richie Smullen,Red,Lightweight
+07/06/2018,Allan Zuniga,John Gunther,Blue,Lightweight
+07/06/2018,Bryce Mitchell,Tyler Diamond,Red,Featherweight
+07/06/2018,Steven Peterson,Matt Bessette,Red,Featherweight
+07/06/2018,Oskar Piechota,Gerald Meerschaert,Blue,Middleweight
+06/23/2018,Leon Edwards,Donald Cerrone,Red,Welterweight
+06/23/2018,Tyson Pedro,Ovince Saint Preux,Blue,Light Heavyweight
+06/23/2018,Jessica-Rose Clark,Jessica Eye,Blue,Women's Flyweight
+06/23/2018,Daichi Abe,Li Jingliang,Blue,Welterweight
+06/23/2018,Teruto Ishihara,Petr Yan,Blue,Bantamweight
+06/23/2018,Song Yadong,Felipe Arantes,Red,Bantamweight
+06/23/2018,Shane Young,Rolando Dy,Red,Featherweight
+06/23/2018,Song Kenan,Hector Aldana,Red,Welterweight
+06/23/2018,Shinsho Anzai,Jake Matthews,Blue,Welterweight
+06/23/2018,Yan Xiaonan,Viviane Pereira,Red,Women's Strawweight
+06/23/2018,Matt Schnell,Naoki Inoue,Red,Flyweight
+06/23/2018,Jenel Lausa,Yuta Sasaki,Blue,Flyweight
+06/23/2018,Melinda Fabian,Ji Yeon Kim,Blue,Women's Flyweight
+06/09/2018,Robert Whittaker,Yoel Romero,Red,Middleweight
+06/09/2018,Rafael Dos Anjos,Colby Covington,Blue,UFC Interim Welterweight Title
+06/09/2018,Holly Holm,Megan Anderson,Red,Women's Featherweight
+06/09/2018,Tai Tuivasa,Andrei Arlovski,Red,Heavyweight
+06/09/2018,Curtis Blaydes,Alistair Overeem,Red,Heavyweight
+06/09/2018,Claudia Gadelha,Carla Esparza,Red,Women's Strawweight
+06/09/2018,Ricardo Lamas,Mirsad Bektic,Blue,Featherweight
+06/09/2018,Rashad Coulter,Chris de la Rocha,Blue,Heavyweight
+06/09/2018,Rashad Evans,Anthony Smith,Blue,Light Heavyweight
+06/09/2018,Sergio Pettis,Joseph Benavidez,Red,Flyweight
+06/09/2018,Charles Oliveira,Clay Guida,Red,Lightweight
+06/09/2018,Mike Santiago,Dan Ige,Blue,Featherweight
+06/01/2018,Jimmie Rivera,Marlon Moraes,Blue,Bantamweight
+06/01/2018,Gregor Gillespie,Vinc Pichel,Red,Lightweight
+06/01/2018,Daniel Spitz,Walt Harris,Blue,Heavyweight
+06/01/2018,Jake Ellenberger,Ben Saunders,Blue,Welterweight
+06/01/2018,Daniel Teymur,Julio Arce,Blue,Featherweight
+06/01/2018,Sam Alvey,Gian Villante,Red,Light Heavyweight
+06/01/2018,Sijara Eubanks,Lauren Murphy,Red,Women's Flyweight
+06/01/2018,Nik Lentz,David Teymur,Blue,Lightweight
+06/01/2018,Chance Rencountre,Belal Muhammad,Blue,Welterweight
+06/01/2018,Desmond Green,Gleison Tibau,Red,Lightweight
+06/01/2018,Nathaniel Wood,Johnny Eduardo,Red,Bantamweight
+06/01/2018,Jose Torres,Jarred Brooks,Red,Flyweight
+05/27/2018,Stephen Thompson,Darren Till,Blue,Welterweight
+05/27/2018,Craig White,Neil Magny,Blue,Welterweight
+05/27/2018,Arnold Allen,Mads Burnell,Red,Featherweight
+05/27/2018,Jason Knight,Makwan Amirkhani,Blue,Featherweight
+05/27/2018,Claudio Silva,Nordine Taleb,Red,Welterweight
+05/27/2018,Eric Spicely,Darren Stewart,Blue,Middleweight
+05/27/2018,Tom Breese,Daniel Kelly,Red,Middleweight
+05/27/2018,Gina Mazany,Lina Lansberg,Blue,Women's Bantamweight
+05/27/2018,Brad Scott,Carlo Pedersoli Jr.,Blue,Welterweight
+05/27/2018,Gillian Robertson,Molly McCann,Red,Women's Flyweight
+05/27/2018,Trevor Smith,Elias Theodorou,Blue,Middleweight
+05/19/2018,Demian Maia,Kamaru Usman,Blue,Welterweight
+05/19/2018,Alexa Grasso,Tatiana Suarez,Blue,Women's Strawweight
+05/19/2018,Dominick Reyes,Jared Cannonier,Red,Light Heavyweight
+05/19/2018,Guido Cannetti,Diego Rivas,Red,Bantamweight
+05/19/2018,Veronica Hardy,Andrea Lee,Blue,Women's Flyweight
+05/19/2018,Vicente Luque,Chad Laprise,Red,Welterweight
+05/19/2018,Michel Prazeres,Zak Cummings,Red,Welterweight
+05/19/2018,Alexandre Pantoja,Brandon Moreno,Red,Flyweight
+05/19/2018,Poliana Botelho,Syuri Kondo,Red,Women's Strawweight
+05/19/2018,Humberto Bandenay,Gabriel Benitez,Blue,Featherweight
+05/19/2018,Brandon Davis,Enrique Barzola,Blue,Featherweight
+05/19/2018,Henry Briones,Frankie Saenz,Blue,Bantamweight
+05/19/2018,Claudio Puelles,Felipe Silva,Red,Lightweight
+05/12/2018,Amanda Nunes,Raquel Pennington,Red,UFC Women's Bantamweight Title
+05/12/2018,Kelvin Gastelum,Jacare Souza,Red,Middleweight
+05/12/2018,Mackenzie Dern,Amanda Cooper,Red,Women's Strawweight
+05/12/2018,Brian Kelleher,John Lineker,Blue,Bantamweight
+05/12/2018,Lyoto Machida,Vitor Belfort,Red,Middleweight
+05/12/2018,Cezar Ferreira,Karl Roberson,Red,Middleweight
+05/12/2018,Aleksei Oleinik,Junior Albini,Red,Heavyweight
+05/12/2018,Nick Hein,Davi Ramos,Blue,Lightweight
+05/12/2018,Elizeu Zaleski dos Santos,Sean Strickland,Red,Welterweight
+05/12/2018,Warlley Alves,Sultan Aliev,Red,Welterweight
+05/12/2018,Jack Hermansson,Thales Leites,Red,Middleweight
+05/12/2018,Alberto Mina,Ramazan Emeev,Blue,Welterweight
+05/12/2018,James Bochnovic,Markus Perez,Blue,Middleweight
+04/21/2018,Kevin Lee,Edson Barboza,Red,Lightweight
+04/21/2018,Cub Swanson,Frankie Edgar,Blue,Featherweight
+04/21/2018,Justin Willis,Chase Sherman,Red,Heavyweight
+04/21/2018,Thiago Santos,David Branch,Blue,Middleweight
+04/21/2018,Aljamain Sterling,Brett Johns,Red,Bantamweight
+04/21/2018,Dan Hooker,Jim Miller,Red,Lightweight
+04/21/2018,Ryan LaFlare,Alex Garcia,Red,Welterweight
+04/21/2018,Ricky Simon,Merab Dvalishvili,Red,Bantamweight
+04/21/2018,Siyar Bahadurzada,Luan Chagas,Red,Welterweight
+04/21/2018,Corey Anderson,Patrick Cummins,Red,Light Heavyweight
+04/21/2018,Keita Nakamura,Anthony Rocco Martin,Blue,Welterweight
+04/14/2018,Justin Gaethje,Dustin Poirier,Blue,Lightweight
+04/14/2018,Carlos Condit,Alex Oliveira,Blue,Welterweight
+04/14/2018,Marvin Vettori,Israel Adesanya,Blue,Middleweight
+04/14/2018,Michelle Waterson-Gomez,Cortney Casey,Red,Women's Strawweight
+04/14/2018,Tim Boetsch,Antonio Carlos Junior,Blue,Middleweight
+04/14/2018,Ricky Rainey,Muslim Salikhov,Blue,Welterweight
+04/14/2018,John Moraga,Wilson Reis,Red,Flyweight
+04/14/2018,Krzysztof Jotko,Brad Tavares,Blue,Middleweight
+04/14/2018,Dan Moret,Gilbert Burns,Blue,Lightweight
+04/14/2018,Lauren Mueller,Shana Dobson,Red,Women's Flyweight
+04/14/2018,Dhiego Lima,Yushin Okami,Blue,Welterweight
+04/14/2018,Adam Wieczorek,Arjan Bhullar,Red,Heavyweight
+04/14/2018,Alejandro Perez,Matthew Lopez,Red,Bantamweight
+04/14/2018,Luke Sanders,Patrick Williams,Red,Bantamweight
+04/07/2018,Al Iaquinta,Khabib Nurmagomedov,Blue,UFC Lightweight Title
+04/07/2018,Rose Namajunas,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+04/07/2018,Calvin Kattar,Renato Moicano,Blue,Featherweight
+04/07/2018,Kyle Bochniak,Zabit Magomedsharipov,Blue,Featherweight
+04/07/2018,Joe Lauzon,Chris Gruetzemacher,Blue,Lightweight
+04/07/2018,Karolina Kowalkiewicz,Felice Herrig,Red,Women's Strawweight
+04/07/2018,Olivier Aubin-Mercier,Evan Dunham,Red,Lightweight
+04/07/2018,Ashlee Evans-Smith,Bec Rawlings,Red,Women's Flyweight
+04/07/2018,Mike Rodriguez,Devin Clark,Blue,Light Heavyweight
+03/17/2018,Alexander Volkov,Fabricio Werdum,Red,Heavyweight
+03/17/2018,Jimi Manuwa,Jan Blachowicz,Blue,Light Heavyweight
+03/17/2018,Tom Duquesnoy,Terrion Ware,Red,Bantamweight
+03/17/2018,Leon Edwards,Peter Sobotta,Red,Welterweight
+03/17/2018,John Phillips,Charles Byrd,Blue,Middleweight
+03/17/2018,Danny Roberts,Oliver Enkamp,Red,Welterweight
+03/17/2018,Hakeem Dawodu,Danny Henry,Blue,Featherweight
+03/17/2018,Paul Craig,Magomed Ankalaev,Red,Light Heavyweight
+03/17/2018,Stevie Ray,Kajan Johnson,Blue,Lightweight
+03/17/2018,Dmitry Sosnovskiy,Mark Godbeer,Red,Heavyweight
+03/03/2018,Yana Santos,Cristiane Justino,Blue,UFC Women's Featherweight Title
+03/03/2018,Brian Ortega,Frankie Edgar,Red,Featherweight
+03/03/2018,Sean O'Malley,Andre Soukhamthath,Red,Bantamweight
+03/03/2018,Stefan Struve,Andrei Arlovski,Blue,Heavyweight
+03/03/2018,Ketlen Vieira,Cat Zingano,Red,Women's Bantamweight
+03/03/2018,Ashley Yoder,Mackenzie Dern,Blue,Women's Strawweight
+03/03/2018,Beneil Dariush,Alexander Hernandez,Blue,Lightweight
+03/03/2018,John Dodson,Pedro Munhoz,Red,Bantamweight
+03/03/2018,CB Dollaway,Hector Lombard,Red,Middleweight
+03/03/2018,Mike Pyle,Zak Ottow,Blue,Welterweight
+03/03/2018,Bryan Caraway,Cody Stamann,Blue,Bantamweight
+03/03/2018,Adam Milstead,Jordan Johnson,Blue,Light Heavyweight
+02/24/2018,Jeremy Stephens,Josh Emmett,Red,Featherweight
+02/24/2018,Jessica Andrade,Tecia Torres,Red,Women's Strawweight
+02/24/2018,Ovince Saint Preux,Ilir Latifi,Blue,Light Heavyweight
+02/24/2018,Max Griffin,Mike Perry,Red,Welterweight
+02/24/2018,Renan Barao,Brian Kelleher,Blue,Bantamweight
+02/24/2018,Marion Reneau,Sara McMann,Red,Women's Bantamweight
+02/24/2018,Angela Hill,Maryna Moroz,Red,Women's Strawweight
+02/24/2018,Ben Saunders,Alan Jouban,Blue,Welterweight
+02/24/2018,Sam Alvey,Marcin Prachnio,Red,Light Heavyweight
+02/24/2018,Rani Yahya,Russell Doane,Red,Bantamweight
+02/24/2018,Alex Perez,Eric Shelton,Red,Flyweight
+02/24/2018,Albert Morales,Manny Bermudez,Blue,Bantamweight
+02/18/2018,Yancy Medeiros,Donald Cerrone,Blue,Welterweight
+02/18/2018,Derrick Lewis,Marcin Tybura,Red,Heavyweight
+02/18/2018,James Vick,Francisco Trinaldo,Red,Lightweight
+02/18/2018,Thiago Alves,Curtis Millender,Blue,Welterweight
+02/18/2018,Brandon Davis,Steven Peterson,Red,Featherweight
+02/18/2018,Thibault Gouti,Sage Northcutt,Blue,Lightweight
+02/18/2018,Jared Gordon,Diego Ferreira,Blue,Lightweight
+02/18/2018,Geoff Neal,Brian Camozzi,Red,Welterweight
+02/18/2018,Joby Sanchez,Robert Sanchez,Blue,Flyweight
+02/18/2018,Lucie Pudilova,Sarah Moras,Red,Women's Bantamweight
+02/18/2018,Alex Morono,Joshua Burkman,Red,Welterweight
+02/18/2018,Tim Williams,Oskar Piechota,Blue,Middleweight
+02/10/2018,Luke Rockhold,Yoel Romero,Blue,Middleweight
+02/10/2018,Curtis Blaydes,Mark Hunt,Red,Heavyweight
+02/10/2018,Cyril Asker,Tai Tuivasa,Blue,Heavyweight
+02/10/2018,Jake Matthews,Li Jingliang,Red,Welterweight
+02/10/2018,Saparbeg Safarov,Tyson Pedro,Blue,Light Heavyweight
+02/10/2018,Dong Hyun Ma,Damien Brown,Red,Lightweight
+02/10/2018,Rob Wilkinson,Israel Adesanya,Blue,Middleweight
+02/10/2018,Jeremy Kennedy,Alexander Volkanovski,Blue,Featherweight
+02/10/2018,Jussier Formiga,Ben Nguyen,Red,Flyweight
+02/10/2018,Mizuto Hirota,Ross Pearson,Blue,Lightweight
+02/10/2018,Jose Quinonez,Teruto Ishihara,Red,Bantamweight
+02/10/2018,Daichi Abe,Luke Jumeau,Blue,Welterweight
+02/03/2018,Eryk Anders,Lyoto Machida,Blue,Middleweight
+02/03/2018,Priscila Cachoeira,Valentina Shevchenko,Blue,Women's Flyweight
+02/03/2018,Michel Prazeres,Desmond Green,Red,Lightweight
+02/03/2018,Marcelo Golm,Timothy Johnson,Blue,Heavyweight
+02/03/2018,Douglas Silva de Andrade,Marlon Vera,Red,Bantamweight
+02/03/2018,Thiago Santos,Anthony Smith,Red,Middleweight
+02/03/2018,Sergio Moraes,Tim Means,Red,Welterweight
+02/03/2018,Alan Patrick,Damir Hadzovic,Red,Lightweight
+02/03/2018,Maia Stevenson,Polyana Viana,Blue,Women's Strawweight
+02/03/2018,Joe Soto,Iuri Alcantara,Blue,Bantamweight
+02/03/2018,Joseph Morales,Deiveson Figueiredo,Blue,Flyweight
+01/27/2018,Derek Brunson,Jacare Souza,Blue,Middleweight
+01/27/2018,Andre Fili,Dennis Bermudez,Red,Featherweight
+01/27/2018,Jordan Rinaldi,Gregor Gillespie,Blue,Lightweight
+01/27/2018,Drew Dober,Frank Camacho,Red,Welterweight
+01/27/2018,Bobby Green,Erik Koch,Red,Lightweight
+01/27/2018,Mirsad Bektic,Godofredo Pepey,Red,Featherweight
+01/27/2018,Katlyn Cerminara,Mara Romero Borella,Red,Women's Flyweight
+01/27/2018,Juliana Lima,Randa Markos,Blue,Women's Strawweight
+01/27/2018,Ji Yeon Kim,Justine Kish,Red,Women's Flyweight
+01/27/2018,Vinc Pichel,Joaquim Silva,Red,Lightweight
+01/27/2018,George Sullivan,Niko Price,Blue,Welterweight
+01/27/2018,Austin Arnett,Cory Sandhagen,Blue,Featherweight
+01/20/2018,Francis Ngannou,Stipe Miocic,Blue,UFC Heavyweight Title
+01/20/2018,Volkan Oezdemir,Daniel Cormier,Blue,UFC Light Heavyweight Title
+01/20/2018,Calvin Kattar,Shane Burgos,Red,Featherweight
+01/20/2018,Francimar Barroso,Gian Villante,Blue,Light Heavyweight
+01/20/2018,Thomas Almeida,Rob Font,Blue,Bantamweight
+01/20/2018,Kyle Bochniak,Brandon Davis,Red,Featherweight
+01/20/2018,Sabah Homasi,Abdul Razak Alhassan,Blue,Welterweight
+01/20/2018,Dustin Ortiz,Alexandre Pantoja,Red,Flyweight
+01/20/2018,Dan Ige,Julio Arce,Blue,Featherweight
+01/20/2018,Enrique Barzola,Matt Bessette,Red,Featherweight
+01/20/2018,Gleison Tibau,Islam Makhachev,Blue,Lightweight
+01/14/2018,Jeremy Stephens,Dooho Choi,Red,Featherweight
+01/14/2018,Paige VanZant,Jessica-Rose Clark,Blue,Women's Flyweight
+01/14/2018,Kamaru Usman,Emil Meek,Red,Welterweight
+01/14/2018,Michael Johnson,Darren Elkins,Blue,Featherweight
+01/14/2018,James Krause,Alex White,Red,Lightweight
+01/14/2018,Matt Frevola,Marco Polo Reyes,Blue,Lightweight
+01/14/2018,Irene Aldana,Talita Bernardo,Red,Women's Bantamweight
+01/14/2018,Guido Cannetti,Kyung Ho Kang,Blue,Bantamweight
+01/14/2018,Kalindra Faria,Jessica Eye,Blue,Women's Flyweight
+01/14/2018,Danielle Taylor,JJ Aldrich,Blue,Women's Strawweight
+01/14/2018,Mike Santiago,Mads Burnell,Blue,Featherweight
+12/30/2017,Cristiane Justino,Holly Holm,Red,UFC Women's Featherweight Title
+12/30/2017,Khabib Nurmagomedov,Edson Barboza,Red,Lightweight
+12/30/2017,Marc Diakiese,Dan Hooker,Blue,Lightweight
+12/30/2017,Cynthia Calvillo,Carla Esparza,Blue,Women's Strawweight
+12/30/2017,Neil Magny,Carlos Condit,Red,Welterweight
+12/30/2017,Ricky Glenn,Myles Jury,Blue,Featherweight
+12/30/2017,Louis Smolka,Matheus Nicolau,Blue,Flyweight
+12/30/2017,Tim Elliott,Mark De La Rosa,Red,Bantamweight
+12/16/2017,Robbie Lawler,Rafael Dos Anjos,Blue,Welterweight
+12/16/2017,Ricardo Lamas,Josh Emmett,Blue,Featherweight
+12/16/2017,Santiago Ponzinibbio,Mike Perry,Red,Welterweight
+12/16/2017,Misha Cirkunov,Glover Teixeira,Blue,Light Heavyweight
+12/16/2017,Jan Blachowicz,Jared Cannonier,Red,Light Heavyweight
+12/16/2017,Julian Marquez,Darren Stewart,Red,Middleweight
+12/16/2017,Galore Bofando,Chad Laprise,Blue,Welterweight
+12/16/2017,Nordine Taleb,Danny Roberts,Red,Welterweight
+12/16/2017,Abel Trujillo,John Makdessi,Blue,Lightweight
+12/16/2017,Alessio Di Chirico,Oluwale Bamgbose,Red,Middleweight
+12/16/2017,Erick Silva,Jordan Mein,Blue,Welterweight
+12/09/2017,Brian Ortega,Cub Swanson,Red,Featherweight
+12/09/2017,Jason Knight,Gabriel Benitez,Blue,Featherweight
+12/09/2017,Marlon Moraes,Aljamain Sterling,Red,Bantamweight
+12/09/2017,Darrell Horcher,Scott Holtzman,Blue,Lightweight
+12/09/2017,Eryk Anders,Markus Perez,Red,Middleweight
+12/09/2017,Benito Lopez,Albert Morales,Red,Bantamweight
+12/09/2017,Alexis Davis,Liz Carmouche,Red,Women's Flyweight
+12/09/2017,Andre Soukhamthath,Luke Sanders,Red,Bantamweight
+12/09/2017,Alex Perez,Carls John De Tomas,Red,Bantamweight
+12/09/2017,Frankie Saenz,Merab Dvalishvili,Red,Bantamweight
+12/09/2017,Alejandro Perez,Iuri Alcantara,Red,Bantamweight
+12/09/2017,Chris Gruetzemacher,Davi Ramos,Blue,Lightweight
+12/09/2017,Trevin Giles,Antonio Braga Neto,Red,Middleweight
+12/02/2017,Max Holloway,Jose Aldo,Red,UFC Featherweight Title
+12/02/2017,Alistair Overeem,Francis Ngannou,Blue,Heavyweight
+12/02/2017,Henry Cejudo,Sergio Pettis,Red,Flyweight
+12/02/2017,Justin Gaethje,Eddie Alvarez,Blue,Lightweight
+12/02/2017,Tecia Torres,Michelle Waterson-Gomez,Red,Women's Strawweight
+12/02/2017,Charles Oliveira,Paul Felder,Blue,Lightweight
+12/02/2017,Alex Oliveira,Yancy Medeiros,Blue,Welterweight
+12/02/2017,Drakkar Klose,David Teymur,Blue,Lightweight
+12/02/2017,Cortney Casey,Felice Herrig,Blue,Women's Strawweight
+12/02/2017,Angela Magana,Amanda Cooper,Blue,Women's Strawweight
+12/02/2017,Abdul Razak Alhassan,Sabah Homasi,Red,Welterweight
+12/02/2017,Dominick Reyes,Jeremy Kimball,Red,Light Heavyweight
+12/02/2017,Allen Crowder,Justin Willis,Blue,Heavyweight
+12/01/2017,Roxanne Modafferi,Nicco Montano,Blue,UFC Women's Flyweight Title
+12/01/2017,Terrion Ware,Sean O'Malley,Blue,Bantamweight
+12/01/2017,Barb Honchak,Lauren Murphy,Blue,Women's Flyweight
+12/01/2017,Eric Spicely,Gerald Meerschaert,Blue,Middleweight
+12/01/2017,Joe Soto,Brett Johns,Blue,Bantamweight
+12/01/2017,Montana De La Rosa,Christina Marks,Red,Women's Flyweight
+12/01/2017,Ryan Janes,Andrew Sanchez,Red,Middleweight
+12/01/2017,Rachael Ostovich,Karine Gevorgyan,Red,Women's Flyweight
+12/01/2017,Shana Dobson,Ariel Beck,Red,Women's Flyweight
+12/01/2017,Gillian Robertson,Emily Whitmire,Red,Women's Flyweight
+11/25/2017,Michael Bisping,Kelvin Gastelum,Blue,Middleweight
+11/25/2017,Zak Ottow,Li Jingliang,Blue,Welterweight
+11/25/2017,Wang Guan,Alex Caceres,Red,Featherweight
+11/25/2017,Alex Garcia,Muslim Salikhov,Red,Welterweight
+11/25/2017,Zabit Magomedsharipov,Sheymon Moraes,Red,Featherweight
+11/25/2017,Bobby Nash,Song Kenan,Blue,Welterweight
+11/25/2017,Kailin Curran,Yan Xiaonan,Blue,Women's Strawweight
+11/25/2017,Bharat Kandare,Song Yadong,Blue,Featherweight
+11/25/2017,Shamil Abdurakhimov,Chase Sherman,Red,Heavyweight
+11/25/2017,Gina Mazany,Wu Yanan,Red,Women's Bantamweight
+11/25/2017,Rolando Dy,Wulijiburen,Red,Featherweight
+11/25/2017,Hu Yaozong,Cyril Asker,Blue,Heavyweight
+11/18/2017,Marcin Tybura,Fabricio Werdum,Blue,Heavyweight
+11/18/2017,Jessica-Rose Clark,Bec Rawlings,Red,Women's Flyweight
+11/18/2017,Belal Muhammad,Tim Means,Red,Welterweight
+11/18/2017,Jake Matthews,Bojan Velickovic,Red,Welterweight
+11/18/2017,Elias Theodorou,Daniel Kelly,Red,Middleweight
+11/18/2017,Shane Young,Alexander Volkanovski,Blue,Catch Weight
+11/18/2017,Ashkan Mokhtarian,Ryan Benoit,Blue,Flyweight
+11/18/2017,Will Brooks,Nik Lentz,Blue,Lightweight
+11/18/2017,Tai Tuivasa,Rashad Coulter,Red,Heavyweight
+11/18/2017,Frank Camacho,Damien Brown,Red,Lightweight
+11/18/2017,Alex Chambers,Nadia Kassem,Blue,Women's Strawweight
+11/18/2017,Jenel Lausa,Eric Shelton,Blue,Flyweight
+11/18/2017,Adam Wieczorek,Anthony Hamilton,Red,Heavyweight
+11/11/2017,Dustin Poirier,Anthony Pettis,Red,Lightweight
+11/11/2017,Diego Sanchez,Matt Brown,Blue,Welterweight
+11/11/2017,Andrei Arlovski,Junior Albini,Red,Heavyweight
+11/11/2017,Cezar Ferreira,Nate Marquardt,Red,Middleweight
+11/11/2017,Matthew Lopez,Raphael Assuncao,Blue,Bantamweight
+11/11/2017,Clay Guida,Joe Lauzon,Red,Lightweight
+11/11/2017,John Dodson,Marlon Moraes,Blue,Bantamweight
+11/11/2017,Viviane Pereira,Tatiana Suarez,Blue,Women's Strawweight
+11/11/2017,Michel Quinones,Sage Northcutt,Blue,Lightweight
+11/11/2017,Nina Nunes,Angela Hill,Red,Women's Strawweight
+11/11/2017,Sean Strickland,Court McGee,Red,Welterweight
+11/11/2017,Jake Collier,Marcel Fortuna,Red,Light Heavyweight
+11/11/2017,Karl Roberson,Darren Stewart,Red,Middleweight
+11/04/2017,Georges St-Pierre,Michael Bisping,Red,UFC Middleweight Title
+11/04/2017,TJ Dillashaw,Cody Garbrandt,Red,UFC Bantamweight Title
+11/04/2017,Rose Namajunas,Joanna Jedrzejczyk,Red,UFC Women's Strawweight Title
+11/04/2017,Stephen Thompson,Jorge Masvidal,Red,Welterweight
+11/04/2017,Johny Hendricks,Paulo Costa,Blue,Middleweight
+11/04/2017,Joe Duffy,James Vick,Blue,Lightweight
+11/04/2017,Walt Harris,Mark Godbeer,Blue,Heavyweight
+11/04/2017,Corey Anderson,Ovince Saint Preux,Blue,Light Heavyweight
+11/04/2017,Randy Brown,Mickey Gall,Red,Welterweight
+11/04/2017,Aleksei Oleinik,Curtis Blaydes,Blue,Heavyweight
+11/04/2017,Ricardo Ramos,Aiemann Zahabi,Red,Bantamweight
+10/28/2017,Lyoto Machida,Derek Brunson,Blue,Middleweight
+10/28/2017,Demian Maia,Colby Covington,Blue,Welterweight
+10/28/2017,Rob Font,Pedro Munhoz,Blue,Bantamweight
+10/28/2017,Jim Miller,Francisco Trinaldo,Blue,Lightweight
+10/28/2017,Thiago Santos,Jack Hermansson,Red,Middleweight
+10/28/2017,Marlon Vera,John Lineker,Blue,Bantamweight
+10/28/2017,Vicente Luque,Niko Price,Red,Welterweight
+10/28/2017,Antonio Carlos Junior,Jack Marshman,Red,Middleweight
+10/28/2017,Jared Gordon,Hacran Dias,Red,Lightweight
+10/28/2017,Elizeu Zaleski dos Santos,Max Griffin,Red,Welterweight
+10/28/2017,Jarred Brooks,Deiveson Figueiredo,Blue,Flyweight
+10/28/2017,Marcelo Golm,Christian Colombo,Red,Heavyweight
+10/21/2017,Donald Cerrone,Darren Till,Blue,Welterweight
+10/21/2017,Karolina Kowalkiewicz,Jodie Esquibel,Red,Women's Strawweight
+10/21/2017,Devin Clark,Jan Blachowicz,Blue,Light Heavyweight
+10/21/2017,Jonathan Wilson,Oskar Piechota,Blue,Middleweight
+10/21/2017,Marcin Held,Nasrat Haqparast,Red,Lightweight
+10/21/2017,Brian Kelleher,Damian Stasiak,Red,Bantamweight
+10/21/2017,Ramazan Emeev,Sam Alvey,Red,Middleweight
+10/21/2017,Artem Lobov,Andre Fili,Blue,Featherweight
+10/21/2017,Salim Touahri,Warlley Alves,Blue,Welterweight
+10/21/2017,Lina Lansberg,Aspen Ladd,Blue,Women's Bantamweight
+10/21/2017,Felipe Arantes,Josh Emmett,Blue,Featherweight
+10/07/2017,Tony Ferguson,Kevin Lee,Red,UFC Interim Lightweight Title
+10/07/2017,Ray Borg,Demetrious Johnson,Blue,UFC Flyweight Title
+10/07/2017,Walt Harris,Fabricio Werdum,Blue,Heavyweight
+10/07/2017,Mara Romero Borella,Kalindra Faria,Red,Women's Flyweight
+10/07/2017,Cody Stamann,Tom Duquesnoy,Red,Bantamweight
+10/07/2017,Poliana Botelho,Pearl Gonzalez,Red,Women's Strawweight
+10/07/2017,Marco Beltran,Matt Schnell,Blue,Flyweight
+10/07/2017,John Moraga,Bibulatov Magomed,Red,Flyweight
+10/07/2017,Thales Leites,Brad Tavares,Blue,Middleweight
+09/22/2017,Yushin Okami,Ovince Saint Preux,Blue,Light Heavyweight
+09/22/2017,Jessica Andrade,Claudia Gadelha,Red,Women's Strawweight
+09/22/2017,Takanori Gomi,Dong Hyun Ma,Blue,Lightweight
+09/22/2017,Henrique da Silva,Gokhan Saki,Blue,Light Heavyweight
+09/22/2017,Rolando Dy,Teruto Ishihara,Blue,Featherweight
+09/22/2017,Jussier Formiga,Yuta Sasaki,Red,Flyweight
+09/22/2017,Keita Nakamura,Alex Morono,Red,Welterweight
+09/22/2017,Chan-Mi Jeon,Syuri Kondo,Blue,Women's Strawweight
+09/22/2017,Shinsho Anzai,Luke Jumeau,Red,Welterweight
+09/22/2017,Daichi Abe,Hyun Gyu Lim,Red,Welterweight
+09/16/2017,David Branch,Luke Rockhold,Blue,Middleweight
+09/16/2017,Mike Perry,Alex Reyes,Red,Welterweight
+09/16/2017,Anthony Smith,Hector Lombard,Red,Middleweight
+09/16/2017,Gregor Gillespie,Jason Gonzalez,Red,Lightweight
+09/16/2017,Sergio Moraes,Kamaru Usman,Blue,Welterweight
+09/16/2017,Justin Ledet,Azunna Anyanwu,Red,Heavyweight
+09/16/2017,Olivier Aubin-Mercier,Anthony Rocco Martin,Red,Lightweight
+09/16/2017,Daniel Spitz,Anthony Hamilton,Red,Heavyweight
+09/16/2017,Uriah Hall,Krzysztof Jotko,Red,Middleweight
+09/16/2017,Jason Saggo,Gilbert Burns,Blue,Lightweight
+09/09/2017,Amanda Nunes,Valentina Shevchenko,Red,UFC Women's Bantamweight Title
+09/09/2017,Neil Magny,Rafael Dos Anjos,Blue,Welterweight
+09/09/2017,Henry Cejudo,Wilson Reis,Red,Flyweight
+09/09/2017,Ilir Latifi,Tyson Pedro,Red,Light Heavyweight
+09/09/2017,Gilbert Melendez,Jeremy Stephens,Blue,Featherweight
+09/09/2017,Ketlen Vieira,Sara McMann,Red,Women's Bantamweight
+09/09/2017,Ashlee Evans-Smith,Sarah Moras,Blue,Women's Bantamweight
+09/09/2017,Ricky Glenn,Gavin Tucker,Red,Featherweight
+09/09/2017,Mitch Clarke,Alex White,Blue,Lightweight
+09/09/2017,Luis Henrique,Arjan Bhullar,Blue,Heavyweight
+09/09/2017,Kajan Johnson,Adriano Martins,Red,Lightweight
+09/02/2017,Stefan Struve,Alexander Volkov,Blue,Heavyweight
+09/02/2017,Siyar Bahadurzada,Rob Wilkinson,Red,Middleweight
+09/02/2017,Marion Reneau,Talita Bernardo,Red,Women's Bantamweight
+09/02/2017,Leon Edwards,Bryan Barberena,Red,Welterweight
+09/02/2017,Bojan Velickovic,Darren Till,Blue,Welterweight
+09/02/2017,Mairbek Taisumov,Felipe Silva,Red,Lightweight
+09/02/2017,Mads Burnell,Michel Prazeres,Blue,Lightweight
+09/02/2017,Rustam Khabilov,Desmond Green,Red,Lightweight
+09/02/2017,Aleksandar Rakic,Francimar Barroso,Red,Light Heavyweight
+09/02/2017,Mike Santiago,Zabit Magomedsharipov,Blue,Featherweight
+09/02/2017,Bojan Mihajlovic,Abdul-Kerim Edilov,Blue,Light Heavyweight
+09/02/2017,Thibault Gouti,Andrew Holbrook,Red,Lightweight
+08/05/2017,Sergio Pettis,Brandon Moreno,Red,Flyweight
+08/05/2017,Randa Markos,Alexa Grasso,Blue,Women's Strawweight
+08/05/2017,Alan Jouban,Niko Price,Blue,Welterweight
+08/05/2017,Humberto Bandenay,Martin Bravo,Red,Featherweight
+08/05/2017,Sam Alvey,Rashad Evans,Red,Middleweight
+08/05/2017,Andre Soukhamthath,Alejandro Perez,Blue,Bantamweight
+08/05/2017,Brad Scott,Jack Hermansson,Blue,Middleweight
+08/05/2017,Hector Sandoval,Dustin Ortiz,Blue,Flyweight
+08/05/2017,Rani Yahya,Henry Briones,Red,Bantamweight
+08/05/2017,Diego Rivas,Jose Quinonez,Blue,Bantamweight
+08/05/2017,Joseph Morales,Robert Sanchez,Red,Flyweight
+08/05/2017,Jordan Rinaldi,Alvaro Herrera Mendoza,Red,Lightweight
+07/29/2017,Demian Maia,Tyron Woodley,Blue,UFC Welterweight Title
+07/29/2017,Tonya Evinger,Cristiane Justino,Blue,UFC Women's Featherweight Title
+07/29/2017,Donald Cerrone,Robbie Lawler,Blue,Welterweight
+07/29/2017,Volkan Oezdemir,Jimi Manuwa,Red,Light Heavyweight
+07/29/2017,Jason Knight,Ricardo Lamas,Blue,Featherweight
+07/29/2017,Aljamain Sterling,Renan Barao,Red,Catch Weight
+07/29/2017,Renato Moicano,Brian Ortega,Blue,Featherweight
+07/29/2017,Andre Fili,Calvin Kattar,Blue,Featherweight
+07/29/2017,Kailin Curran,Aleksandra Albu,Blue,Women's Strawweight
+07/29/2017,Jarred Brooks,Eric Shelton,Red,Flyweight
+07/29/2017,Joshua Burkman,Drew Dober,Blue,Lightweight
+07/22/2017,Chris Weidman,Kelvin Gastelum,Red,Middleweight
+07/22/2017,Darren Elkins,Dennis Bermudez,Red,Featherweight
+07/22/2017,Gian Villante,Patrick Cummins,Blue,Light Heavyweight
+07/22/2017,Jimmie Rivera,Thomas Almeida,Red,Bantamweight
+07/22/2017,Lyman Good,Elizeu Zaleski dos Santos,Blue,Welterweight
+07/22/2017,Eryk Anders,Rafael Natal,Red,Middleweight
+07/22/2017,Ryan LaFlare,Alex Oliveira,Blue,Welterweight
+07/22/2017,Chase Sherman,Damian Grabowski,Red,Heavyweight
+07/22/2017,Kyle Bochniak,Jeremy Kennedy,Blue,Featherweight
+07/22/2017,Marlon Vera,Brian Kelleher,Red,Bantamweight
+07/22/2017,Junior Albini,Timothy Johnson,Red,Heavyweight
+07/22/2017,Shane Burgos,Godofredo Pepey,Red,Featherweight
+07/22/2017,Frankie Perez,Chris Wade,Blue,Lightweight
+07/16/2017,Gunnar Nelson,Santiago Ponzinibbio,Blue,Welterweight
+07/16/2017,Cynthia Calvillo,Joanne Wood,Red,Women's Strawweight
+07/16/2017,Paul Felder,Stevie Ray,Red,Lightweight
+07/16/2017,Jack Marshman,Ryan Janes,Red,Middleweight
+07/16/2017,Paul Craig,Khalil Rountree Jr.,Blue,Light Heavyweight
+07/16/2017,James Mulheron,Justin Willis,Blue,Heavyweight
+07/16/2017,Bobby Nash,Danny Roberts,Blue,Welterweight
+07/16/2017,Neil Seery,Alexandre Pantoja,Blue,Flyweight
+07/16/2017,Charlie Ward,Galore Bofando,Blue,Welterweight
+07/16/2017,Danny Henry,Daniel Teymur,Red,Lightweight
+07/16/2017,Albert Morales,Brett Johns,Blue,Bantamweight
+07/16/2017,Leslie Smith,Amanda Lemos,Red,Women's Bantamweight
+07/08/2017,Robert Whittaker,Yoel Romero,Red,UFC Interim Middleweight Title
+07/08/2017,Alistair Overeem,Fabricio Werdum,Red,Heavyweight
+07/08/2017,Daniel Omielanczuk,Curtis Blaydes,Blue,Heavyweight
+07/08/2017,Anthony Pettis,Jim Miller,Red,Lightweight
+07/08/2017,Rob Font,Douglas Silva de Andrade,Red,Bantamweight
+07/08/2017,Aleksei Oleinik,Travis Browne,Red,Heavyweight
+07/08/2017,Chad Laprise,Brian Camozzi,Red,Welterweight
+07/08/2017,Gerald Meerschaert,Thiago Santos,Blue,Middleweight
+07/08/2017,Belal Muhammad,Jordan Mein,Red,Welterweight
+07/08/2017,Cody Stamann,Terrion Ware,Red,Featherweight
+07/08/2017,Trevin Giles,James Bochnovic,Red,Light Heavyweight
+07/07/2017,Justin Gaethje,Michael Johnson,Red,Lightweight
+07/07/2017,Dhiego Lima,Jesse Taylor,Blue,Ultimate Fighter 25 Welterweight Tournament Title
+07/07/2017,Marc Diakiese,Drakkar Klose,Blue,Lightweight
+07/07/2017,Nick Roehrick,Jared Cannonier,Blue,Light Heavyweight
+07/07/2017,Elias Theodorou,Brad Tavares,Blue,Middleweight
+07/07/2017,Jordan Johnson,Marcel Fortuna,Red,Light Heavyweight
+07/07/2017,Angela Hill,Ashley Yoder,Red,Women's Strawweight
+07/07/2017,James Krause,Tom Gallicchio,Red,Welterweight
+07/07/2017,CB Dollaway,Ed Herman,Red,Light Heavyweight
+07/07/2017,Tecia Torres,Juliana Lima,Red,Women's Strawweight
+07/07/2017,Teruto Ishihara,Gray Maynard,Blue,Featherweight
+06/25/2017,Michael Chiesa,Kevin Lee,Blue,Lightweight
+06/25/2017,Tim Boetsch,Johny Hendricks,Red,Middleweight
+06/25/2017,Felice Herrig,Justine Kish,Red,Women's Strawweight
+06/25/2017,Dominick Reyes,Joachim Christensen,Red,Light Heavyweight
+06/25/2017,Alex Garcia,Tim Means,Blue,Welterweight
+06/25/2017,Dennis Siver,BJ Penn,Red,Featherweight
+06/25/2017,Erik Koch,Clay Guida,Blue,Lightweight
+06/25/2017,Marvin Vettori,Vitor Miranda,Red,Middleweight
+06/25/2017,Carla Esparza,Maryna Moroz,Red,Women's Strawweight
+06/25/2017,Darrell Horcher,Devin Powell,Red,Lightweight
+06/25/2017,Jared Gordon,Michel Quinones,Red,Featherweight
+06/25/2017,Anthony Rocco Martin,Johnny Case,Red,Lightweight
+06/25/2017,Jeremy Kimball,Josh Stansbury,Red,Light Heavyweight
+06/17/2017,Holly Holm,Bethe Correia,Red,Women's Bantamweight
+06/17/2017,Andrei Arlovski,Marcin Tybura,Blue,Heavyweight
+06/17/2017,Dong Hyun Kim,Colby Covington,Blue,Welterweight
+06/17/2017,Rafael Dos Anjos,Tarec Saffiedine,Red,Welterweight
+06/17/2017,Takanori Gomi,Jon Tuck,Blue,Lightweight
+06/17/2017,Cyril Asker,Walt Harris,Blue,Heavyweight
+06/17/2017,Alex Caceres,Rolando Dy,Red,Featherweight
+06/17/2017,Yuta Sasaki,Justin Scoggins,Red,Flyweight
+06/17/2017,Li Jingliang,Frank Camacho,Red,Welterweight
+06/17/2017,Kwan Ho Kwak,Russell Doane,Blue,Bantamweight
+06/17/2017,Naoki Inoue,Carls John De Tomas,Red,Flyweight
+06/17/2017,Ji Yeon Kim,Lucie Pudilova,Blue,Women's Bantamweight
+06/10/2017,Derrick Lewis,Mark Hunt,Blue,Heavyweight
+06/10/2017,Derek Brunson,Daniel Kelly,Red,Middleweight
+06/10/2017,Dan Hooker,Ross Pearson,Red,Lightweight
+06/10/2017,Ion Cutelaba,Henrique da Silva,Red,Light Heavyweight
+06/10/2017,Ben Nguyen,Tim Elliott,Red,Flyweight
+06/10/2017,Alexander Volkanovski,Mizuto Hirota,Red,Featherweight
+06/10/2017,Damien Brown,Vinc Pichel,Blue,Lightweight
+06/10/2017,Dominique Steele,Luke Jumeau,Blue,Welterweight
+06/10/2017,John Moraga,Ashkan Mokhtarian,Red,Flyweight
+06/10/2017,Kiichi Kunimoto,Zak Ottow,Blue,Welterweight
+06/10/2017,JJ Aldrich,Chan-Mi Jeon,Red,Women's Strawweight
+06/03/2017,Jose Aldo,Max Holloway,Blue,UFC Featherweight Title
+06/03/2017,Karolina Kowalkiewicz,Claudia Gadelha,Blue,Women's Strawweight
+06/03/2017,Vitor Belfort,Nate Marquardt,Red,Middleweight
+06/03/2017,Oluwale Bamgbose,Paulo Costa,Blue,Middleweight
+06/03/2017,Erick Silva,Yancy Medeiros,Blue,Welterweight
+06/03/2017,Marlon Moraes,Raphael Assuncao,Blue,Bantamweight
+06/03/2017,Eric Spicely,Antonio Carlos Junior,Blue,Middleweight
+06/03/2017,Johnny Eduardo,Matthew Lopez,Blue,Bantamweight
+06/03/2017,Iuri Alcantara,Brian Kelleher,Blue,Bantamweight
+06/03/2017,Jamie Moyle,Viviane Pereira,Blue,Women's Strawweight
+06/03/2017,Luan Chagas,Jim Wallhead,Red,Welterweight
+06/03/2017,Marco Beltran,Deiveson Figueiredo,Blue,Flyweight
+05/28/2017,Alexander Gustafsson,Glover Teixeira,Red,Light Heavyweight
+05/28/2017,Misha Cirkunov,Volkan Oezdemir,Blue,Light Heavyweight
+05/28/2017,Peter Sobotta,Ben Saunders,Red,Welterweight
+05/28/2017,Abdul Razak Alhassan,Omari Akhmedov,Blue,Welterweight
+05/28/2017,Oliver Enkamp,Nordine Taleb,Blue,Welterweight
+05/28/2017,Jack Hermansson,Alex Nicholson,Red,Middleweight
+05/28/2017,Pedro Munhoz,Damian Stasiak,Red,Bantamweight
+05/28/2017,Trevor Smith,Chris Camozzi,Red,Middleweight
+05/28/2017,Reza Madadi,Joaquim Silva,Blue,Lightweight
+05/28/2017,Nicholas Musoke,Bojan Velickovic,Blue,Welterweight
+05/28/2017,Jessin Ayari,Darren Till,Blue,Welterweight
+05/28/2017,Damir Hadzovic,Marcin Held,Red,Lightweight
+05/13/2017,Stipe Miocic,Junior Dos Santos,Red,UFC Heavyweight Title
+05/13/2017,Joanna Jedrzejczyk,Jessica Andrade,Red,UFC Women's Strawweight Title
+05/13/2017,Demian Maia,Jorge Masvidal,Red,Welterweight
+05/13/2017,Yair Rodriguez,Frankie Edgar,Blue,Featherweight
+05/13/2017,Krzysztof Jotko,David Branch,Blue,Middleweight
+05/13/2017,Jason Knight,Chas Skelly,Red,Featherweight
+05/13/2017,Rashad Coulter,Chase Sherman,Blue,Heavyweight
+05/13/2017,James Vick,Marco Polo Reyes,Red,Lightweight
+05/13/2017,Cortney Casey,Jessica Aguilar,Red,Women's Strawweight
+05/13/2017,Enrique Barzola,Gabriel Benitez,Red,Featherweight
+05/13/2017,Joachim Christensen,Gadzhimurad Antigulov,Blue,Light Heavyweight
+04/22/2017,Artem Lobov,Cub Swanson,Blue,Featherweight
+04/22/2017,Al Iaquinta,Diego Sanchez,Red,Lightweight
+04/22/2017,Ovince Saint Preux,Marcos Rogerio de Lima,Red,Light Heavyweight
+04/22/2017,John Dodson,Eddie Wineland,Red,Bantamweight
+04/22/2017,Joe Lauzon,Stevie Ray,Blue,Lightweight
+04/22/2017,Jake Ellenberger,Mike Perry,Blue,Welterweight
+04/22/2017,Sam Alvey,Thales Leites,Blue,Middleweight
+04/22/2017,Dustin Ortiz,Brandon Moreno,Blue,Flyweight
+04/22/2017,Scott Holtzman,Michael McBride,Red,Lightweight
+04/22/2017,Danielle Taylor,Jessica Penne,Red,Women's Strawweight
+04/22/2017,Alexis Davis,Cindy Dandois,Red,Women's Bantamweight
+04/22/2017,Joe Proctor,Bryan Barberena,Blue,Welterweight
+04/22/2017,Hector Sandoval,Matt Schnell,Red,Flyweight
+04/15/2017,Wilson Reis,Demetrious Johnson,Blue,UFC Flyweight Title
+04/15/2017,Michelle Waterson-Gomez,Rose Namajunas,Blue,Women's Strawweight
+04/15/2017,Jacare Souza,Robert Whittaker,Blue,Middleweight
+04/15/2017,Jeremy Stephens,Renato Moicano,Blue,Featherweight
+04/15/2017,Alexander Volkov,Roy Nelson,Red,Heavyweight
+04/15/2017,Patrick Williams,Tom Duquesnoy,Blue,Bantamweight
+04/15/2017,Rashid Magomedov,Bobby Green,Red,Lightweight
+04/15/2017,Tim Elliott,Louis Smolka,Red,Flyweight
+04/15/2017,Aljamain Sterling,Augusto Mendes,Red,Bantamweight
+04/15/2017,Devin Clark,Jake Collier,Red,Light Heavyweight
+04/15/2017,Anthony Smith,Andrew Sanchez,Red,Middleweight
+04/15/2017,Nathan Coy,Zak Cummings,Blue,Welterweight
+04/15/2017,Ashlee Evans-Smith,Ketlen Vieira,Blue,Women's Bantamweight
+04/08/2017,Daniel Cormier,Anthony Johnson,Red,UFC Light Heavyweight Title
+04/08/2017,Chris Weidman,Gegard Mousasi,Blue,Middleweight
+04/08/2017,Pearl Gonzalez,Cynthia Calvillo,Blue,Women's Strawweight
+04/08/2017,Patrick Cote,Thiago Alves,Blue,Welterweight
+04/08/2017,Charles Oliveira,Will Brooks,Red,Lightweight
+04/08/2017,Myles Jury,Mike de la Torre,Red,Featherweight
+04/08/2017,Kamaru Usman,Sean Strickland,Red,Welterweight
+04/08/2017,Charles Rosa,Shane Burgos,Blue,Featherweight
+04/08/2017,Patrick Cummins,Jan Blachowicz,Red,Light Heavyweight
+04/08/2017,Gregor Gillespie,Andrew Holbrook,Red,Lightweight
+04/08/2017,Josh Emmett,Desmond Green,Blue,Lightweight
+04/08/2017,Irene Aldana,Katlyn Cerminara,Blue,Women's Bantamweight
+04/08/2017,Bibulatov Magomed,Jenel Lausa,Red,Flyweight
+03/18/2017,Corey Anderson,Jimi Manuwa,Blue,Light Heavyweight
+03/18/2017,Gunnar Nelson,Alan Jouban,Red,Welterweight
+03/18/2017,Brad Pickett,Marlon Vera,Blue,Catch Weight
+03/18/2017,Makwan Amirkhani,Arnold Allen,Blue,Featherweight
+03/18/2017,Reza Madadi,Joe Duffy,Blue,Lightweight
+03/18/2017,Francimar Barroso,Darren Stewart,Red,Light Heavyweight
+03/18/2017,Timothy Johnson,Daniel Omielanczuk,Red,Heavyweight
+03/18/2017,Vicente Luque,Leon Edwards,Blue,Welterweight
+03/18/2017,Teemu Packalen,Marc Diakiese,Blue,Lightweight
+03/18/2017,Brad Scott,Scott Askham,Red,Middleweight
+03/18/2017,Lina Lansberg,Lucie Pudilova,Red,Women's Bantamweight
+03/11/2017,Mauricio Rua,Gian Villante,Red,Light Heavyweight
+03/11/2017,Edson Barboza,Beneil Dariush,Red,Lightweight
+03/11/2017,Ray Borg,Jussier Formiga,Red,Flyweight
+03/11/2017,Tim Means,Alex Oliveira,Blue,Welterweight
+03/11/2017,Francisco Trinaldo,Kevin Lee,Blue,Lightweight
+03/11/2017,Davi Ramos,Sergio Moraes,Blue,Welterweight
+03/11/2017,Joe Soto,Rani Yahya,Red,Bantamweight
+03/11/2017,Michel Prazeres,Joshua Burkman,Red,Lightweight
+03/11/2017,Jeremy Kennedy,Rony Jason,Red,Featherweight
+03/11/2017,Garreth McLellan,Paulo Costa,Blue,Middleweight
+03/04/2017,Tyron Woodley,Stephen Thompson,Red,UFC Welterweight Title
+03/04/2017,David Teymur,Lando Vannata,Red,Lightweight
+03/04/2017,Daniel Kelly,Rashad Evans,Red,Middleweight
+03/04/2017,Cynthia Calvillo,Amanda Cooper,Red,Women's Strawweight
+03/04/2017,Mark Hunt,Alistair Overeem,Blue,Heavyweight
+03/04/2017,Luis Henrique,Marcin Tybura,Blue,Heavyweight
+03/04/2017,Darren Elkins,Mirsad Bektic,Red,Featherweight
+03/04/2017,Luke Sanders,Iuri Alcantara,Blue,Bantamweight
+03/04/2017,Mark Godbeer,Daniel Spitz,Red,Heavyweight
+03/04/2017,Paul Craig,Tyson Pedro,Blue,Light Heavyweight
+03/04/2017,Albert Morales,Andre Soukhamthath,Red,Bantamweight
+02/19/2017,Derrick Lewis,Travis Browne,Red,Heavyweight
+02/19/2017,Johny Hendricks,Hector Lombard,Red,Middleweight
+02/19/2017,Sam Sicilia,Gavin Tucker,Blue,Featherweight
+02/19/2017,Elias Theodorou,Cezar Ferreira,Red,Middleweight
+02/19/2017,Sara McMann,Gina Mazany,Red,Women's Bantamweight
+02/19/2017,Alex Ricci,Paul Felder,Blue,Lightweight
+02/19/2017,Santiago Ponzinibbio,Nordine Taleb,Red,Welterweight
+02/19/2017,Randa Markos,Carla Esparza,Red,Women's Strawweight
+02/19/2017,Aiemann Zahabi,Reginaldo Vieira,Red,Bantamweight
+02/19/2017,Thiago Santos,Jack Marshman,Red,Middleweight
+02/19/2017,Gerald Meerschaert,Ryan Janes,Red,Middleweight
+02/11/2017,Germaine de Randamie,Holly Holm,Red,UFC Women's Featherweight Title
+02/11/2017,Anderson Silva,Derek Brunson,Red,Middleweight
+02/11/2017,Jacare Souza,Tim Boetsch,Red,Middleweight
+02/11/2017,Jared Cannonier,Glover Teixeira,Blue,Light Heavyweight
+02/11/2017,Jim Miller,Dustin Poirier,Blue,Lightweight
+02/11/2017,Randy Brown,Belal Muhammad,Blue,Welterweight
+02/11/2017,Wilson Reis,Yuta Sasaki,Red,Flyweight
+02/11/2017,Islam Makhachev,Nik Lentz,Red,Lightweight
+02/11/2017,Ricky Glenn,Phillipe Nover,Red,Featherweight
+02/11/2017,Roan Carneiro,Ryan LaFlare,Blue,Welterweight
+02/04/2017,Dennis Bermudez,Chan Sung Jung,Blue,Featherweight
+02/04/2017,Alexa Grasso,Felice Herrig,Blue,Women's Strawweight
+02/04/2017,James Vick,Abel Trujillo,Red,Lightweight
+02/04/2017,Volkan Oezdemir,Ovince Saint Preux,Red,Light Heavyweight
+02/04/2017,Marcel Fortuna,Anthony Hamilton,Red,Heavyweight
+02/04/2017,Jessica Andrade,Angela Hill,Red,Women's Strawweight
+02/04/2017,Chas Skelly,Chris Gruetzemacher,Red,Featherweight
+02/04/2017,Ricardo Ramos,Michinori Tanaka,Red,Bantamweight
+02/04/2017,Bec Rawlings,Tecia Torres,Blue,Women's Strawweight
+02/04/2017,Daniel Jolly,Khalil Rountree Jr.,Blue,Light Heavyweight
+01/28/2017,Julianna Pena,Valentina Shevchenko,Blue,Women's Bantamweight
+01/28/2017,Jorge Masvidal,Donald Cerrone,Red,Welterweight
+01/28/2017,Andrei Arlovski,Francis Ngannou,Blue,Heavyweight
+01/28/2017,Alex Caceres,Jason Knight,Blue,Featherweight
+01/28/2017,Sam Alvey,Nate Marquardt,Red,Middleweight
+01/28/2017,Raphael Assuncao,Aljamain Sterling,Red,Bantamweight
+01/28/2017,Bobby Nash,Li Jingliang,Blue,Welterweight
+01/28/2017,Henrique da Silva,Jordan Johnson,Blue,Light Heavyweight
+01/28/2017,Eric Spicely,Alessio Di Chirico,Red,Middleweight
+01/28/2017,Jeremy Kimball,Marcos Rogerio de Lima,Blue,Light Heavyweight
+01/28/2017,Eric Shelton,Alexandre Pantoja,Blue,Flyweight
+01/28/2017,Jason Gonzalez,JC Cottrell,Red,Lightweight
+01/15/2017,BJ Penn,Yair Rodriguez,Blue,Featherweight
+01/15/2017,Marcin Held,Joe Lauzon,Blue,Lightweight
+01/15/2017,Ben Saunders,Court McGee,Red,Welterweight
+01/15/2017,Sergio Pettis,John Moraga,Red,Flyweight
+01/15/2017,Devin Powell,Drakkar Klose,Blue,Lightweight
+01/15/2017,Frankie Saenz,Augusto Mendes,Blue,Bantamweight
+01/15/2017,Viktor Pesta,Aleksei Oleinik,Blue,Heavyweight
+01/15/2017,Anthony Rocco Martin,Alex White,Red,Lightweight
+01/15/2017,Nina Nunes,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+01/15/2017,Chase Sherman,Walt Harris,Blue,Heavyweight
+01/15/2017,Bojan Mihajlovic,Joachim Christensen,Blue,Light Heavyweight
+01/15/2017,Cyril Asker,Dmitrii Smoliakov,Red,Heavyweight
+12/30/2016,Amanda Nunes,Ronda Rousey,Red,UFC Women's Bantamweight Title
+12/30/2016,Cody Garbrandt,Dominick Cruz,Red,UFC Bantamweight Title
+12/30/2016,John Lineker,TJ Dillashaw,Blue,Bantamweight
+12/30/2016,Dong Hyun Kim,Tarec Saffiedine,Red,Welterweight
+12/30/2016,Louis Smolka,Ray Borg,Blue,Flyweight
+12/30/2016,Neil Magny,Johny Hendricks,Red,Welterweight
+12/30/2016,Marvin Vettori,Antonio Carlos Junior,Blue,Middleweight
+12/30/2016,Alex Garcia,Mike Pyle,Red,Welterweight
+12/30/2016,Niko Price,Brandon Thatch,Red,Welterweight
+12/17/2016,Paige VanZant,Michelle Waterson-Gomez,Blue,Women's Strawweight
+12/17/2016,Mickey Gall,Sage Northcutt,Red,Welterweight
+12/17/2016,Urijah Faber,Brad Pickett,Red,Bantamweight
+12/17/2016,Alan Jouban,Mike Perry,Red,Welterweight
+12/17/2016,Henrique da Silva,Paul Craig,Blue,Light Heavyweight
+12/17/2016,Cole Miller,Mizuto Hirota,Blue,Featherweight
+12/17/2016,Colby Covington,Bryan Barberena,Red,Welterweight
+12/17/2016,James Moontasri,Alex Morono,Blue,Welterweight
+12/17/2016,Scott Holtzman,Josh Emmett,Blue,Lightweight
+12/17/2016,Irene Aldana,Leslie Smith,Blue,Women's Bantamweight
+12/17/2016,Takeya Mizugaki,Eddie Wineland,Blue,Bantamweight
+12/17/2016,Fredy Serrano,Hector Sandoval,Blue,Flyweight
+12/17/2016,Bojan Velickovic,Sultan Aliev,Blue,Welterweight
+12/10/2016,Anthony Pettis,Max Holloway,Blue,UFC Interim Featherweight Title
+12/10/2016,Matt Brown,Donald Cerrone,Blue,Welterweight
+12/10/2016,Cub Swanson,Dooho Choi,Red,Featherweight
+12/10/2016,Kelvin Gastelum,Tim Kennedy,Red,Middleweight
+12/10/2016,Emil Meek,Jordan Mein,Red,Welterweight
+12/10/2016,Misha Cirkunov,Nikita Krylov,Red,Light Heavyweight
+12/10/2016,Drew Dober,Olivier Aubin-Mercier,Blue,Lightweight
+12/10/2016,Valerie Letourneau,Viviane Pereira,Blue,Women's Strawweight
+12/10/2016,Mitch Gagnon,Matthew Lopez,Blue,Bantamweight
+12/10/2016,Lando Vannata,John Makdessi,Red,Lightweight
+12/10/2016,Jason Saggo,Rustam Khabilov,Blue,Lightweight
+12/10/2016,Dustin Ortiz,Zach Makovsky,Red,Flyweight
+12/09/2016,Shamil Abdurakhimov,Derrick Lewis,Blue,Heavyweight
+12/09/2016,Francis Ngannou,Anthony Hamilton,Red,Heavyweight
+12/09/2016,Corey Anderson,Sean O'Connell,Red,Light Heavyweight
+12/09/2016,Saparbeg Safarov,Gian Villante,Blue,Light Heavyweight
+12/09/2016,Justine Kish,Ashley Yoder,Red,Women's Strawweight
+12/09/2016,Randy Brown,Brian Camozzi,Red,Welterweight
+12/09/2016,Joseph Gigliotti,Gerald Meerschaert,Blue,Middleweight
+12/09/2016,Andrew Sanchez,Trevor Smith,Red,Middleweight
+12/09/2016,Shane Burgos,Tiago dos Santos e Silva,Red,Featherweight
+12/09/2016,Frankie Perez,Marc Diakiese,Blue,Lightweight
+12/09/2016,Ryan Janes,Keith Berish,Red,Middleweight
+12/09/2016,Juliana Lima,JJ Aldrich,Red,Women's Strawweight
+12/03/2016,Demetrious Johnson,Tim Elliott,Red,UFC Flyweight Title
+12/03/2016,Henry Cejudo,Joseph Benavidez,Blue,Flyweight
+12/03/2016,Jorge Masvidal,Jake Ellenberger,Red,Welterweight
+12/03/2016,Jared Cannonier,Ion Cutelaba,Red,Light Heavyweight
+12/03/2016,Sara McMann,Alexis Davis,Red,Women's Bantamweight
+12/03/2016,Ryan Benoit,Brandon Moreno,Blue,Flyweight
+12/03/2016,Ryan Hall,Gray Maynard,Red,Featherweight
+12/03/2016,Rob Font,Matt Schnell,Red,Bantamweight
+12/03/2016,Brendan O'Reilly,Dong Hyun Ma,Blue,Lightweight
+12/03/2016,Jamie Moyle,Kailin Curran,Red,Women's Strawweight
+12/03/2016,Elvis Mutapcic,Anthony Smith,Blue,Middleweight
+12/03/2016,Devin Clark,Josh Stansbury,Red,Light Heavyweight
+11/26/2016,Derek Brunson,Robert Whittaker,Blue,Middleweight
+11/26/2016,Andrew Holbrook,Jake Matthews,Red,Lightweight
+11/26/2016,Kyle Noke,Omari Akhmedov,Blue,Welterweight
+11/26/2016,Alexander Volkanovski,Yusuke Kasuya,Red,Lightweight
+11/26/2016,Khalil Rountree Jr.,Tyson Pedro,Blue,Light Heavyweight
+11/26/2016,Seo Hee Ham,Danielle Taylor,Blue,Women's Strawweight
+11/26/2016,Chris Camozzi,Daniel Kelly,Blue,Middleweight
+11/26/2016,Damien Brown,Jon Tuck,Red,Lightweight
+11/26/2016,Richard Walsh,Jonathan Meunier,Blue,Welterweight
+11/26/2016,Ben Nguyen,Geane Herrera,Red,Flyweight
+11/26/2016,Dan Hooker,Jason Knight,Blue,Featherweight
+11/26/2016,Guangyou Ning,Marlon Vera,Blue,Featherweight
+11/26/2016,Jenel Lausa,Yao Zhikui,Red,Flyweight
+11/19/2016,Rogerio Nogueira,Ryan Bader,Blue,Light Heavyweight
+11/19/2016,Albert Morales,Thomas Almeida,Blue,Bantamweight
+11/19/2016,Claudia Gadelha,Cortney Casey,Red,Women's Strawweight
+11/19/2016,Krzysztof Jotko,Thales Leites,Red,Middleweight
+11/19/2016,Kamaru Usman,Warlley Alves,Red,Welterweight
+11/19/2016,Sergio Moraes,Zak Ottow,Red,Welterweight
+11/19/2016,Jack Hermansson,Cezar Ferreira,Blue,Middleweight
+11/19/2016,Gadzhimurad Antigulov,Marcos Rogerio de Lima,Red,Light Heavyweight
+11/19/2016,Johnny Eduardo,Manvel Gamburyan,Red,Bantamweight
+11/19/2016,Luis Henrique,Christian Colombo,Red,Heavyweight
+11/19/2016,Pedro Munhoz,Justin Scoggins,Red,Bantamweight
+11/19/2016,Gegard Mousasi,Uriah Hall,Red,Middleweight
+11/19/2016,Ross Pearson,Stevie Ray,Blue,Lightweight
+11/19/2016,Alexander Volkov,Timothy Johnson,Red,Heavyweight
+11/19/2016,Teruto Ishihara,Artem Lobov,Blue,Featherweight
+11/19/2016,Jack Marshman,Magnus Cedenblad,Red,Middleweight
+11/19/2016,Ali Bagautinov,Kyoji Horiguchi,Blue,Flyweight
+11/19/2016,Kevin Lee,Magomed Mustafaev,Red,Lightweight
+11/19/2016,Amanda Cooper,Anna Elmose,Red,Women's Strawweight
+11/19/2016,Justin Ledet,Mark Godbeer,Red,Heavyweight
+11/19/2016,Alexander Yakovlev,Zak Cummings,Blue,Welterweight
+11/19/2016,Milana Dudieva,Marion Reneau,Blue,Women's Bantamweight
+11/19/2016,Kwan Ho Kwak,Brett Johns,Blue,Bantamweight
+11/19/2016,Abdul Razak Alhassan,Charlie Ward,Red,Welterweight
+11/12/2016,Eddie Alvarez,Conor McGregor,Blue,UFC Lightweight Title
+11/12/2016,Karolina Kowalkiewicz,Joanna Jedrzejczyk,Blue,UFC Women's Strawweight Title
+11/12/2016,Yoel Romero,Chris Weidman,Red,Middleweight
+11/12/2016,Raquel Pennington,Miesha Tate,Red,Women's Bantamweight
+11/12/2016,Frankie Edgar,Jeremy Stephens,Red,Featherweight
+11/12/2016,Khabib Nurmagomedov,Michael Johnson,Red,Lightweight
+11/12/2016,Tim Boetsch,Rafael Natal,Red,Middleweight
+11/12/2016,Belal Muhammad,Vicente Luque,Blue,Welterweight
+11/12/2016,Jim Miller,Thiago Alves,Red,Catch Weight
+11/12/2016,Katlyn Cerminara,Liz Carmouche,Blue,Women's Bantamweight
+11/05/2016,Tony Ferguson,Rafael Dos Anjos,Red,Lightweight
+11/05/2016,Diego Sanchez,Marcin Held,Red,Lightweight
+11/05/2016,Ricardo Lamas,Charles Oliveira,Red,Featherweight
+11/05/2016,Claudio Puelles,Martin Bravo,Blue,Ultimate Fighter Latin America 3 Lightweight Tournament Title
+11/05/2016,Rashid Magomedov,Beneil Dariush,Blue,Lightweight
+11/05/2016,Heather Clark,Alexa Grasso,Blue,Women's Strawweight
+11/05/2016,Erik Perez,Felipe Arantes,Red,Bantamweight
+11/05/2016,Marco Beltran,Joe Soto,Blue,Catch Weight
+11/05/2016,Erick Montano,Max Griffin,Blue,Welterweight
+11/05/2016,Douglas Silva de Andrade,Henry Briones,Red,Bantamweight
+11/05/2016,Sam Alvey,Alex Nicholson,Red,Middleweight
+11/05/2016,Jason Novelli,Marco Polo Reyes,Blue,Lightweight
+11/05/2016,Enrique Barzola,Chris Avila,Red,Featherweight
+10/08/2016,Michael Bisping,Dan Henderson,Red,UFC Middleweight Title
+10/08/2016,Vitor Belfort,Gegard Mousasi,Blue,Middleweight
+10/08/2016,Jimi Manuwa,Ovince Saint Preux,Red,Light Heavyweight
+10/08/2016,Daniel Omielanczuk,Stefan Struve,Blue,Heavyweight
+10/08/2016,Mirsad Bektic,Russell Doane,Red,Featherweight
+10/08/2016,Brad Pickett,Iuri Alcantara,Blue,Bantamweight
+10/08/2016,Davey Grant,Damian Stasiak,Blue,Bantamweight
+10/08/2016,Leon Edwards,Albert Tumenov,Red,Welterweight
+10/08/2016,Marc Diakiese,Lukasz Sajewski,Red,Lightweight
+10/08/2016,Danny Roberts,Mike Perry,Blue,Welterweight
+10/08/2016,Adriano Martins,Leonardo Santos,Blue,Lightweight
+10/01/2016,John Lineker,John Dodson,Red,Bantamweight
+10/01/2016,Alex Oliveira,Will Brooks,Red,Lightweight
+10/01/2016,Joshua Burkman,Zak Ottow,Blue,Welterweight
+10/01/2016,Louis Smolka,Brandon Moreno,Blue,Flyweight
+10/01/2016,Joachim Christensen,Henrique da Silva,Blue,Light Heavyweight
+10/01/2016,Andre Fili,Hacran Dias,Red,Featherweight
+10/01/2016,Walt Harris,Shamil Abdurakhimov,Blue,Heavyweight
+10/01/2016,Keita Nakamura,Elizeu Zaleski dos Santos,Blue,Welterweight
+10/01/2016,Tamdan McCrory,Nate Marquardt,Blue,Middleweight
+10/01/2016,Jonathan Wilson,Ion Cutelaba,Blue,Light Heavyweight
+10/01/2016,Cody East,Curtis Blaydes,Blue,Heavyweight
+10/01/2016,Kelly Faszholz,Ketlen Vieira,Blue,Women's Bantamweight
+09/24/2016,Lina Lansberg,Cristiane Justino,Blue,Catch Weight
+09/24/2016,Renan Barao,Phillipe Nover,Red,Featherweight
+09/24/2016,Roy Nelson,Antonio Silva,Red,Heavyweight
+09/24/2016,Paul Felder,Francisco Trinaldo,Blue,Lightweight
+09/24/2016,Thiago Santos,Eric Spicely,Blue,Middleweight
+09/24/2016,Mike de la Torre,Godofredo Pepey,Blue,Featherweight
+09/24/2016,Gilbert Burns,Michel Prazeres,Blue,Lightweight
+09/24/2016,Rani Yahya,Michinori Tanaka,Red,Bantamweight
+09/24/2016,Dustin Ortiz,Jussier Formiga,Blue,Flyweight
+09/24/2016,Luan Chagas,Erick Silva,Blue,Welterweight
+09/24/2016,Alan Patrick,Stevie Ray,Red,Lightweight
+09/24/2016,Hector Urbina,Vicente Luque,Blue,Welterweight
+09/24/2016,Gregor Gillespie,Glaico Franca Moreira,Red,Lightweight
+09/17/2016,Michael Johnson,Dustin Poirier,Red,Lightweight
+09/17/2016,Uriah Hall,Derek Brunson,Blue,Middleweight
+09/17/2016,Ricky Glenn,Evan Dunham,Blue,Lightweight
+09/17/2016,Roan Carneiro,Kenny Robertson,Red,Welterweight
+09/17/2016,Chris Wade,Islam Makhachev,Blue,Lightweight
+09/17/2016,Chas Skelly,Maximo Blanco,Red,Featherweight
+09/17/2016,Sam Sicilia,Gabriel Benitez,Blue,Featherweight
+09/17/2016,Belal Muhammad,Augusto Montano,Red,Welterweight
+09/17/2016,Leonardo Guimaraes,Antonio Carlos Junior,Blue,Middleweight
+09/17/2016,Joey Gomez,Jose Quinonez,Blue,Bantamweight
+09/17/2016,Randy Brown,Erick Montano,Red,Welterweight
+09/10/2016,Alistair Overeem,Stipe Miocic,Blue,UFC Heavyweight Title
+09/10/2016,Fabricio Werdum,Travis Browne,Red,Heavyweight
+09/10/2016,Mickey Gall,CM Punk,Red,Welterweight
+09/10/2016,Urijah Faber,Jimmie Rivera,Blue,Bantamweight
+09/10/2016,Jessica Andrade,Joanne Wood,Red,Women's Strawweight
+09/10/2016,Jessica Eye,Bethe Correia,Blue,Women's Bantamweight
+09/10/2016,Brad Tavares,Caio Magalhaes,Red,Middleweight
+09/10/2016,Michael McBride,Nik Lentz,Blue,Lightweight
+09/10/2016,Jason Gonzalez,Drew Dober,Blue,Lightweight
+09/10/2016,Sean Spencer,Yancy Medeiros,Blue,Welterweight
+09/03/2016,Andrei Arlovski,Josh Barnett,Blue,Heavyweight
+09/03/2016,Jan Blachowicz,Alexander Gustafsson,Blue,Light Heavyweight
+09/03/2016,Ryan Bader,Ilir Latifi,Red,Light Heavyweight
+09/03/2016,Tae Hyun Bang,Nick Hein,Blue,Lightweight
+09/03/2016,Jessin Ayari,Jim Wallhead,Red,Welterweight
+09/03/2016,Nicolas Dalby,Peter Sobotta,Blue,Welterweight
+09/03/2016,Ashlee Evans-Smith,Veronica Hardy,Red,Women's Bantamweight
+09/03/2016,Leandro Issa,Taylor Lapilus,Blue,Bantamweight
+09/03/2016,Scott Askham,Jack Hermansson,Blue,Middleweight
+09/03/2016,Rustam Khabilov,Leandro Silva,Red,Lightweight
+08/27/2016,Demian Maia,Carlos Condit,Red,Welterweight
+08/27/2016,Charles Oliveira,Anthony Pettis,Blue,Featherweight
+08/27/2016,Bec Rawlings,Paige VanZant,Blue,Women's Strawweight
+08/27/2016,Jim Miller,Joe Lauzon,Red,Lightweight
+08/27/2016,Kevin Casey,Sam Alvey,Blue,Middleweight
+08/27/2016,Kyle Bochniak,Enrique Barzola,Red,Featherweight
+08/27/2016,Garreth McLellan,Alessio Di Chirico,Blue,Middleweight
+08/27/2016,Shane Campbell,Felipe Silva,Blue,Lightweight
+08/27/2016,Thibault Gouti,Chad Laprise,Blue,Lightweight
+08/27/2016,Alex Ricci,Jeremy Kennedy,Blue,Lightweight
+08/20/2016,Nate Diaz,Conor McGregor,Blue,Welterweight
+08/20/2016,Glover Teixeira,Anthony Johnson,Blue,Light Heavyweight
+08/20/2016,Rick Story,Donald Cerrone,Blue,Welterweight
+08/20/2016,Hyun Gyu Lim,Mike Perry,Blue,Welterweight
+08/20/2016,Tim Means,Sabah Homasi,Red,Welterweight
+08/20/2016,Cody Garbrandt,Takeya Mizugaki,Red,Bantamweight
+08/20/2016,Elizabeth Phillips,Raquel Pennington,Blue,Women's Bantamweight
+08/20/2016,Artem Lobov,Chris Avila,Red,Featherweight
+08/20/2016,Randa Markos,Cortney Casey,Blue,Women's Strawweight
+08/20/2016,Neil Magny,Lorenz Larkin,Blue,Welterweight
+08/20/2016,Max Griffin,Colby Covington,Blue,Welterweight
+08/20/2016,Marvin Vettori,Alberto Uda,Red,Middleweight
+08/06/2016,Yair Rodriguez,Alex Caceres,Red,Featherweight
+08/06/2016,Dennis Bermudez,Rony Jason,Red,Featherweight
+08/06/2016,Chris Camozzi,Thales Leites,Blue,Middleweight
+08/06/2016,Santiago Ponzinibbio,Zak Cummings,Red,Welterweight
+08/06/2016,Joseph Gigliotti,Trevor Smith,Blue,Middleweight
+08/06/2016,Maryna Moroz,Danielle Taylor,Red,Women's Strawweight
+08/06/2016,Dominique Steele,Court McGee,Blue,Welterweight
+08/06/2016,Viktor Pesta,Marcin Tybura,Blue,Heavyweight
+08/06/2016,David Teymur,Jason Novelli,Red,Lightweight
+08/06/2016,Teruto Ishihara,Horacio Gutierrez,Red,Featherweight
+08/06/2016,Tatsuya Kawajiri,Cub Swanson,Blue,Featherweight
+08/06/2016,Chase Sherman,Justin Ledet,Blue,Heavyweight
+07/30/2016,Tyron Woodley,Robbie Lawler,Red,UFC Welterweight Title
+07/30/2016,Rose Namajunas,Karolina Kowalkiewicz,Blue,Women's Strawweight
+07/30/2016,Matt Brown,Jake Ellenberger,Blue,Welterweight
+07/30/2016,Erik Perez,Francisco Rivera,Red,Bantamweight
+07/30/2016,Ryan Benoit,Fredy Serrano,Red,Flyweight
+07/30/2016,Nikita Krylov,Ed Herman,Red,Light Heavyweight
+07/30/2016,Ross Pearson,Jorge Masvidal,Blue,Welterweight
+07/30/2016,Anthony Hamilton,Damian Grabowski,Red,Heavyweight
+07/30/2016,Wilson Reis,Hector Sandoval,Red,Flyweight
+07/30/2016,Cesar Arzamendia,Damien Brown,Blue,Lightweight
+07/23/2016,Holly Holm,Valentina Shevchenko,Blue,Women's Bantamweight
+07/23/2016,Edson Barboza,Gilbert Melendez,Red,Lightweight
+07/23/2016,Bojan Mihajlovic,Francis Ngannou,Blue,Heavyweight
+07/23/2016,Felice Herrig,Kailin Curran,Red,Women's Strawweight
+07/23/2016,Eddie Wineland,Frankie Saenz,Red,Bantamweight
+07/23/2016,Godofredo Pepey,Darren Elkins,Blue,Featherweight
+07/23/2016,Alexander Yakovlev,Kamaru Usman,Blue,Welterweight
+07/23/2016,Michel Prazeres,JC Cottrell,Red,Lightweight
+07/23/2016,Alex Oliveira,James Moontasri,Red,Welterweight
+07/23/2016,Jim Alers,Jason Knight,Blue,Featherweight
+07/23/2016,Dmitrii Smoliakov,Luis Henrique,Blue,Heavyweight
+07/13/2016,Michael McDonald,John Lineker,Blue,Bantamweight
+07/13/2016,Tony Ferguson,Lando Vannata,Red,Lightweight
+07/13/2016,Tim Boetsch,Josh Samman,Red,Middleweight
+07/13/2016,Aleksei Oleinik,Daniel Omielanczuk,Blue,Heavyweight
+07/13/2016,Kyle Noke,Keita Nakamura,Blue,Welterweight
+07/13/2016,Louis Smolka,Ben Nguyen,Red,Flyweight
+07/13/2016,Lauren Murphy,Katlyn Cerminara,Blue,Women's Bantamweight
+07/13/2016,Eric Spicely,Sam Alvey,Blue,Middleweight
+07/13/2016,Cortney Casey,Cristina Stanciu,Red,Women's Strawweight
+07/13/2016,Cody Pfister,Scott Holtzman,Blue,Lightweight
+07/13/2016,Rani Yahya,Matthew Lopez,Red,Bantamweight
+07/13/2016,Alex Nicholson,Devin Clark,Red,Middleweight
+07/09/2016,Miesha Tate,Amanda Nunes,Blue,UFC Women's Bantamweight Title
+07/09/2016,Anderson Silva,Daniel Cormier,Blue,Light Heavyweight
+07/09/2016,Frankie Edgar,Jose Aldo,Blue,UFC Interim Featherweight Title
+07/09/2016,Travis Browne,Cain Velasquez,Blue,Heavyweight
+07/09/2016,Julianna Pena,Cat Zingano,Red,Women's Bantamweight
+07/09/2016,Kelvin Gastelum,Johny Hendricks,Red,Welterweight
+07/09/2016,Raphael Assuncao,TJ Dillashaw,Blue,Bantamweight
+07/09/2016,Enrique Marin,Sage Northcutt,Blue,Lightweight
+07/09/2016,Diego Sanchez,Joe Lauzon,Blue,Lightweight
+07/09/2016,Thiago Santos,Gegard Mousasi,Blue,Middleweight
+07/09/2016,Jim Miller,Takanori Gomi,Red,Lightweight
+07/08/2016,Claudia Gadelha,Joanna Jedrzejczyk,Blue,UFC Women's Strawweight Title
+07/08/2016,Khalil Rountree Jr.,Andrew Sanchez,Blue,Ultimate Fighter 23 Light Heavyweight Tournament Title
+07/08/2016,Amanda Cooper,Tatiana Suarez,Blue,Ultimate Fighter 23 Women's Strawweight Tournament Title
+07/08/2016,Will Brooks,Ross Pearson,Red,Lightweight
+07/08/2016,Thiago Tavares,Dooho Choi,Blue,Featherweight
+07/08/2016,Joaquim Silva,Andrew Holbrook,Red,Lightweight
+07/08/2016,Fernando Bruno,Gray Maynard,Blue,Featherweight
+07/08/2016,John Moraga,Matheus Nicolau,Blue,Flyweight
+07/08/2016,Cory Hendricks,Josh Stansbury,Blue,Light Heavyweight
+07/08/2016,Cezar Ferreira,Anthony Smith,Red,Middleweight
+07/08/2016,Kevin Lee,Jake Matthews,Red,Lightweight
+07/08/2016,Li Jingliang,Anton Zafir,Red,Welterweight
+07/07/2016,Eddie Alvarez,Rafael Dos Anjos,Red,UFC Lightweight Title
+07/07/2016,Derrick Lewis,Roy Nelson,Red,Heavyweight
+07/07/2016,Belal Muhammad,Alan Jouban,Blue,Welterweight
+07/07/2016,Mitch Clarke,Joe Duffy,Blue,Lightweight
+07/07/2016,Mike Pyle,Alberto Mina,Blue,Welterweight
+07/07/2016,John Makdessi,Mehdi Baghdad,Red,Lightweight
+07/07/2016,Dileno Lopes,Anthony Birchak,Blue,Bantamweight
+07/07/2016,Russell Doane,Pedro Munhoz,Blue,Bantamweight
+07/07/2016,Felipe Arantes,Jerrod Sanders,Red,Bantamweight
+07/07/2016,Gilbert Burns,Lukasz Sajewski,Red,Lightweight
+07/07/2016,Reginaldo Vieira,Marco Beltran,Blue,Bantamweight
+07/07/2016,Alvaro Herrera Mendoza,Vicente Luque,Blue,Welterweight
+06/18/2016,Rory MacDonald,Stephen Thompson,Blue,Welterweight
+06/18/2016,Donald Cerrone,Patrick Cote,Red,Welterweight
+06/18/2016,Sean O'Connell,Steve Bosse,Blue,Light Heavyweight
+06/18/2016,Thibault Gouti,Olivier Aubin-Mercier,Blue,Lightweight
+06/18/2016,Valerie Letourneau,Joanne Wood,Blue,Women's Flyweight
+06/18/2016,Leandro Silva,Jason Saggo,Blue,Lightweight
+06/18/2016,Ion Cutelaba,Misha Cirkunov,Blue,Light Heavyweight
+06/18/2016,Krzysztof Jotko,Tamdan McCrory,Red,Middleweight
+06/18/2016,Chris Beal,Joe Soto,Blue,Bantamweight
+06/18/2016,Sam Alvey,Elias Theodorou,Blue,Middleweight
+06/18/2016,Randa Markos,Jocelyn Jones-Lybarger,Red,Women's Strawweight
+06/18/2016,Jonathan Meunier,Colby Covington,Blue,Welterweight
+06/18/2016,Ali Bagautinov,Geane Herrera,Red,Flyweight
+06/04/2016,Luke Rockhold,Michael Bisping,Blue,UFC Middleweight Title
+06/04/2016,Dominick Cruz,Urijah Faber,Red,UFC Bantamweight Title
+06/04/2016,Max Holloway,Ricardo Lamas,Red,Featherweight
+06/04/2016,Dan Henderson,Hector Lombard,Red,Middleweight
+06/04/2016,Dustin Poirier,Bobby Green,Red,Lightweight
+06/04/2016,Brian Ortega,Clay Guida,Red,Featherweight
+06/04/2016,Beneil Dariush,James Vick,Red,Lightweight
+06/04/2016,Jessica Penne,Jessica Andrade,Blue,Women's Strawweight
+06/04/2016,Cole Miller,Alex Caceres,Blue,Featherweight
+06/04/2016,Sean Strickland,Tom Breese,Red,Welterweight
+06/04/2016,Henrique da Silva,Jonathan Wilson,Red,Light Heavyweight
+06/04/2016,Marco Polo Reyes,Dong Hyun Ma,Red,Lightweight
+05/29/2016,Cody Garbrandt,Thomas Almeida,Red,Bantamweight
+05/29/2016,Jeremy Stephens,Renan Barao,Red,Featherweight
+05/29/2016,Tarec Saffiedine,Rick Story,Blue,Welterweight
+05/29/2016,Vitor Miranda,Chris Camozzi,Blue,Middleweight
+05/29/2016,Lorenz Larkin,Jorge Masvidal,Red,Welterweight
+05/29/2016,Paul Felder,Joshua Burkman,Red,Lightweight
+05/29/2016,Sara McMann,Jessica Eye,Red,Women's Bantamweight
+05/29/2016,Jordan Rinaldi,Abel Trujillo,Blue,Lightweight
+05/29/2016,Jake Collier,Alberto Uda,Red,Middleweight
+05/29/2016,Shane Campbell,Erik Koch,Blue,Lightweight
+05/29/2016,Bryan Caraway,Aljamain Sterling,Red,Bantamweight
+05/29/2016,Adam Milstead,Chris de la Rocha,Red,Heavyweight
+05/14/2016,Fabricio Werdum,Stipe Miocic,Blue,UFC Heavyweight Title
+05/14/2016,Jacare Souza,Vitor Belfort,Red,Middleweight
+05/14/2016,Cristiane Justino,Leslie Smith,Red,Catch Weight
+05/14/2016,Corey Anderson,Mauricio Rua,Blue,Light Heavyweight
+05/14/2016,Bryan Barberena,Warlley Alves,Red,Welterweight
+05/14/2016,Matt Brown,Demian Maia,Blue,Welterweight
+05/14/2016,Thiago Santos,Nate Marquardt,Red,Middleweight
+05/14/2016,Yancy Medeiros,Francisco Trinaldo,Blue,Lightweight
+05/14/2016,Rob Font,John Lineker,Blue,Bantamweight
+05/14/2016,Patrick Cummins,Rogerio Nogueira,Blue,Light Heavyweight
+05/14/2016,Renato Moicano,Zubaira Tukhugov,Red,Featherweight
+05/08/2016,Alistair Overeem,Andrei Arlovski,Red,Heavyweight
+05/08/2016,Antonio Silva,Stefan Struve,Blue,Heavyweight
+05/08/2016,Albert Tumenov,Gunnar Nelson,Blue,Welterweight
+05/08/2016,Germaine de Randamie,Anna Elmose,Red,Women's Bantamweight
+05/08/2016,Francimar Barroso,Nikita Krylov,Blue,Light Heavyweight
+05/08/2016,Heather Clark,Karolina Kowalkiewicz,Blue,Women's Strawweight
+05/08/2016,Chris Wade,Rustam Khabilov,Blue,Lightweight
+05/08/2016,Magnus Cedenblad,Garreth McLellan,Red,Middleweight
+05/08/2016,Jon Tuck,Josh Emmett,Blue,Lightweight
+05/08/2016,Yan Cabral,Reza Madadi,Blue,Lightweight
+05/08/2016,Kyoji Horiguchi,Neil Seery,Red,Flyweight
+05/08/2016,Leon Edwards,Dominic Waters,Red,Welterweight
+05/08/2016,Willie Gates,Yuta Sasaki,Blue,Flyweight
+04/23/2016,Jon Jones,Ovince Saint Preux,Red,UFC Interim Light Heavyweight Title
+04/23/2016,Henry Cejudo,Demetrious Johnson,Blue,UFC Flyweight Title
+04/23/2016,Edson Barboza,Anthony Pettis,Red,Lightweight
+04/23/2016,Robert Whittaker,Rafael Natal,Red,Middleweight
+04/23/2016,Yair Rodriguez,Andre Fili,Red,Featherweight
+04/23/2016,Chris Kelades,Sergio Pettis,Blue,Flyweight
+04/23/2016,Dominique Steele,Danny Roberts,Blue,Welterweight
+04/23/2016,Carla Esparza,Juliana Lima,Red,Women's Strawweight
+04/23/2016,Glaico Franca Moreira,James Vick,Blue,Lightweight
+04/23/2016,Walt Harris,Cody East,Red,Heavyweight
+04/23/2016,Clint Hester,Marcos Rogerio de Lima,Blue,Light Heavyweight
+04/23/2016,Kevin Lee,Efrain Escudero,Red,Lightweight
+04/16/2016,Glover Teixeira,Rashad Evans,Red,Light Heavyweight
+04/16/2016,Tecia Torres,Rose Namajunas,Blue,Women's Strawweight
+04/16/2016,Darrell Horcher,Khabib Nurmagomedov,Blue,Catch Weight
+04/16/2016,Cub Swanson,Hacran Dias,Red,Featherweight
+04/16/2016,Michael Chiesa,Beneil Dariush,Red,Lightweight
+04/16/2016,Raquel Pennington,Bethe Correia,Red,Women's Bantamweight
+04/16/2016,Santiago Ponzinibbio,Court McGee,Red,Welterweight
+04/16/2016,Michael Graves,Randy Brown,Red,Welterweight
+04/16/2016,John Dodson,Manvel Gamburyan,Red,Bantamweight
+04/16/2016,Cezar Ferreira,Oluwale Bamgbose,Red,Middleweight
+04/16/2016,Elizeu Zaleski dos Santos,Omari Akhmedov,Red,Welterweight
+04/10/2016,Junior Dos Santos,Ben Rothwell,Red,Heavyweight
+04/10/2016,Gabriel Gonzaga,Derrick Lewis,Blue,Heavyweight
+04/10/2016,Francis Ngannou,Curtis Blaydes,Red,Heavyweight
+04/10/2016,Marcin Tybura,Timothy Johnson,Blue,Heavyweight
+04/10/2016,Jan Blachowicz,Igor Pokrajac,Red,Light Heavyweight
+04/10/2016,Cristina Stanciu,Maryna Moroz,Blue,Women's Strawweight
+04/10/2016,Nicolas Dalby,Zak Cummings,Blue,Welterweight
+04/10/2016,Ian Entwistle,Alejandro Perez,Blue,Bantamweight
+04/10/2016,Mairbek Taisumov,Damir Hadzovic,Red,Lightweight
+04/10/2016,Filip Pejic,Damian Stasiak,Blue,Bantamweight
+04/10/2016,Lucas Martins,Robert Whiteford,Red,Featherweight
+04/10/2016,Jared Cannonier,Cyril Asker,Red,Heavyweight
+04/10/2016,Bojan Velickovic,Alessio Di Chirico,Red,Middleweight
+03/19/2016,Frank Mir,Mark Hunt,Blue,Heavyweight
+03/19/2016,Neil Magny,Hector Lombard,Red,Welterweight
+03/19/2016,Jake Matthews,Johnny Case,Red,Lightweight
+03/19/2016,Antonio Carlos Junior,Daniel Kelly,Blue,Middleweight
+03/19/2016,James Te Huna,Steve Bosse,Blue,Light Heavyweight
+03/19/2016,Seo Hee Ham,Bec Rawlings,Blue,Women's Strawweight
+03/19/2016,Alan Jouban,Brendan O'Reilly,Red,Welterweight
+03/19/2016,Mark Eddiva,Dan Hooker,Blue,Featherweight
+03/19/2016,Leslie Smith,Rin Nakai,Red,Women's Bantamweight
+03/19/2016,Richard Walsh,Viscardi Andrade,Blue,Welterweight
+03/19/2016,Ross Pearson,Chad Laprise,Red,Lightweight
+03/19/2016,Damien Brown,Alan Patrick,Blue,Lightweight
+03/05/2016,Nate Diaz,Conor McGregor,Red,Welterweight
+03/05/2016,Miesha Tate,Holly Holm,Red,UFC Women's Bantamweight Title
+03/05/2016,Gian Villante,Ilir Latifi,Blue,Light Heavyweight
+03/05/2016,Tom Lawlor,Corey Anderson,Blue,Light Heavyweight
+03/05/2016,Amanda Nunes,Valentina Shevchenko,Red,Women's Bantamweight
+03/05/2016,Siyar Bahadurzada,Brandon Thatch,Red,Welterweight
+03/05/2016,Erick Silva,Nordine Taleb,Blue,Welterweight
+03/05/2016,Marcelo Guimaraes,Vitor Miranda,Blue,Middleweight
+03/05/2016,Chas Skelly,Darren Elkins,Blue,Featherweight
+03/05/2016,Diego Sanchez,Jim Miller,Red,Lightweight
+03/05/2016,Jason Saggo,Justin Salas,Red,Lightweight
+03/05/2016,Teruto Ishihara,Julian Erosa,Red,Featherweight
+02/27/2016,Michael Bisping,Anderson Silva,Red,Middleweight
+02/27/2016,Thales Leites,Gegard Mousasi,Blue,Middleweight
+02/27/2016,Keita Nakamura,Tom Breese,Blue,Welterweight
+02/27/2016,Brad Pickett,Francisco Rivera,Red,Bantamweight
+02/27/2016,Makwan Amirkhani,Mike Wilkinson,Red,Featherweight
+02/27/2016,Marlon Vera,Davey Grant,Blue,Bantamweight
+02/27/2016,Chris Dempsey,Scott Askham,Blue,Middleweight
+02/27/2016,Arnold Allen,Yaotzin Meza,Red,Featherweight
+02/27/2016,Brad Scott,Krzysztof Jotko,Blue,Middleweight
+02/27/2016,Rustam Khabilov,Norman Parke,Red,Lightweight
+02/27/2016,Daniel Omielanczuk,Jarjis Danho,Red,Heavyweight
+02/27/2016,Thibault Gouti,Teemu Packalen,Blue,Lightweight
+02/27/2016,David Teymur,Martin Svensson,Red,Lightweight
+02/21/2016,Alex Oliveira,Donald Cerrone,Blue,Welterweight
+02/21/2016,Derek Brunson,Roan Carneiro,Red,Middleweight
+02/21/2016,Cody Garbrandt,Augusto Mendes,Red,Catch Weight
+02/21/2016,Tatsuya Kawajiri,Dennis Bermudez,Blue,Featherweight
+02/21/2016,Chris Camozzi,Joe Riggs,Red,Middleweight
+02/21/2016,James Krause,Shane Campbell,Red,Lightweight
+02/21/2016,Alex Garcia,Sean Strickland,Blue,Welterweight
+02/21/2016,Daniel Sarafian,Oluwale Bamgbose,Blue,Middleweight
+02/21/2016,Anthony Smith,Leonardo Guimaraes,Red,Middleweight
+02/21/2016,Jonavin Webb,Nathan Coy,Blue,Welterweight
+02/21/2016,Marion Reneau,Ashlee Evans-Smith,Blue,Women's Bantamweight
+02/21/2016,Kelly Faszholz,Lauren Murphy,Blue,Women's Bantamweight
+02/21/2016,Shamil Abdurakhimov,Anthony Hamilton,Red,Heavyweight
+02/06/2016,Johny Hendricks,Stephen Thompson,Blue,Welterweight
+02/06/2016,Jared Rosholt,Roy Nelson,Blue,Heavyweight
+02/06/2016,Ovince Saint Preux,Rafael Cavalcante,Red,Light Heavyweight
+02/06/2016,Zach Makovsky,Joseph Benavidez,Blue,Flyweight
+02/06/2016,Misha Cirkunov,Alex Nicholson,Red,Light Heavyweight
+02/06/2016,Sean Spencer,Mike Pyle,Blue,Welterweight
+02/06/2016,Joshua Burkman,KJ Noons,Red,Lightweight
+02/06/2016,Derrick Lewis,Damian Grabowski,Red,Heavyweight
+02/06/2016,Justin Scoggins,Ray Borg,Red,Flyweight
+02/06/2016,Diego Rivas,Noad Lahat,Red,Featherweight
+02/06/2016,Mickey Gall,Mike Jackson,Red,Welterweight
+02/06/2016,Artem Lobov,Alex White,Blue,Featherweight
+01/30/2016,Anthony Johnson,Ryan Bader,Red,Light Heavyweight
+01/30/2016,Ben Rothwell,Josh Barnett,Red,Heavyweight
+01/30/2016,Jimmie Rivera,Iuri Alcantara,Red,Bantamweight
+01/30/2016,Sage Northcutt,Bryan Barberena,Blue,Welterweight
+01/30/2016,Tarec Saffiedine,Jake Ellenberger,Red,Welterweight
+01/30/2016,Olivier Aubin-Mercier,Diego Ferreira,Blue,Lightweight
+01/30/2016,Rafael Natal,Kevin Casey,Red,Middleweight
+01/30/2016,Dustin Ortiz,Wilson Reis,Blue,Flyweight
+01/30/2016,George Sullivan,Alexander Yakovlev,Blue,Welterweight
+01/30/2016,Masio Fullen,Alex Caceres,Blue,Featherweight
+01/30/2016,Randy Brown,Matt Dwyer,Red,Welterweight
+01/30/2016,Anthony Rocco Martin,Felipe Olivieri,Red,Lightweight
+01/17/2016,TJ Dillashaw,Dominick Cruz,Blue,UFC Bantamweight Title
+01/17/2016,Eddie Alvarez,Anthony Pettis,Red,Lightweight
+01/17/2016,Matt Mitrione,Travis Browne,Blue,Heavyweight
+01/17/2016,Francisco Trinaldo,Ross Pearson,Red,Lightweight
+01/17/2016,Patrick Cote,Ben Saunders,Red,Welterweight
+01/17/2016,Tim Boetsch,Ed Herman,Blue,Light Heavyweight
+01/17/2016,Mehdi Baghdad,Chris Wade,Blue,Lightweight
+01/17/2016,Luke Sanders,Maximo Blanco,Red,Featherweight
+01/17/2016,Paul Felder,Daron Cruickshank,Red,Lightweight
+01/17/2016,Ilir Latifi,Sean O'Connell,Red,Light Heavyweight
+01/17/2016,Kyle Bochniak,Charles Rosa,Blue,Featherweight
+01/17/2016,Joey Gomez,Rob Font,Blue,Bantamweight
+01/17/2016,Francimar Barroso,Elvis Mutapcic,Red,Light Heavyweight
+01/02/2016,Robbie Lawler,Carlos Condit,Red,UFC Welterweight Title
+01/02/2016,Andrei Arlovski,Stipe Miocic,Blue,Heavyweight
+01/02/2016,Albert Tumenov,Lorenz Larkin,Red,Welterweight
+01/02/2016,Brian Ortega,Diego Brandao,Red,Featherweight
+01/02/2016,Abel Trujillo,Tony Sims,Red,Lightweight
+01/02/2016,Masanori Kanehara,Michael McDonald,Blue,Bantamweight
+01/02/2016,Alex Morono,Kyle Noke,Red,Welterweight
+01/02/2016,Justine Kish,Nina Nunes,Red,Women's Strawweight
+01/02/2016,Drew Dober,Scott Holtzman,Red,Lightweight
+01/02/2016,Joe Duffy,Dustin Poirier,Blue,Lightweight
+01/02/2016,Michinori Tanaka,Joe Soto,Red,Bantamweight
+01/02/2016,Sheldon Westcott,Edgar Garcia,Red,Welterweight
+12/19/2015,Rafael Dos Anjos,Donald Cerrone,Red,UFC Lightweight Title
+12/19/2015,Junior Dos Santos,Alistair Overeem,Blue,Heavyweight
+12/19/2015,Michael Johnson,Nate Diaz,Blue,Lightweight
+12/19/2015,Randa Markos,Karolina Kowalkiewicz,Blue,Women's Strawweight
+12/19/2015,Charles Oliveira,Myles Jury,Red,Featherweight
+12/19/2015,Nate Marquardt,CB Dollaway,Red,Middleweight
+12/19/2015,Sarah Kaufman,Valentina Shevchenko,Blue,Women's Bantamweight
+12/19/2015,Tamdan McCrory,Josh Samman,Red,Middleweight
+12/19/2015,Danny Castillo,Nik Lentz,Blue,Lightweight
+12/19/2015,Kamaru Usman,Leon Edwards,Red,Welterweight
+12/19/2015,Vicente Luque,Hayder Hassan,Red,Welterweight
+12/19/2015,Francis Ngannou,Luis Henrique,Red,Heavyweight
+12/12/2015,Jose Aldo,Conor McGregor,Blue,UFC Featherweight Title
+12/12/2015,Chris Weidman,Luke Rockhold,Blue,UFC Middleweight Title
+12/12/2015,Yoel Romero,Jacare Souza,Red,Middleweight
+12/12/2015,Demian Maia,Gunnar Nelson,Red,Welterweight
+12/12/2015,Jeremy Stephens,Max Holloway,Blue,Featherweight
+12/12/2015,Frankie Saenz,Urijah Faber,Blue,Bantamweight
+12/12/2015,Jocelyn Jones-Lybarger,Tecia Torres,Blue,Women's Strawweight
+12/12/2015,Colby Covington,Warlley Alves,Blue,Welterweight
+12/12/2015,Kevin Lee,Leonardo Santos,Blue,Lightweight
+12/12/2015,Magomed Mustafaev,Joe Proctor,Red,Lightweight
+12/12/2015,John Makdessi,Yancy Medeiros,Blue,Lightweight
+12/12/2015,Marcio Alexandre Junior,Court McGee,Blue,Welterweight
+12/11/2015,Chad Mendes,Frankie Edgar,Blue,Featherweight
+12/11/2015,Artem Lobov,Ryan Hall,Blue,Ultimate Fighter 22 Lightweight Tournament Title
+12/11/2015,Tony Ferguson,Edson Barboza,Red,Lightweight
+12/11/2015,Joe Lauzon,Evan Dunham,Blue,Lightweight
+12/11/2015,Jason Knight,Tatsuya Kawajiri,Blue,Featherweight
+12/11/2015,Marcin Wrzosek,Julian Erosa,Blue,Lightweight
+12/11/2015,Konstantin Erokhin,Gabriel Gonzaga,Blue,Heavyweight
+12/11/2015,Ryan LaFlare,Mike Pierce,Red,Welterweight
+12/11/2015,Joby Sanchez,Geane Herrera,Blue,Flyweight
+12/11/2015,Chris Gruetzemacher,Abner Lloveras,Red,Lightweight
+12/10/2015,Rose Namajunas,Paige VanZant,Red,Women's Strawweight
+12/10/2015,Michael Chiesa,Jim Miller,Red,Lightweight
+12/10/2015,Sage Northcutt,Cody Pfister,Red,Lightweight
+12/10/2015,Elias Theodorou,Thiago Santos,Blue,Middleweight
+12/10/2015,John Howard,Tim Means,Blue,Welterweight
+12/10/2015,Omari Akhmedov,Sergio Moraes,Blue,Welterweight
+12/10/2015,Aljamain Sterling,Johnny Eduardo,Red,Bantamweight
+12/10/2015,Andreas Stahl,Santiago Ponzinibbio,Blue,Welterweight
+12/10/2015,Nathan Coy,Danny Roberts,Blue,Welterweight
+12/10/2015,Zubaira Tukhugov,Phillipe Nover,Red,Featherweight
+12/10/2015,Emily Kagan,Kailin Curran,Blue,Women's Strawweight
+11/28/2015,Jorge Masvidal,Benson Henderson,Blue,Welterweight
+11/28/2015,Dominic Waters,Dong Hyun Kim,Blue,Welterweight
+11/28/2015,Yoshihiro Akiyama,Alberto Mina,Blue,Welterweight
+11/28/2015,Sam Sicilia,Dooho Choi,Blue,Featherweight
+11/28/2015,Dongi Yang,Jake Collier,Red,Middleweight
+11/28/2015,Yui Chul Nam,Mike de la Torre,Blue,Featherweight
+11/28/2015,Tae Hyun Bang,Leo Kuntz,Red,Lightweight
+11/28/2015,Cortney Casey,Seo Hee Ham,Blue,Women's Strawweight
+11/28/2015,Fredy Serrano,Yao Zhikui,Red,Flyweight
+11/28/2015,Marco Beltran,Guangyou Ning,Red,Bantamweight
+11/28/2015,Dominique Steele,Dong Hyun Ma,Red,Welterweight
+11/21/2015,Neil Magny,Kelvin Gastelum,Red,Welterweight
+11/21/2015,Ricardo Lamas,Diego Sanchez,Red,Featherweight
+11/21/2015,Jussier Formiga,Henry Cejudo,Blue,Flyweight
+11/21/2015,Enrique Marin,Erick Montano,Blue,Ultimate Fighter Latin America 2 Welterweight Tournament Title
+11/21/2015,Horacio Gutierrez,Enrique Barzola,Blue,Ultimate Fighter Latin America 2 Lightweight Tournament Title
+11/21/2015,Efrain Escudero,Leandro Silva,Blue,Lightweight
+11/21/2015,Taylor Lapilus,Erik Perez,Blue,Bantamweight
+11/21/2015,Bartosz Fabinski,Hector Urbina,Red,Welterweight
+11/21/2015,Alejandro Perez,Scott Jorgensen,Red,Bantamweight
+11/21/2015,Gabriel Benitez,Andre Fili,Blue,Featherweight
+11/21/2015,Alvaro Herrera Mendoza,Vernon Ramos Ho,Red,Welterweight
+11/21/2015,Cesar Arzamendia,Marco Polo Reyes,Blue,Lightweight
+11/21/2015,Valmir Lazaro,Michel Prazeres,Blue,Lightweight
+11/14/2015,Holly Holm,Ronda Rousey,Red,UFC Women's Bantamweight Title
+11/14/2015,Joanna Jedrzejczyk,Valerie Letourneau,Red,UFC Women's Strawweight Title
+11/14/2015,Mark Hunt,Antonio Silva,Red,Heavyweight
+11/14/2015,Robert Whittaker,Uriah Hall,Red,Middleweight
+11/14/2015,Stefan Struve,Jared Rosholt,Blue,Heavyweight
+11/14/2015,Jake Matthews,Akbarh Arreola,Red,Lightweight
+11/14/2015,Kyle Noke,Peter Sobotta,Red,Welterweight
+11/14/2015,Anthony Perosh,Gian Villante,Blue,Light Heavyweight
+11/14/2015,Richie Vaculik,Danny Martinez,Blue,Flyweight
+11/14/2015,Daniel Kelly,Steve Montgomery,Red,Middleweight
+11/14/2015,Steve Kennedy,Richard Walsh,Blue,Welterweight
+11/14/2015,Anton Zafir,James Moontasri,Blue,Welterweight
+11/14/2015,Ben Nguyen,Ryan Benoit,Red,Flyweight
+11/07/2015,Vitor Belfort,Dan Henderson,Red,Middleweight
+11/07/2015,Glover Teixeira,Patrick Cummins,Red,Light Heavyweight
+11/07/2015,Anthony Birchak,Thomas Almeida,Blue,Bantamweight
+11/07/2015,Piotr Hallmann,Alex Oliveira,Blue,Lightweight
+11/07/2015,Gilbert Burns,Rashid Magomedov,Blue,Lightweight
+11/07/2015,Corey Anderson,Fabio Maldonado,Red,Light Heavyweight
+11/07/2015,Gleison Tibau,Abel Trujillo,Blue,Lightweight
+11/07/2015,Yan Cabral,Johnny Case,Blue,Lightweight
+11/07/2015,Clay Guida,Thiago Tavares,Blue,Featherweight
+11/07/2015,Edimilson Souza,Chas Skelly,Blue,Featherweight
+11/07/2015,Viscardi Andrade,Gasan Umalatov,Red,Welterweight
+11/07/2015,Jimmie Rivera,Pedro Munhoz,Red,Bantamweight
+11/07/2015,Matheus Nicolau,Bruno Korea,Red,Bantamweight
+10/24/2015,Paddy Holohan,Louis Smolka,Blue,Flyweight
+10/24/2015,Norman Parke,Reza Madadi,Red,Lightweight
+10/24/2015,Neil Seery,Jon Delos Reyes,Red,Flyweight
+10/24/2015,Stevie Ray,Mickael Lebout,Red,Lightweight
+10/24/2015,Ericka Almeida,Aisling Daly,Blue,Women's Strawweight
+10/24/2015,Scott Askham,Krzysztof Jotko,Blue,Middleweight
+10/24/2015,Tom Breese,Cathal Pendred,Red,Welterweight
+10/24/2015,Robert Whiteford,Darren Elkins,Blue,Featherweight
+10/24/2015,Bubba Bush,Garreth McLellan,Blue,Middleweight
+10/03/2015,Alexander Gustafsson,Daniel Cormier,Blue,UFC Light Heavyweight Title
+10/03/2015,Ryan Bader,Rashad Evans,Red,Light Heavyweight
+10/03/2015,Ruslan Magomedov,Shawn Jordan,Red,Heavyweight
+10/03/2015,Joseph Benavidez,Ali Bagautinov,Red,Flyweight
+10/03/2015,Julianna Pena,Jessica Eye,Red,Women's Bantamweight
+10/03/2015,Dan Hooker,Yair Rodriguez,Blue,Featherweight
+10/03/2015,Alan Jouban,Albert Tumenov,Blue,Welterweight
+10/03/2015,Islam Makhachev,Adriano Martins,Blue,Lightweight
+10/03/2015,Angela Hill,Rose Namajunas,Blue,Women's Strawweight
+10/03/2015,Francisco Trevino,Sage Northcutt,Blue,Lightweight
+10/03/2015,Chris Cariaso,Sergio Pettis,Blue,Flyweight
+10/03/2015,Derrick Lewis,Viktor Pesta,Red,Heavyweight
+09/26/2015,Roy Nelson,Josh Barnett,Blue,Heavyweight
+09/26/2015,Uriah Hall,Gegard Mousasi,Red,Middleweight
+09/26/2015,Kyoji Horiguchi,Chico Camus,Red,Flyweight
+09/26/2015,George Roop,Takeya Mizugaki,Blue,Bantamweight
+09/26/2015,Katsunori Kikuno,Diego Brandao,Blue,Featherweight
+09/26/2015,Keita Nakamura,Li Jingliang,Red,Welterweight
+09/26/2015,Nick Hein,Yusuke Kasuya,Red,Lightweight
+09/26/2015,Kajan Johnson,Naoyuki Kotani,Red,Lightweight
+09/26/2015,Shinsho Anzai,Roger Zapata,Red,Welterweight
+09/05/2015,Demetrious Johnson,John Dodson,Red,UFC Flyweight Title
+09/05/2015,Frank Mir,Andrei Arlovski,Blue,Heavyweight
+09/05/2015,Jimi Manuwa,Anthony Johnson,Blue,Light Heavyweight
+09/05/2015,Corey Anderson,Jan Blachowicz,Red,Light Heavyweight
+09/05/2015,Paige VanZant,Alex Chambers,Red,Women's Strawweight
+09/05/2015,Paul Felder,Ross Pearson,Blue,Lightweight
+09/05/2015,John Lineker,Francisco Rivera,Red,Bantamweight
+09/05/2015,Raquel Pennington,Jessica Andrade,Red,Women's Bantamweight
+09/05/2015,Tiago dos Santos e Silva,Clay Collard,Red,Featherweight
+09/05/2015,Joe Riggs,Ron Stallings,Red,Middleweight
+09/05/2015,Nazareno Malegarie,Joaquim Silva,Blue,Lightweight
+08/23/2015,Charles Oliveira,Max Holloway,Blue,Featherweight
+08/23/2015,Erick Silva,Neil Magny,Blue,Welterweight
+08/23/2015,Joshua Burkman,Patrick Cote,Blue,Welterweight
+08/23/2015,Chad Laprise,Francisco Trinaldo,Blue,Lightweight
+08/23/2015,Olivier Aubin-Mercier,Tony Sims,Red,Lightweight
+08/23/2015,Maryna Moroz,Valerie Letourneau,Blue,Women's Strawweight
+08/23/2015,Frankie Perez,Sam Stout,Red,Lightweight
+08/23/2015,Felipe Arantes,Yves Jabouin,Red,Bantamweight
+08/23/2015,Marcos Rogerio de Lima,Nikita Krylov,Blue,Light Heavyweight
+08/23/2015,Chris Kelades,Chris Beal,Red,Flyweight
+08/23/2015,Elias Silverio,Shane Campbell,Blue,Lightweight
+08/23/2015,Daniel Jolly,Misha Cirkunov,Blue,Light Heavyweight
+08/08/2015,Glover Teixeira,Ovince Saint Preux,Red,Light Heavyweight
+08/08/2015,Michael Johnson,Beneil Dariush,Blue,Lightweight
+08/08/2015,Sam Alvey,Derek Brunson,Blue,Middleweight
+08/08/2015,Jared Rosholt,Timothy Johnson,Red,Heavyweight
+08/08/2015,Sara McMann,Amanda Nunes,Blue,Women's Bantamweight
+08/08/2015,Ray Borg,Geane Herrera,Red,Flyweight
+08/08/2015,Oluwale Bamgbose,Uriah Hall,Blue,Middleweight
+08/08/2015,Tom Watson,Chris Camozzi,Blue,Middleweight
+08/08/2015,Dustin Ortiz,Willie Gates,Red,Flyweight
+08/08/2015,Frankie Saenz,Sirwan Kakai,Red,Bantamweight
+08/08/2015,Chris Dempsey,Jonathan Wilson,Blue,Light Heavyweight
+08/08/2015,Marlon Vera,Roman Salazar,Red,Bantamweight
+08/08/2015,Scott Holtzman,Anthony Christodoulou,Red,Lightweight
+08/01/2015,Bethe Correia,Ronda Rousey,Blue,UFC Women's Bantamweight Title
+08/01/2015,Rogerio Nogueira,Mauricio Rua,Blue,Light Heavyweight
+08/01/2015,Fernando Bruno,Glaico Franca Moreira,Blue,Ultimate Fighter Brazil 4 Lightweight Tournament Title
+08/01/2015,Dileno Lopes,Reginaldo Vieira,Blue,Ultimate Fighter Brazil 4 Bantamweight Tournament Title
+08/01/2015,Antonio Rodrigo Nogueira,Stefan Struve,Blue,Heavyweight
+08/01/2015,Antonio Silva,Soa Palelei,Red,Heavyweight
+08/01/2015,Jessica Aguilar,Claudia Gadelha,Blue,Women's Strawweight
+08/01/2015,Demian Maia,Neil Magny,Red,Welterweight
+08/01/2015,Patrick Cummins,Rafael Cavalcante,Red,Light Heavyweight
+08/01/2015,Warlley Alves,Nordine Taleb,Red,Welterweight
+08/01/2015,Leandro Issa,Iuri Alcantara,Blue,Bantamweight
+08/01/2015,Clint Hester,Vitor Miranda,Blue,Middleweight
+08/01/2015,Guido Cannetti,Hugo Viana,Red,Bantamweight
+07/25/2015,Renan Barao,TJ Dillashaw,Blue,UFC Bantamweight Title
+07/25/2015,Miesha Tate,Jessica Eye,Red,Women's Bantamweight
+07/25/2015,Edson Barboza,Paul Felder,Red,Lightweight
+07/25/2015,Takanori Gomi,Joe Lauzon,Blue,Lightweight
+07/25/2015,Tom Lawlor,Gian Villante,Red,Light Heavyweight
+07/25/2015,Danny Castillo,Jim Miller,Blue,Lightweight
+07/25/2015,Ben Saunders,Kenny Robertson,Red,Welterweight
+07/25/2015,Bryan Caraway,Eddie Wineland,Red,Bantamweight
+07/25/2015,Daron Cruickshank,James Krause,Blue,Lightweight
+07/25/2015,Andrew Holbrook,Ramsey Nijem,Red,Lightweight
+07/25/2015,Jessamyn Duke,Elizabeth Phillips,Blue,Women's Bantamweight
+07/25/2015,Dominique Steele,Zak Cummings,Blue,Middleweight
+07/18/2015,Thales Leites,Michael Bisping,Blue,Middleweight
+07/18/2015,Ross Pearson,Evan Dunham,Blue,Lightweight
+07/18/2015,Joe Duffy,Ivan Jorge,Red,Lightweight
+07/18/2015,Cortney Casey,Joanne Wood,Blue,Women's Strawweight
+07/18/2015,Pawel Pawlak,Leon Edwards,Blue,Welterweight
+07/18/2015,Leonardo Mafra,Stevie Ray,Blue,Lightweight
+07/18/2015,Vaughan Lee,Paddy Holohan,Blue,Flyweight
+07/18/2015,Hans Stringer,Ilir Latifi,Blue,Light Heavyweight
+07/18/2015,Mickael Lebout,Teemu Packalen,Red,Lightweight
+07/18/2015,Robert Whiteford,Paul Redmond,Red,Featherweight
+07/18/2015,Marcus Brimage,Jimmie Rivera,Blue,Bantamweight
+07/18/2015,Daniel Omielanczuk,Chris de la Rocha,Red,Heavyweight
+07/15/2015,Frank Mir,Todd Duffee,Red,Heavyweight
+07/15/2015,Josh Thomson,Tony Ferguson,Blue,Lightweight
+07/15/2015,Holly Holm,Marion Reneau,Red,Women's Bantamweight
+07/15/2015,Manvel Gamburyan,Scott Jorgensen,Red,Bantamweight
+07/15/2015,Kevin Lee,James Moontasri,Red,Lightweight
+07/15/2015,Alan Jouban,Matt Dwyer,Red,Welterweight
+07/15/2015,Yaotzin Meza,Sam Sicilia,Blue,Featherweight
+07/15/2015,Sarah Moras,Jessica Andrade,Blue,Women's Bantamweight
+07/15/2015,Rani Yahya,Masanori Kanehara,Red,Bantamweight
+07/15/2015,Igor Araujo,Sean Strickland,Blue,Welterweight
+07/15/2015,Ildemar Alcantara,Kevin Casey,Blue,Middleweight
+07/15/2015,Lyman Good,Andrew Craig,Red,Welterweight
+07/12/2015,Stephen Thompson,Jake Ellenberger,Red,Welterweight
+07/12/2015,Hayder Hassan,Kamaru Usman,Blue,Ultimate Fighter 21 Welterweight Tournament Title
+07/12/2015,Vicente Luque,Michael Graves,Blue,Welterweight
+07/12/2015,Jorge Masvidal,Cezar Ferreira,Red,Welterweight
+07/12/2015,Angela Magana,Michelle Waterson-Gomez,Blue,Women's Strawweight
+07/12/2015,Mike de la Torre,Maximo Blanco,Blue,Featherweight
+07/12/2015,Caio Magalhaes,Josh Samman,Blue,Middleweight
+07/12/2015,Russell Doane,Jerrod Sanders,Blue,Bantamweight
+07/12/2015,Trevor Smith,Dan Miller,Red,Middleweight
+07/12/2015,Dominic Waters,George Sullivan,Blue,Welterweight
+07/12/2015,Darrell Montague,Willie Gates,Blue,Flyweight
+07/11/2015,Conor McGregor,Chad Mendes,Red,UFC Interim Featherweight Title
+07/11/2015,Rory MacDonald,Robbie Lawler,Blue,UFC Welterweight Title
+07/11/2015,Jeremy Stephens,Dennis Bermudez,Red,Featherweight
+07/11/2015,Brandon Thatch,Gunnar Nelson,Blue,Welterweight
+07/11/2015,Brad Pickett,Thomas Almeida,Blue,Bantamweight
+07/11/2015,Matt Brown,Tim Means,Red,Welterweight
+07/11/2015,Mike Swick,Alex Garcia,Blue,Welterweight
+07/11/2015,John Howard,Cathal Pendred,Red,Welterweight
+07/11/2015,Cody Garbrandt,Henry Briones,Red,Bantamweight
+07/11/2015,Neil Seery,Louis Smolka,Blue,Flyweight
+07/11/2015,Yosdenis Cedeno,Cody Pfister,Blue,Lightweight
+06/27/2015,Lyoto Machida,Yoel Romero,Blue,Middleweight
+06/27/2015,Lorenz Larkin,Santiago Ponzinibbio,Red,Welterweight
+06/27/2015,Antonio Carlos Junior,Eddie Gordon,Red,Middleweight
+06/27/2015,Thiago Santos,Steve Bosse,Red,Middleweight
+06/27/2015,Hacran Dias,Levan Makashvili,Red,Featherweight
+06/27/2015,Alex Oliveira,Joe Merritt,Red,Welterweight
+06/27/2015,Lewis Gonzalez,Leandro Silva,Blue,Welterweight
+06/27/2015,Steve Montgomery,Tony Sims,Blue,Welterweight
+06/27/2015,Sirwan Kakai,Danny Martinez,Red,Bantamweight
+06/20/2015,Jessica Penne,Joanna Jedrzejczyk,Blue,UFC Women's Strawweight Title
+06/20/2015,Dennis Siver,Tatsuya Kawajiri,Blue,Featherweight
+06/20/2015,Steve Kennedy,Peter Sobotta,Blue,Welterweight
+06/20/2015,Lukasz Sajewski,Nick Hein,Blue,Lightweight
+06/20/2015,Masio Fullen,Makwan Amirkhani,Blue,Featherweight
+06/20/2015,Mairbek Taisumov,Alan Patrick,Red,Lightweight
+06/20/2015,Arnold Allen,Alan Omer,Red,Featherweight
+06/20/2015,Noad Lahat,Niklas Backstrom,Red,Featherweight
+06/20/2015,Antonio Dos Santos,Scott Askham,Blue,Middleweight
+06/20/2015,Piotr Hallmann,Magomed Mustafaev,Blue,Lightweight
+06/20/2015,Yuta Sasaki,Taylor Lapilus,Blue,Bantamweight
+06/13/2015,Fabricio Werdum,Cain Velasquez,Red,UFC Heavyweight Title
+06/13/2015,Eddie Alvarez,Gilbert Melendez,Red,Lightweight
+06/13/2015,Kelvin Gastelum,Nate Marquardt,Red,Middleweight
+06/13/2015,Charles Rosa,Yair Rodriguez,Blue,Featherweight
+06/13/2015,Tecia Torres,Angela Hill,Red,Women's Strawweight
+06/13/2015,Chico Camus,Henry Cejudo,Blue,Flyweight
+06/13/2015,Efrain Escudero,Drew Dober,Red,Lightweight
+06/13/2015,Alejandro Perez,Patrick Williams,Blue,Bantamweight
+06/13/2015,Francisco Trevino,Johnny Case,Blue,Lightweight
+06/13/2015,Augusto Montano,Cathal Pendred,Blue,Welterweight
+06/13/2015,Clay Collard,Gabriel Benitez,Blue,Featherweight
+06/06/2015,Tim Boetsch,Dan Henderson,Blue,Middleweight
+06/06/2015,Ben Rothwell,Matt Mitrione,Red,Heavyweight
+06/06/2015,Yancy Medeiros,Dustin Poirier,Blue,Lightweight
+06/06/2015,Thiago Tavares,Brian Ortega,Blue,Featherweight
+06/06/2015,Anthony Birchak,Joe Soto,Red,Bantamweight
+06/06/2015,Alex Caceres,Francisco Rivera,Blue,Bantamweight
+06/06/2015,Shawn Jordan,Derrick Lewis,Red,Heavyweight
+06/06/2015,Omari Akhmedov,Brian Ebersole,Red,Welterweight
+06/06/2015,Chris Wade,Christos Giagos,Red,Lightweight
+06/06/2015,Justin Edwards,Joe Proctor,Blue,Lightweight
+06/06/2015,Ricardo Abreu,Jake Collier,Blue,Middleweight
+06/06/2015,Jose Quinonez,Leonardo Morales,Red,Bantamweight
+05/30/2015,Thiago Alves,Carlos Condit,Blue,Welterweight
+05/30/2015,Charles Oliveira,Nik Lentz,Red,Featherweight
+05/30/2015,Alex Oliveira,KJ Noons,Red,Welterweight
+05/30/2015,Ryan Jimmo,Francimar Barroso,Blue,Light Heavyweight
+05/30/2015,Norman Parke,Francisco Trinaldo,Blue,Lightweight
+05/30/2015,Wendell Oliveira Marques,Darren Till,Blue,Welterweight
+05/30/2015,Wilson Reis,Jussier Formiga,Blue,Flyweight
+05/30/2015,Nicolas Dalby,Elizeu Zaleski dos Santos,Red,Welterweight
+05/30/2015,Lucas Martins,Mirsad Bektic,Blue,Featherweight
+05/30/2015,Ericka Almeida,Juliana Lima,Blue,Women's Strawweight
+05/30/2015,Luiz Dutra,Tom Breese,Blue,Welterweight
+05/23/2015,Daniel Cormier,Anthony Johnson,Red,UFC Light Heavyweight Title
+05/23/2015,Chris Weidman,Vitor Belfort,Red,UFC Middleweight Title
+05/23/2015,John Makdessi,Donald Cerrone,Blue,Lightweight
+05/23/2015,Andrei Arlovski,Travis Browne,Red,Heavyweight
+05/23/2015,John Moraga,Joseph Benavidez,Blue,Flyweight
+05/23/2015,John Dodson,Zach Makovsky,Red,Flyweight
+05/23/2015,Joshua Burkman,Dong Hyun Kim,Blue,Welterweight
+05/23/2015,Rafael Natal,Uriah Hall,Red,Middleweight
+05/23/2015,Mike Pyle,Colby Covington,Blue,Welterweight
+05/23/2015,Leo Kuntz,Islam Makhachev,Blue,Lightweight
+05/23/2015,Justin Scoggins,Josh Sampo,Red,Flyweight
+05/16/2015,Urijah Faber,Frankie Edgar,Blue,Featherweight
+05/16/2015,Constantinos Philippou,Gegard Mousasi,Blue,Middleweight
+05/16/2015,Mark Munoz,Luke Barnatt,Red,Middleweight
+05/16/2015,Hyun Gyu Lim,Neil Magny,Blue,Welterweight
+05/16/2015,Phillipe Nover,Yui Chul Nam,Red,Featherweight
+05/16/2015,Mark Eddiva,Levan Makashvili,Blue,Featherweight
+05/16/2015,Jon Tuck,Tae Hyun Bang,Red,Lightweight
+05/16/2015,Kajan Johnson,Zhang Lipeng,Red,Lightweight
+05/16/2015,Li Jingliang,Dhiego Lima,Red,Welterweight
+05/16/2015,Guangyou Ning,Royston Wee,Red,Bantamweight
+05/16/2015,Jon Delos Reyes,Roldan Sangcha'an,Red,Flyweight
+05/16/2015,Nolan Ticman,Yao Zhikui,Blue,Flyweight
+05/09/2015,Stipe Miocic,Mark Hunt,Red,Heavyweight
+05/09/2015,Robert Whittaker,Brad Tavares,Red,Middleweight
+05/09/2015,Anthony Perosh,Sean O'Connell,Blue,Light Heavyweight
+05/09/2015,James Vick,Jake Matthews,Red,Lightweight
+05/09/2015,Hatsu Hioki,Dan Hooker,Blue,Featherweight
+05/09/2015,Kyle Noke,Jonavin Webb,Red,Welterweight
+05/09/2015,Daniel Kelly,Sam Alvey,Blue,Middleweight
+05/09/2015,Bec Rawlings,Lisa Ellis,Red,Women's Strawweight
+05/09/2015,Dylan Andrews,Brad Scott,Blue,Middleweight
+05/09/2015,Kailin Curran,Alex Chambers,Blue,Women's Strawweight
+05/09/2015,Brendan O'Reilly,Vik Grujic,Red,Welterweight
+05/09/2015,Ben Nguyen,Alptekin Ozkilic,Red,Flyweight
+04/25/2015,Kyoji Horiguchi,Demetrious Johnson,Blue,UFC Flyweight Title
+04/25/2015,Fabio Maldonado,Quinton Jackson,Blue,Catch Weight
+04/25/2015,CB Dollaway,Michael Bisping,Blue,Middleweight
+04/25/2015,Shane Campbell,John Makdessi,Blue,Catch Weight
+04/25/2015,Thomas Almeida,Yves Jabouin,Red,Bantamweight
+04/25/2015,Patrick Cote,Joe Riggs,Red,Welterweight
+04/25/2015,Alexis Davis,Sarah Kaufman,Red,Women's Bantamweight
+04/25/2015,Chad Laprise,Bryan Barberena,Red,Lightweight
+04/25/2015,David Michaud,Olivier Aubin-Mercier,Blue,Lightweight
+04/25/2015,Chris Clements,Nordine Taleb,Blue,Welterweight
+04/25/2015,Valerie Letourneau,Jessica Rakoczy,Red,Women's Strawweight
+04/25/2015,Aisling Daly,Randa Markos,Blue,Women's Strawweight
+04/18/2015,Luke Rockhold,Lyoto Machida,Red,Middleweight
+04/18/2015,Jacare Souza,Chris Camozzi,Red,Middleweight
+04/18/2015,Max Holloway,Cub Swanson,Red,Featherweight
+04/18/2015,Felice Herrig,Paige VanZant,Blue,Women's Strawweight
+04/18/2015,Beneil Dariush,Jim Miller,Red,Lightweight
+04/18/2015,Patrick Cummins,Ovince Saint Preux,Blue,Light Heavyweight
+04/18/2015,Gian Villante,Corey Anderson,Red,Light Heavyweight
+04/18/2015,Aljamain Sterling,Takeya Mizugaki,Red,Bantamweight
+04/18/2015,George Sullivan,Tim Means,Blue,Welterweight
+04/18/2015,Diego Brandao,Jimy Hettes,Red,Featherweight
+04/18/2015,Eddie Gordon,Chris Dempsey,Blue,Middleweight
+04/11/2015,Mirko Filipovic,Gabriel Gonzaga,Red,Heavyweight
+04/11/2015,Jan Blachowicz,Jimi Manuwa,Blue,Light Heavyweight
+04/11/2015,Sheldon Westcott,Pawel Pawlak,Blue,Welterweight
+04/11/2015,Joanne Wood,Maryna Moroz,Blue,Women's Strawweight
+04/11/2015,Leon Edwards,Seth Baczynski,Red,Welterweight
+04/11/2015,Garreth McLellan,Bartosz Fabinski,Blue,Middleweight
+04/11/2015,Sergio Moraes,Mickael Lebout,Red,Welterweight
+04/11/2015,Damian Stasiak,Yaotzin Meza,Blue,Featherweight
+04/11/2015,Daniel Omielanczuk,Anthony Hamilton,Blue,Heavyweight
+04/11/2015,Izabela Badurek,Aleksandra Albu,Blue,Women's Strawweight
+04/11/2015,Stevie Ray,Marcin Bandel,Red,Lightweight
+04/11/2015,Rocky Lee,Taylor Lapilus,Blue,Featherweight
+04/04/2015,Chad Mendes,Ricardo Lamas,Red,Featherweight
+04/04/2015,Jorge Masvidal,Al Iaquinta,Blue,Lightweight
+04/04/2015,Mitch Clarke,Michael Chiesa,Blue,Lightweight
+04/04/2015,Milana Dudieva,Julianna Pena,Blue,Women's Bantamweight
+04/04/2015,Clay Guida,Robert Peralta,Red,Featherweight
+04/04/2015,Dustin Poirier,Diego Ferreira,Red,Lightweight
+04/04/2015,Lauren Murphy,Liz Carmouche,Blue,Women's Bantamweight
+04/04/2015,Gray Maynard,Alexander Yakovlev,Blue,Lightweight
+04/04/2015,Shamil Abdurakhimov,Timothy Johnson,Blue,Heavyweight
+04/04/2015,Ron Stallings,Justin Jones,Red,Middleweight
+03/21/2015,Ryan LaFlare,Demian Maia,Blue,Welterweight
+03/21/2015,Erick Silva,Josh Koscheck,Red,Welterweight
+03/21/2015,Leonardo Santos,Anthony Rocco Martin,Red,Lightweight
+03/21/2015,Shayna Baszler,Amanda Nunes,Blue,Women's Bantamweight
+03/21/2015,Gilbert Burns,Alex Oliveira,Red,Lightweight
+03/21/2015,Godofredo Pepey,Andre Fili,Red,Featherweight
+03/21/2015,Francisco Trinaldo,Akbarh Arreola,Red,Lightweight
+03/21/2015,Katsunori Kikuno,Edimilson Souza,Blue,Featherweight
+03/21/2015,Leonardo Mafra,Cain Carrizosa,Red,Lightweight
+03/21/2015,Jorge de Oliveira,Christos Giagos,Blue,Lightweight
+03/21/2015,Fredy Serrano,Bentley Syler,Red,Flyweight
+03/14/2015,Anthony Pettis,Rafael Dos Anjos,Blue,UFC Lightweight Title
+03/14/2015,Joanna Jedrzejczyk,Carla Esparza,Red,UFC Women's Strawweight Title
+03/14/2015,Johny Hendricks,Matt Brown,Red,Welterweight
+03/14/2015,Roy Nelson,Alistair Overeem,Blue,Heavyweight
+03/14/2015,Chris Cariaso,Henry Cejudo,Blue,Flyweight
+03/14/2015,Ross Pearson,Sam Stout,Red,Lightweight
+03/14/2015,Elias Theodorou,Roger Narvaez,Red,Middleweight
+03/14/2015,Daron Cruickshank,Beneil Dariush,Blue,Lightweight
+03/14/2015,Josh Copeland,Jared Rosholt,Blue,Heavyweight
+03/14/2015,Sergio Pettis,Ryan Benoit,Blue,Flyweight
+03/14/2015,Joe Duffy,Jake Lindsey,Red,Lightweight
+03/14/2015,Larissa Pacheco,Germaine de Randamie,Blue,Women's Bantamweight
+02/28/2015,Ronda Rousey,Cat Zingano,Red,UFC Women's Bantamweight Title
+02/28/2015,Raquel Pennington,Holly Holm,Blue,Women's Bantamweight
+02/28/2015,Jake Ellenberger,Josh Koscheck,Red,Welterweight
+02/28/2015,Richard Walsh,Alan Jouban,Blue,Welterweight
+02/28/2015,Tony Ferguson,Gleison Tibau,Red,Lightweight
+02/28/2015,Mark Munoz,Roan Carneiro,Blue,Middleweight
+02/28/2015,Tim Means,Dhiego Lima,Red,Welterweight
+02/28/2015,Derrick Lewis,Ruan Potts,Red,Heavyweight
+02/28/2015,James Krause,Valmir Lazaro,Blue,Lightweight
+02/28/2015,Alex Torres,Masio Fullen,Blue,Featherweight
+02/22/2015,Antonio Silva,Frank Mir,Blue,Heavyweight
+02/22/2015,Michael Johnson,Edson Barboza,Red,Lightweight
+02/22/2015,Sam Alvey,Cezar Ferreira,Red,Middleweight
+02/22/2015,Rustam Khabilov,Adriano Martins,Blue,Lightweight
+02/22/2015,Frankie Saenz,Iuri Alcantara,Red,Bantamweight
+02/22/2015,Santiago Ponzinibbio,Sean Strickland,Red,Welterweight
+02/22/2015,Marion Reneau,Jessica Andrade,Red,Women's Bantamweight
+02/22/2015,Matt Dwyer,William Macario,Red,Welterweight
+02/22/2015,Mike de la Torre,Tiago dos Santos e Silva,Red,Featherweight
+02/22/2015,Cody Gibson,Douglas Silva de Andrade,Blue,Bantamweight
+02/22/2015,Josh Shockley,Ivan Jorge,Blue,Lightweight
+02/14/2015,Benson Henderson,Brandon Thatch,Red,Welterweight
+02/14/2015,Max Holloway,Cole Miller,Red,Featherweight
+02/14/2015,Kiichi Kunimoto,Neil Magny,Blue,Welterweight
+02/14/2015,Daniel Kelly,Patrick Walsh,Red,Middleweight
+02/14/2015,Kevin Lee,Michel Prazeres,Red,Lightweight
+02/14/2015,Ray Borg,Chris Kelades,Red,Flyweight
+02/14/2015,Efrain Escudero,Rodrigo de Lima,Red,Lightweight
+02/14/2015,Chas Skelly,Jim Alers,Red,Featherweight
+02/14/2015,Tim Elliott,Zach Makovsky,Blue,Flyweight
+02/14/2015,James Moontasri,Cody Pfister,Red,Lightweight
+01/31/2015,Tyron Woodley,Kelvin Gastelum,Red,Welterweight
+01/31/2015,Joe Lauzon,Al Iaquinta,Blue,Lightweight
+01/31/2015,Tim Boetsch,Thales Leites,Blue,Middleweight
+01/31/2015,Jordan Mein,Thiago Alves,Blue,Welterweight
+01/31/2015,Sara McMann,Miesha Tate,Blue,Women's Bantamweight
+01/31/2015,Derek Brunson,Ed Herman,Red,Middleweight
+01/31/2015,Ian McCall,John Lineker,Blue,Flyweight
+01/31/2015,Tom Watson,Rafael Natal,Blue,Middleweight
+01/31/2015,Richardson Moreira,Ildemar Alcantara,Blue,Middleweight
+01/31/2015,Andy Enz,Thiago Santos,Blue,Middleweight
+01/24/2015,Alexander Gustafsson,Anthony Johnson,Blue,Light Heavyweight
+01/24/2015,Gegard Mousasi,Dan Henderson,Red,Middleweight
+01/24/2015,Ryan Bader,Phil Davis,Red,Light Heavyweight
+01/24/2015,Akira Corassani,Sam Sicilia,Blue,Featherweight
+01/24/2015,Albert Tumenov,Nicholas Musoke,Red,Welterweight
+01/24/2015,Kenny Robertson,Sultan Aliev,Red,Welterweight
+01/24/2015,Makwan Amirkhani,Andy Ogle,Red,Featherweight
+01/24/2015,Nikita Krylov,Stanislav Nedkov,Red,Light Heavyweight
+01/24/2015,Mairbek Taisumov,Anthony Christodoulou,Red,Lightweight
+01/24/2015,Paul Redmond,Mirsad Bektic,Blue,Featherweight
+01/24/2015,Konstantin Erokhin,Viktor Pesta,Blue,Heavyweight
+01/24/2015,Chris Beal,Neil Seery,Blue,Flyweight
+01/18/2015,Dennis Siver,Conor McGregor,Blue,Featherweight
+01/18/2015,Donald Cerrone,Benson Henderson,Red,Lightweight
+01/18/2015,Ron Stallings,Uriah Hall,Blue,Middleweight
+01/18/2015,Gleison Tibau,Norman Parke,Red,Lightweight
+01/18/2015,Cathal Pendred,Sean Spencer,Red,Welterweight
+01/18/2015,John Howard,Lorenz Larkin,Blue,Welterweight
+01/18/2015,Zhang Lipeng,Chris Wade,Blue,Lightweight
+01/18/2015,Paddy Holohan,Shane Howell,Red,Flyweight
+01/18/2015,Frankie Perez,Johnny Case,Blue,Lightweight
+01/18/2015,Sean Soriano,Charles Rosa,Blue,Featherweight
+01/18/2015,Matt Van Buren,Sean O'Connell,Blue,Light Heavyweight
+01/18/2015,Tateki Matsuda,Joby Sanchez,Blue,Flyweight
+01/03/2015,Jon Jones,Daniel Cormier,Red,UFC Light Heavyweight Title
+01/03/2015,Donald Cerrone,Myles Jury,Red,Lightweight
+01/03/2015,Brad Tavares,Nate Marquardt,Red,Middleweight
+01/03/2015,Louis Gaudinot,Kyoji Horiguchi,Blue,Flyweight
+01/03/2015,Paul Felder,Danny Castillo,Red,Lightweight
+01/03/2015,Marcus Brimage,Cody Garbrandt,Blue,Bantamweight
+01/03/2015,Jared Cannonier,Shawn Jordan,Blue,Heavyweight
+01/03/2015,Rodrigo Damm,Evan Dunham,Blue,Lightweight
+01/03/2015,Omari Akhmedov,Mats Nilsson,Red,Welterweight
+01/03/2015,Alexis Dufresne,Marion Reneau,Blue,Women's Bantamweight
+12/20/2014,Lyoto Machida,CB Dollaway,Red,Middleweight
+12/20/2014,Renan Barao,Mitch Gagnon,Red,Bantamweight
+12/20/2014,Patrick Cummins,Antonio Carlos Junior,Red,Light Heavyweight
+12/20/2014,Elias Silverio,Rashid Magomedov,Blue,Lightweight
+12/20/2014,Erick Silva,Mike Rhodes,Red,Welterweight
+12/20/2014,Daniel Sarafian,Antonio Dos Santos,Red,Middleweight
+12/20/2014,Marcos Rogerio de Lima,Igor Pokrajac,Red,Light Heavyweight
+12/20/2014,Renato Moicano,Tom Niinimaki,Red,Featherweight
+12/20/2014,Hacran Dias,Darren Elkins,Red,Featherweight
+12/20/2014,Yuta Sasaki,Leandro Issa,Blue,Bantamweight
+12/20/2014,Marcio Alexandre Junior,Tim Means,Blue,Welterweight
+12/20/2014,Jake Collier,Vitor Miranda,Blue,Middleweight
+12/13/2014,Stipe Miocic,Junior Dos Santos,Blue,Heavyweight
+12/13/2014,Rafael Dos Anjos,Nate Diaz,Red,Lightweight
+12/13/2014,Alistair Overeem,Stefan Struve,Red,Heavyweight
+12/13/2014,Matt Mitrione,Gabriel Gonzaga,Red,Heavyweight
+12/13/2014,Claudia Gadelha,Joanna Jedrzejczyk,Blue,Women's Strawweight
+12/13/2014,Willie Gates,John Moraga,Blue,Flyweight
+12/13/2014,Ben Saunders,Joe Riggs,Red,Welterweight
+12/13/2014,Jamie Varner,Drew Dober,Blue,Lightweight
+12/13/2014,Bryan Barberena,Joe Ellenberger,Red,Lightweight
+12/13/2014,Garett Whiteley,David Michaud,Blue,Lightweight
+12/13/2014,Dustin Kimura,Henry Cejudo,Blue,Bantamweight
+12/13/2014,Ian Entwistle,Anthony Birchak,Red,Bantamweight
+12/12/2014,Rose Namajunas,Carla Esparza,Blue,UFC Women's Strawweight Title
+12/12/2014,Charles Oliveira,Jeremy Stephens,Red,Featherweight
+12/12/2014,Joe Proctor,Yancy Medeiros,Blue,Lightweight
+12/12/2014,Randa Markos,Jessica Penne,Blue,Women's Strawweight
+12/12/2014,Felice Herrig,Lisa Ellis,Red,Women's Strawweight
+12/12/2014,Heather Clark,Bec Rawlings,Red,Women's Strawweight
+12/12/2014,Seo Hee Ham,Joanne Wood,Blue,Women's Strawweight
+12/12/2014,Tecia Torres,Angela Magana,Red,Women's Strawweight
+12/12/2014,Aisling Daly,Alex Chambers,Red,Women's Strawweight
+12/12/2014,Emily Kagan,Angela Hill,Blue,Women's Strawweight
+12/06/2014,Robbie Lawler,Johny Hendricks,Red,UFC Welterweight Title
+12/06/2014,Anthony Pettis,Gilbert Melendez,Red,UFC Lightweight Title
+12/06/2014,Travis Browne,Brendan Schaub,Red,Heavyweight
+12/06/2014,Anthony Hamilton,Todd Duffee,Blue,Heavyweight
+12/06/2014,Tony Ferguson,Abel Trujillo,Red,Lightweight
+12/06/2014,Urijah Faber,Francisco Rivera,Red,Bantamweight
+12/06/2014,Josh Samman,Eddie Gordon,Red,Middleweight
+12/06/2014,Justin Jones,Corey Anderson,Blue,Light Heavyweight
+12/06/2014,Ashlee Evans-Smith,Raquel Pennington,Blue,Women's Bantamweight
+12/06/2014,Sergio Pettis,Matt Hobar,Red,Bantamweight
+12/06/2014,Clay Collard,Alex White,Red,Featherweight
+11/22/2014,Cub Swanson,Frankie Edgar,Blue,Featherweight
+11/22/2014,Edson Barboza,Bobby Green,Red,Lightweight
+11/22/2014,Brad Pickett,Chico Camus,Blue,Flyweight
+11/22/2014,Jared Rosholt,Aleksei Oleinik,Blue,Heavyweight
+11/22/2014,Dustin Ortiz,Joseph Benavidez,Blue,Flyweight
+11/22/2014,Matt Wiman,Isaac Vallie-Flagg,Red,Lightweight
+11/22/2014,Ruslan Magomedov,Josh Copeland,Red,Heavyweight
+11/22/2014,Roger Narvaez,Luke Barnatt,Red,Middleweight
+11/22/2014,James Vick,Nick Hein,Red,Lightweight
+11/22/2014,Akbarh Arreola,Yves Edwards,Red,Lightweight
+11/22/2014,Kailin Curran,Paige VanZant,Blue,Women's Strawweight
+11/22/2014,Juan Manuel Puig,Dooho Choi,Blue,Featherweight
+11/15/2014,Fabricio Werdum,Mark Hunt,Red,UFC Interim Heavyweight Title
+11/15/2014,Kelvin Gastelum,Jake Ellenberger,Red,Welterweight
+11/15/2014,Dennis Bermudez,Ricardo Lamas,Blue,Featherweight
+11/15/2014,Augusto Montano,Chris Heatherly,Red,Welterweight
+11/15/2014,Edgar Garcia,Hector Urbina,Blue,Welterweight
+11/15/2014,Leonardo Morales,Yair Rodriguez,Blue,Ultimate Fighter Latin America Featherweight Tournament Title
+11/15/2014,Jose Quinonez,Alejandro Perez,Blue,Ultimate Fighter Latin America Bantamweight Tournament Title
+11/15/2014,Jessica Eye,Leslie Smith,Red,Women's Bantamweight
+11/15/2014,Humberto Brown Morrison,Gabriel Benitez,Blue,Featherweight
+11/15/2014,Guido Cannetti,Henry Briones,Blue,Bantamweight
+11/15/2014,Marco Beltran,Marlon Vera,Red,Bantamweight
+11/08/2014,Mauricio Rua,Ovince Saint Preux,Blue,Light Heavyweight
+11/08/2014,Alan Jouban,Warlley Alves,Blue,Welterweight
+11/08/2014,Leon Edwards,Claudio Silva,Blue,Welterweight
+11/08/2014,Jorge de Oliveira,Dhiego Lima,Blue,Welterweight
+11/08/2014,Nina Nunes,Juliana Lima,Blue,Women's Strawweight
+11/08/2014,Diego Rivas,Rodolfo Rubio Perez,Red,Featherweight
+11/08/2014,Caio Magalhaes,Trevor Smith,Red,Middleweight
+11/08/2014,Leandro Silva,Charlie Brenneman,Red,Lightweight
+11/08/2014,Thomas Almeida,Tim Gorman,Red,Bantamweight
+11/08/2014,Wagner Silva,Colby Covington,Blue,Welterweight
+11/07/2014,Luke Rockhold,Michael Bisping,Red,Middleweight
+11/07/2014,Ross Pearson,Al Iaquinta,Blue,Lightweight
+11/07/2014,Clint Hester,Robert Whittaker,Blue,Middleweight
+11/07/2014,Soa Palelei,Walt Harris,Red,Heavyweight
+11/07/2014,Jake Matthews,Vagner Rocha,Red,Lightweight
+11/07/2014,Guto Inocente,Anthony Perosh,Blue,Light Heavyweight
+11/07/2014,Sam Alvey,Dylan Andrews,Red,Middleweight
+11/07/2014,Richie Vaculik,Louis Smolka,Blue,Flyweight
+11/07/2014,Vik Grujic,Chris Clements,Blue,Welterweight
+11/07/2014,Daniel Kelly,Luke Zachrich,Red,Middleweight
+11/07/2014,Marcus Brimage,Jumabieke Tuerxun,Red,Bantamweight
+10/25/2014,Jose Aldo,Chad Mendes,Red,UFC Featherweight Title
+10/25/2014,Phil Davis,Glover Teixeira,Red,Light Heavyweight
+10/25/2014,Hans Stringer,Fabio Maldonado,Blue,Light Heavyweight
+10/25/2014,Lucas Martins,Darren Elkins,Blue,Featherweight
+10/25/2014,Diego Ferreira,Beneil Dariush,Blue,Lightweight
+10/25/2014,William Macario,Neil Magny,Blue,Welterweight
+10/25/2014,Naoyuki Kotani,Yan Cabral,Blue,Lightweight
+10/25/2014,Scott Jorgensen,Wilson Reis,Blue,Flyweight
+10/25/2014,Felipe Arantes,Andre Fili,Blue,Featherweight
+10/25/2014,Gilbert Burns,Christos Giagos,Red,Lightweight
+10/25/2014,Fabricio Camoes,Anthony Rocco Martin,Blue,Lightweight
+10/04/2014,Tarec Saffiedine,Rory MacDonald,Blue,Welterweight
+10/04/2014,Bryan Caraway,Raphael Assuncao,Blue,Bantamweight
+10/04/2014,Yosdenis Cedeno,Chad Laprise,Blue,Lightweight
+10/04/2014,Elias Theodorou,Bruno Santos,Red,Middleweight
+10/04/2014,Nordine Taleb,Li Jingliang,Red,Welterweight
+10/04/2014,Roman Salazar,Mitch Gagnon,Blue,Bantamweight
+10/04/2014,Anthony Njokuani,Daron Cruickshank,Blue,Lightweight
+10/04/2014,Jake Lindsey,Olivier Aubin-Mercier,Blue,Lightweight
+10/04/2014,Jason Saggo,Paul Felder,Blue,Lightweight
+10/04/2014,Paddy Holohan,Chris Kelades,Blue,Flyweight
+10/04/2014,Albert Tumenov,Matt Dwyer,Red,Welterweight
+10/04/2014,Rick Story,Gunnar Nelson,Red,Welterweight
+10/04/2014,Akira Corassani,Max Holloway,Blue,Featherweight
+10/04/2014,Ilir Latifi,Jan Blachowicz,Blue,Light Heavyweight
+10/04/2014,Mike Wilkinson,Niklas Backstrom,Red,Featherweight
+10/04/2014,Magnus Cedenblad,Scott Askham,Red,Middleweight
+10/04/2014,Nicholas Musoke,Alexander Yakovlev,Red,Welterweight
+10/04/2014,Dennis Siver,Charles Rosa,Red,Featherweight
+10/04/2014,Gasan Umalatov,Cathal Pendred,Blue,Welterweight
+10/04/2014,Krzysztof Jotko,Tor Troeng,Red,Middleweight
+10/04/2014,Marcin Bandel,Mairbek Taisumov,Blue,Lightweight
+10/04/2014,Ernest Chavez,Zubaira Tukhugov,Blue,Featherweight
+09/27/2014,Demetrious Johnson,Chris Cariaso,Red,UFC Flyweight Title
+09/27/2014,Donald Cerrone,Eddie Alvarez,Red,Lightweight
+09/27/2014,Conor McGregor,Dustin Poirier,Red,Featherweight
+09/27/2014,Tim Kennedy,Yoel Romero,Blue,Middleweight
+09/27/2014,Cat Zingano,Amanda Nunes,Red,Women's Bantamweight
+09/27/2014,Takeya Mizugaki,Dominick Cruz,Blue,Bantamweight
+09/27/2014,James Krause,Jorge Masvidal,Blue,Lightweight
+09/27/2014,Stephen Thompson,Patrick Cote,Red,Welterweight
+09/27/2014,John Howard,Brian Ebersole,Blue,Welterweight
+09/27/2014,Kevin Lee,Jon Tuck,Red,Lightweight
+09/27/2014,Manvel Gamburyan,Cody Gibson,Red,Bantamweight
+09/20/2014,Mark Hunt,Roy Nelson,Red,Heavyweight
+09/20/2014,Myles Jury,Takanori Gomi,Red,Lightweight
+09/20/2014,Yoshihiro Akiyama,Amir Sadollah,Red,Welterweight
+09/20/2014,Rin Nakai,Miesha Tate,Blue,Women's Bantamweight
+09/20/2014,Kiichi Kunimoto,Richard Walsh,Red,Welterweight
+09/20/2014,Jon Delos Reyes,Kyoji Horiguchi,Blue,Flyweight
+09/20/2014,Masanori Kanehara,Alex Caceres,Red,Bantamweight
+09/20/2014,Sam Sicilia,Katsunori Kikuno,Blue,Featherweight
+09/20/2014,Hyun Gyu Lim,Takenori Sato,Red,Welterweight
+09/20/2014,Michinori Tanaka,Kyung Ho Kang,Blue,Bantamweight
+09/20/2014,Kazuki Tokudome,Johnny Case,Blue,Lightweight
+09/20/2014,Maximo Blanco,Dan Hooker,Red,Featherweight
+09/13/2014,Antonio Silva,Andrei Arlovski,Blue,Heavyweight
+09/13/2014,Gleison Tibau,Piotr Hallmann,Red,Lightweight
+09/13/2014,Efrain Escudero,Leonardo Santos,Blue,Lightweight
+09/13/2014,Wendell Oliveira Marques,Santiago Ponzinibbio,Blue,Welterweight
+09/13/2014,Iuri Alcantara,Russell Doane,Red,Bantamweight
+09/13/2014,Larissa Pacheco,Jessica Andrade,Blue,Women's Bantamweight
+09/13/2014,Dashon Johnson,Godofredo Pepey,Blue,Featherweight
+09/13/2014,George Sullivan,Igor Araujo,Red,Welterweight
+09/13/2014,Francisco Trinaldo,Leandro Silva,Red,Lightweight
+09/13/2014,Sean Spencer,Paulo Thiago,Red,Welterweight
+09/13/2014,Johnny Bedford,Rani Yahya,Blue,Bantamweight
+09/05/2014,Jacare Souza,Gegard Mousasi,Red,Middleweight
+09/05/2014,Alistair Overeem,Ben Rothwell,Blue,Heavyweight
+09/05/2014,Derrick Lewis,Matt Mitrione,Blue,Heavyweight
+09/05/2014,Joe Lauzon,Michael Chiesa,Red,Lightweight
+09/05/2014,Justin Scoggins,John Moraga,Blue,Flyweight
+09/05/2014,Al Iaquinta,Rodrigo Damm,Red,Lightweight
+09/05/2014,Chris Camozzi,Rafael Natal,Blue,Middleweight
+09/05/2014,Tateki Matsuda,Chris Beal,Blue,Bantamweight
+09/05/2014,Chas Skelly,Sean Soriano,Red,Featherweight
+08/30/2014,TJ Dillashaw,Joe Soto,Red,UFC Bantamweight Title
+08/30/2014,Tony Ferguson,Danny Castillo,Red,Lightweight
+08/30/2014,Shayna Baszler,Bethe Correia,Blue,Women's Bantamweight
+08/30/2014,Ramsey Nijem,Diego Ferreira,Blue,Lightweight
+08/30/2014,Yancy Medeiros,Damon Jackson,Red,Lightweight
+08/30/2014,Derek Brunson,Lorenz Larkin,Red,Middleweight
+08/30/2014,Anthony Hamilton,Ruan Potts,Red,Heavyweight
+08/30/2014,Chris Wade,Cain Carrizosa,Red,Lightweight
+08/23/2014,Benson Henderson,Rafael Dos Anjos,Blue,Lightweight
+08/23/2014,Mike Pyle,Jordan Mein,Blue,Welterweight
+08/23/2014,Thales Leites,Francis Carmont,Red,Middleweight
+08/23/2014,Clay Collard,Max Holloway,Blue,Catch Weight
+08/23/2014,James Vick,Valmir Lazaro,Red,Lightweight
+08/23/2014,Tom Niinimaki,Chas Skelly,Blue,Featherweight
+08/23/2014,Neil Magny,Alex Garcia,Red,Welterweight
+08/23/2014,Beneil Dariush,Anthony Rocco Martin,Red,Lightweight
+08/23/2014,Matt Hobar,Aaron Phillips,Red,Bantamweight
+08/23/2014,Ben Saunders,Chris Heatherly,Red,Welterweight
+08/23/2014,Wilson Reis,Joby Sanchez,Red,Flyweight
+08/23/2014,Cung Le,Michael Bisping,Blue,Middleweight
+08/23/2014,Dong Hyun Kim,Tyron Woodley,Blue,Welterweight
+08/23/2014,Zhang Lipeng,Brendan O'Reilly,Red,Lightweight
+08/23/2014,Jianping Yang,Guangyou Ning,Blue,Ultimate Fighter China Featherweight Tournament Title
+08/23/2014,Sai Wang,Danny Mitchell,Red,Welterweight
+08/23/2014,Shinsho Anzai,Alberto Mina,Blue,Welterweight
+08/23/2014,Roland Delorme,Yuta Sasaki,Blue,Bantamweight
+08/23/2014,Colby Covington,Anying Wang,Red,Welterweight
+08/23/2014,Yao Zhikui,Royston Wee,Blue,Bantamweight
+08/23/2014,Milana Dudieva,Elizabeth Phillips,Red,Women's Bantamweight
+08/16/2014,Ovince Saint Preux,Ryan Bader,Blue,Light Heavyweight
+08/16/2014,Gray Maynard,Ross Pearson,Blue,Lightweight
+08/16/2014,Tim Boetsch,Brad Tavares,Red,Middleweight
+08/16/2014,Alan Jouban,Seth Baczynski,Red,Welterweight
+08/16/2014,Shawn Jordan,Jack May,Red,Heavyweight
+08/16/2014,Thiago Tavares,Robert Peralta,Red,Featherweight
+08/16/2014,Jussier Formiga,Zach Makovsky,Red,Flyweight
+08/16/2014,Sara McMann,Lauren Murphy,Red,Women's Bantamweight
+08/16/2014,Sam Alvey,Tom Watson,Blue,Middleweight
+08/16/2014,Frankie Saenz,Nolan Ticman,Red,Bantamweight
+07/26/2014,Robbie Lawler,Matt Brown,Red,Welterweight
+07/26/2014,Anthony Johnson,Rogerio Nogueira,Red,Light Heavyweight
+07/26/2014,Dennis Bermudez,Clay Guida,Red,Featherweight
+07/26/2014,Josh Thomson,Bobby Green,Blue,Lightweight
+07/26/2014,Daron Cruickshank,Jorge Masvidal,Blue,Lightweight
+07/26/2014,Patrick Cummins,Kyle Kingsbury,Red,Light Heavyweight
+07/26/2014,Tim Means,Hernani Perpetuo,Red,Welterweight
+07/26/2014,Tiago dos Santos e Silva,Akbarh Arreola,Red,Lightweight
+07/26/2014,Gilbert Burns,Andreas Stahl,Red,Welterweight
+07/26/2014,Joanna Jedrzejczyk,Juliana Lima,Red,Women's Strawweight
+07/26/2014,Steven Siler,Noad Lahat,Blue,Featherweight
+07/19/2014,Conor McGregor,Diego Brandao,Red,Featherweight
+07/19/2014,Gunnar Nelson,Zak Cummings,Red,Welterweight
+07/19/2014,Brad Pickett,Ian McCall,Blue,Flyweight
+07/19/2014,Norman Parke,Naoyuki Kotani,Red,Lightweight
+07/19/2014,Chris Dempsey,Ilir Latifi,Blue,Light Heavyweight
+07/19/2014,Neil Seery,Phil Harris,Red,Flyweight
+07/19/2014,Cathal Pendred,Mike King,Red,Middleweight
+07/19/2014,Trevor Smith,Tor Troeng,Red,Middleweight
+07/19/2014,Nikita Krylov,Cody Donovan,Red,Light Heavyweight
+07/19/2014,Josh Sampo,Paddy Holohan,Blue,Flyweight
+07/16/2014,Donald Cerrone,Jim Miller,Red,Lightweight
+07/16/2014,Edson Barboza,Evan Dunham,Red,Lightweight
+07/16/2014,Leonardo Mafra,Rick Story,Blue,Welterweight
+07/16/2014,Joe Proctor,Justin Salas,Red,Lightweight
+07/16/2014,Alptekin Ozkilic,John Lineker,Blue,Flyweight
+07/16/2014,Lucas Martins,Alex White,Red,Featherweight
+07/16/2014,Pat Healy,Gleison Tibau,Blue,Lightweight
+07/16/2014,Jessamyn Duke,Leslie Smith,Blue,Women's Bantamweight
+07/16/2014,Hugo Viana,Aljamain Sterling,Blue,Bantamweight
+07/16/2014,Jerrod Sanders,Yosdenis Cedeno,Blue,Lightweight
+07/16/2014,Claudia Gadelha,Tina Lahdemaki,Red,Women's Strawweight
+07/06/2014,Frankie Edgar,BJ Penn,Red,Featherweight
+07/06/2014,Matt Van Buren,Corey Anderson,Blue,Ultimate Fighter 19 Light Heavyweight Tournament Title
+07/06/2014,Dhiego Lima,Eddie Gordon,Blue,Ultimate Fighter 19 Middleweight Tournament Title
+07/06/2014,Derrick Lewis,Guto Inocente,Red,Heavyweight
+07/06/2014,Justin Scoggins,Dustin Ortiz,Blue,Flyweight
+07/06/2014,Jesse Ronson,Kevin Lee,Blue,Lightweight
+07/06/2014,Leandro Issa,Jumabieke Tuerxun,Red,Bantamweight
+07/06/2014,Adriano Martins,Juan Manuel Puig,Red,Lightweight
+07/06/2014,Daniel Spohn,Patrick Walsh,Blue,Light Heavyweight
+07/06/2014,Alexis Dufresne,Sarah Moras,Blue,Catch Weight
+07/05/2014,Chris Weidman,Lyoto Machida,Red,UFC Middleweight Title
+07/05/2014,Alexis Davis,Ronda Rousey,Blue,UFC Women's Bantamweight Title
+07/05/2014,Thiago Santos,Uriah Hall,Blue,Middleweight
+07/05/2014,Russell Doane,Marcus Brimage,Red,Bantamweight
+07/05/2014,Alex Caceres,Urijah Faber,Blue,Bantamweight
+07/05/2014,Kenny Robertson,Ildemar Alcantara,Red,Welterweight
+07/05/2014,Chris Camozzi,Bruno Santos,Blue,Middleweight
+07/05/2014,George Roop,Rob Font,Blue,Bantamweight
+07/05/2014,Luke Zachrich,Guilherme Vasconcelos,Red,Middleweight
+06/28/2014,Jeremy Stephens,Cub Swanson,Blue,Featherweight
+06/28/2014,Nicholas Musoke,Kelvin Gastelum,Blue,Welterweight
+06/28/2014,Andrew Craig,Cezar Ferreira,Blue,Middleweight
+06/28/2014,Ricardo Lamas,Hacran Dias,Red,Featherweight
+06/28/2014,Antonio Braga Neto,Clint Hester,Blue,Middleweight
+06/28/2014,James Moontasri,Joe Ellenberger,Blue,Lightweight
+06/28/2014,Diego Ferreira,Colton Smith,Red,Lightweight
+06/28/2014,Johnny Bedford,Cody Gibson,Blue,Bantamweight
+06/28/2014,Andy Enz,Marcelo Guimaraes,Blue,Middleweight
+06/28/2014,Shane Howell,Ray Borg,Blue,Flyweight
+06/28/2014,Aleksei Oleinik,Anthony Hamilton,Red,Heavyweight
+06/28/2014,Nate Marquardt,James Te Huna,Red,Middleweight
+06/28/2014,Jared Rosholt,Soa Palelei,Red,Heavyweight
+06/28/2014,Charles Oliveira,Hatsu Hioki,Red,Featherweight
+06/28/2014,Mike Rhodes,Robert Whittaker,Blue,Welterweight
+06/28/2014,Dashon Johnson,Jake Matthews,Blue,Lightweight
+06/28/2014,Roldan Sangcha'an,Richie Vaculik,Blue,Flyweight
+06/28/2014,Vik Grujic,Chris Indich,Red,Welterweight
+06/28/2014,Neil Magny,Rodrigo de Lima,Red,Welterweight
+06/28/2014,Dan Hooker,Ian Entwistle,Red,Featherweight
+06/28/2014,Sean O'Connell,Gian Villante,Blue,Light Heavyweight
+06/14/2014,Demetrious Johnson,Ali Bagautinov,Red,UFC Flyweight Title
+06/14/2014,Rory MacDonald,Tyron Woodley,Red,Welterweight
+06/14/2014,Rafael Cavalcante,Ryan Bader,Blue,Light Heavyweight
+06/14/2014,Andrei Arlovski,Brendan Schaub,Red,Heavyweight
+06/14/2014,Ovince Saint Preux,Ryan Jimmo,Red,Light Heavyweight
+06/14/2014,Kiichi Kunimoto,Daniel Sarafian,Red,Welterweight
+06/14/2014,Valerie Letourneau,Elizabeth Phillips,Red,Women's Bantamweight
+06/14/2014,Yves Jabouin,Mike Easton,Red,Bantamweight
+06/14/2014,Kajan Johnson,Tae Hyun Bang,Blue,Lightweight
+06/14/2014,Michinori Tanaka,Roland Delorme,Red,Bantamweight
+06/14/2014,Jason Saggo,Josh Shockley,Red,Lightweight
+06/07/2014,Rustam Khabilov,Benson Henderson,Blue,Lightweight
+06/07/2014,Diego Sanchez,Ross Pearson,Red,Lightweight
+06/07/2014,John Moraga,John Dodson,Blue,Flyweight
+06/07/2014,Jason High,Rafael Dos Anjos,Blue,Lightweight
+06/07/2014,Yves Edwards,Piotr Hallmann,Blue,Lightweight
+06/07/2014,Erik Perez,Bryan Caraway,Blue,Bantamweight
+06/07/2014,Yaotzin Meza,Sergio Pettis,Blue,Bantamweight
+06/07/2014,Bobby Voelker,Lance Benoist,Blue,Welterweight
+06/07/2014,Scott Jorgensen,Danny Martinez,Red,Flyweight
+06/07/2014,Jon Tuck,Jake Lindsey,Red,Lightweight
+06/07/2014,Patrick Cummins,Roger Narvaez,Red,Light Heavyweight
+05/31/2014,Stipe Miocic,Fabio Maldonado,Red,Heavyweight
+05/31/2014,Vitor Miranda,Antonio Carlos Junior,Blue,Ultimate Fighter Brazil 3 Heavyweight Tournament Title
+05/31/2014,Marcio Alexandre Junior,Warlley Alves,Blue,Ultimate Fighter Brazil 3 Middleweight Tournament Title
+05/31/2014,Demian Maia,Alexander Yakovlev,Red,Welterweight
+05/31/2014,Rony Jason,Robert Peralta,Blue,Featherweight
+05/31/2014,Rodrigo Damm,Rashid Magomedov,Blue,Lightweight
+05/31/2014,Ernest Chavez,Elias Silverio,Blue,Lightweight
+05/31/2014,Gasan Umalatov,Paulo Thiago,Red,Welterweight
+05/31/2014,Mark Eddiva,Edimilson Souza,Blue,Featherweight
+05/31/2014,Ricardo Abreu,Wagner Silva,Red,Middleweight
+05/31/2014,Marcos Rogerio de Lima,Richardson Moreira,Red,Heavyweight
+05/31/2014,Matt Hobar,Pedro Munhoz,Blue,Bantamweight
+05/31/2014,Mark Munoz,Gegard Mousasi,Blue,Middleweight
+05/31/2014,CB Dollaway,Francis Carmont,Red,Middleweight
+05/31/2014,Luke Barnatt,Sean Strickland,Blue,Middleweight
+05/31/2014,Niklas Backstrom,Tom Niinimaki,Red,Featherweight
+05/31/2014,Drew Dober,Nick Hein,Blue,Lightweight
+05/31/2014,Magnus Cedenblad,Krzysztof Jotko,Red,Middleweight
+05/31/2014,Vaughan Lee,Iuri Alcantara,Blue,Bantamweight
+05/31/2014,Pawel Pawlak,Peter Sobotta,Blue,Welterweight
+05/31/2014,Maximo Blanco,Andy Ogle,Red,Featherweight
+05/31/2014,Viktor Pesta,Ruslan Magomedov,Blue,Heavyweight
+05/24/2014,TJ Dillashaw,Renan Barao,Red,UFC Bantamweight Title
+05/24/2014,Daniel Cormier,Dan Henderson,Red,Light Heavyweight
+05/24/2014,Robbie Lawler,Jake Ellenberger,Red,Welterweight
+05/24/2014,Takeya Mizugaki,Francisco Rivera,Red,Bantamweight
+05/24/2014,James Krause,Jamie Varner,Red,Lightweight
+05/24/2014,Michael Chiesa,Francisco Trinaldo,Red,Lightweight
+05/24/2014,Katsunori Kikuno,Tony Ferguson,Blue,Lightweight
+05/24/2014,Chris Holdsworth,Chico Camus,Red,Bantamweight
+05/24/2014,Mitch Clarke,Al Iaquinta,Red,Lightweight
+05/24/2014,Vinc Pichel,Anthony Njokuani,Red,Lightweight
+05/24/2014,Sam Sicilia,Aaron Phillips,Red,Featherweight
+05/24/2014,Li Jingliang,David Michaud,Red,Welterweight
+05/10/2014,Matt Brown,Erick Silva,Red,Welterweight
+05/10/2014,Lorenz Larkin,Constantinos Philippou,Blue,Middleweight
+05/10/2014,Daron Cruickshank,Erik Koch,Red,Lightweight
+05/10/2014,Tim Means,Neil Magny,Blue,Welterweight
+05/10/2014,Ruan Potts,Soa Palelei,Blue,Heavyweight
+05/10/2014,Louis Smolka,Chris Cariaso,Blue,Flyweight
+05/10/2014,Ed Herman,Rafael Natal,Red,Middleweight
+05/10/2014,Darrell Montague,Kyoji Horiguchi,Blue,Flyweight
+05/10/2014,Yan Cabral,Zak Cummings,Blue,Welterweight
+05/10/2014,Eddie Wineland,Johnny Eduardo,Blue,Bantamweight
+05/10/2014,Nik Lentz,Manvel Gamburyan,Red,Featherweight
+05/10/2014,Ben Wall,Justin Salas,Blue,Lightweight
+05/10/2014,Albert Tumenov,Anthony Lapsley,Red,Welterweight
+04/26/2014,Jon Jones,Glover Teixeira,Red,UFC Light Heavyweight Title
+04/26/2014,Phil Davis,Anthony Johnson,Blue,Light Heavyweight
+04/26/2014,Luke Rockhold,Tim Boetsch,Red,Middleweight
+04/26/2014,Yancy Medeiros,Jim Miller,Blue,Lightweight
+04/26/2014,Max Holloway,Andre Fili,Red,Featherweight
+04/26/2014,Joseph Benavidez,Tim Elliott,Red,Flyweight
+04/26/2014,Isaac Vallie-Flagg,Takanori Gomi,Blue,Lightweight
+04/26/2014,Jessamyn Duke,Bethe Correia,Blue,Women's Bantamweight
+04/26/2014,Charlie Brenneman,Danny Castillo,Blue,Lightweight
+04/26/2014,Patrick Williams,Chris Beal,Blue,Bantamweight
+04/19/2014,Travis Browne,Fabricio Werdum,Blue,Heavyweight
+04/19/2014,Liz Carmouche,Miesha Tate,Blue,Women's Bantamweight
+04/19/2014,Edson Barboza,Donald Cerrone,Blue,Lightweight
+04/19/2014,Yoel Romero,Brad Tavares,Red,Middleweight
+04/19/2014,Khabib Nurmagomedov,Rafael Dos Anjos,Red,Lightweight
+04/19/2014,Thiago Alves,Seth Baczynski,Red,Welterweight
+04/19/2014,Pat Healy,Jorge Masvidal,Blue,Lightweight
+04/19/2014,Estevan Payan,Alex White,Blue,Featherweight
+04/19/2014,Caio Magalhaes,Luke Zachrich,Red,Middleweight
+04/19/2014,Jordan Mein,Hernani Perpetuo,Red,Welterweight
+04/19/2014,Ray Borg,Dustin Ortiz,Blue,Flyweight
+04/19/2014,Mirsad Bektic,Chas Skelly,Red,Featherweight
+04/19/2014,Derrick Lewis,Jack May,Red,Heavyweight
+04/16/2014,Tim Kennedy,Michael Bisping,Red,Middleweight
+04/16/2014,Kyle Noke,Patrick Cote,Blue,Welterweight
+04/16/2014,Sheldon Westcott,Elias Theodorou,Blue,TUF Nations Canada vs. Australia Middleweight Tournament Title
+04/16/2014,Olivier Aubin-Mercier,Chad Laprise,Blue,TUF Nations Canada vs. Australia Welterweight Tournament Title
+04/16/2014,Dustin Poirier,Akira Corassani,Red,Featherweight
+04/16/2014,KJ Noons,Sam Stout,Red,Welterweight
+04/16/2014,Sarah Kaufman,Leslie Smith,Red,Women's Bantamweight
+04/16/2014,Ryan Jimmo,Sean O'Connell,Red,Light Heavyweight
+04/16/2014,George Roop,Dustin Kimura,Red,Bantamweight
+04/16/2014,Mike de la Torre,Mark Bocek,Blue,Lightweight
+04/16/2014,Vik Grujic,Nordine Taleb,Blue,Middleweight
+04/16/2014,Chris Indich,Richard Walsh,Blue,Welterweight
+04/16/2014,Tim Gorman,Mitch Gagnon,Blue,Bantamweight
+04/11/2014,Antonio Rodrigo Nogueira,Roy Nelson,Blue,Heavyweight
+04/11/2014,Clay Guida,Tatsuya Kawajiri,Red,Featherweight
+04/11/2014,John Howard,Ryan LaFlare,Blue,Welterweight
+04/11/2014,Beneil Dariush,Ramsey Nijem,Blue,Lightweight
+04/11/2014,Daniel Omielanczuk,Jared Rosholt,Blue,Heavyweight
+04/11/2014,Thales Leites,Trevor Smith,Red,Middleweight
+04/11/2014,Alan Omer,Jim Alers,Blue,Featherweight
+03/23/2014,Mauricio Rua,Dan Henderson,Blue,Light Heavyweight
+03/23/2014,CB Dollaway,Cezar Ferreira,Red,Middleweight
+03/23/2014,Gian Villante,Fabio Maldonado,Blue,Light Heavyweight
+03/23/2014,Michel Prazeres,Mairbek Taisumov,Red,Lightweight
+03/23/2014,Steven Siler,Rony Jason,Blue,Featherweight
+03/23/2014,Thiago Santos,Ronny Markes,Red,Middleweight
+03/23/2014,Jussier Formiga,Scott Jorgensen,Red,Flyweight
+03/23/2014,Kenny Robertson,Thiago Perpetuo,Red,Welterweight
+03/23/2014,Francimar Barroso,Hans Stringer,Blue,Light Heavyweight
+03/23/2014,Noad Lahat,Godofredo Pepey,Blue,Featherweight
+03/15/2014,Robbie Lawler,Johny Hendricks,Blue,UFC Welterweight Title
+03/15/2014,Tyron Woodley,Carlos Condit,Red,Welterweight
+03/15/2014,Diego Sanchez,Myles Jury,Blue,Lightweight
+03/15/2014,Jake Shields,Hector Lombard,Blue,Welterweight
+03/15/2014,Ovince Saint Preux,Nikita Krylov,Red,Light Heavyweight
+03/15/2014,Rick Story,Kelvin Gastelum,Blue,Welterweight
+03/15/2014,Raquel Pennington,Jessica Andrade,Blue,Women's Bantamweight
+03/15/2014,Jimy Hettes,Dennis Bermudez,Blue,Featherweight
+03/15/2014,Alex Garcia,Sean Spencer,Red,Welterweight
+03/15/2014,Francisco Trevino,Renee Forte,Red,Lightweight
+03/15/2014,Justin Scoggins,Will Campuzano,Red,Flyweight
+03/15/2014,Sean Strickland,Robert McDaniel,Red,Middleweight
+03/15/2014,Daniel Pineda,Robert Whiteford,Blue,Featherweight
+03/08/2014,Alexander Gustafsson,Jimi Manuwa,Red,Light Heavyweight
+03/08/2014,Melvin Guillard,Michael Johnson,Blue,Lightweight
+03/08/2014,Neil Seery,Brad Pickett,Blue,Flyweight
+03/08/2014,Gunnar Nelson,Omari Akhmedov,Red,Welterweight
+03/08/2014,Cyrille Diabate,Ilir Latifi,Blue,Light Heavyweight
+03/08/2014,Luke Barnatt,Mats Nilsson,Red,Middleweight
+03/08/2014,Claudio Silva,Brad Scott,Red,Middleweight
+03/08/2014,Danny Mitchell,Igor Araujo,Blue,Welterweight
+03/01/2014,Dong Hyun Kim,John Hathaway,Red,Welterweight
+03/01/2014,Sai Wang,Zhang Lipeng,Blue,Ultimate Fighter China Welterweight Tournament Title
+03/01/2014,Shawn Jordan,Matt Mitrione,Blue,Heavyweight
+03/01/2014,Ivan Menjivar,Hatsu Hioki,Blue,Featherweight
+03/01/2014,Kazuki Tokudome,Yui Chul Nam,Blue,Lightweight
+03/01/2014,Nam Phan,Vaughan Lee,Blue,Bantamweight
+03/01/2014,Albert Cheng,Anying Wang,Blue,Welterweight
+03/01/2014,Mark Eddiva,Jumabieke Tuerxun,Red,Featherweight
+02/22/2014,Ronda Rousey,Sara McMann,Red,UFC Women's Bantamweight Title
+02/22/2014,Daniel Cormier,Patrick Cummins,Red,Light Heavyweight
+02/22/2014,Demian Maia,Rory MacDonald,Blue,Welterweight
+02/22/2014,TJ Waldburger,Mike Pyle,Blue,Welterweight
+02/22/2014,Robert Whittaker,Stephen Thompson,Blue,Welterweight
+02/22/2014,Jessica Eye,Alexis Davis,Blue,Women's Bantamweight
+02/22/2014,Pedro Munhoz,Raphael Assuncao,Blue,Bantamweight
+02/22/2014,Aljamain Sterling,Cody Gibson,Red,Bantamweight
+02/22/2014,Zach Makovsky,Josh Sampo,Red,Flyweight
+02/22/2014,Erik Koch,Rafaello Oliveira,Red,Lightweight
+02/22/2014,Ernest Chavez,Yosdenis Cedeno,Red,Lightweight
+02/15/2014,Lyoto Machida,Gegard Mousasi,Red,Middleweight
+02/15/2014,Francis Carmont,Jacare Souza,Blue,Middleweight
+02/15/2014,Takenori Sato,Erick Silva,Blue,Welterweight
+02/15/2014,Nicholas Musoke,Viscardi Andrade,Red,Welterweight
+02/15/2014,Andy Ogle,Charles Oliveira,Blue,Featherweight
+02/15/2014,Cristiano Marcello,Joe Proctor,Blue,Lightweight
+02/15/2014,Ivan Jorge,Rodrigo Damm,Blue,Lightweight
+02/15/2014,Jesse Ronson,Francisco Trinaldo,Blue,Lightweight
+02/15/2014,Wilson Reis,Iuri Alcantara,Blue,Bantamweight
+02/15/2014,Maximo Blanco,Felipe Arantes,Blue,Featherweight
+02/15/2014,Albert Tumenov,Ildemar Alcantara,Blue,Welterweight
+02/15/2014,Zubaira Tukhugov,Douglas Silva de Andrade,Red,Featherweight
+02/01/2014,Renan Barao,Urijah Faber,Red,UFC Bantamweight Title
+02/01/2014,Ricardo Lamas,Jose Aldo,Blue,UFC Featherweight Title
+02/01/2014,Alistair Overeem,Frank Mir,Red,Heavyweight
+02/01/2014,John Lineker,Ali Bagautinov,Blue,Flyweight
+02/01/2014,Jamie Varner,Abel Trujillo,Blue,Lightweight
+02/01/2014,John Makdessi,Alan Patrick,Blue,Lightweight
+02/01/2014,Chris Cariaso,Danny Martinez,Red,Flyweight
+02/01/2014,Nick Catone,Tom Watson,Red,Middleweight
+02/01/2014,Al Iaquinta,Kevin Lee,Red,Lightweight
+02/01/2014,Andy Enz,Clint Hester,Blue,Middleweight
+02/01/2014,Rashid Magomedov,Anthony Rocco Martin,Red,Lightweight
+02/01/2014,Neil Magny,Gasan Umalatov,Red,Welterweight
+01/25/2014,Benson Henderson,Josh Thomson,Red,Lightweight
+01/25/2014,Stipe Miocic,Gabriel Gonzaga,Red,Heavyweight
+01/25/2014,Donald Cerrone,Adriano Martins,Red,Lightweight
+01/25/2014,Darren Elkins,Jeremy Stephens,Blue,Featherweight
+01/25/2014,Alex Caceres,Sergio Pettis,Red,Bantamweight
+01/25/2014,Eddie Wineland,Yves Jabouin,Red,Bantamweight
+01/25/2014,Hugo Viana,Ramiro Hernandez,Red,Bantamweight
+01/25/2014,Mike Rio,Daron Cruickshank,Blue,Lightweight
+01/25/2014,George Sullivan,Mike Rhodes,Red,Welterweight
+01/25/2014,Nikita Krylov,Walt Harris,Red,Heavyweight
+01/15/2014,Constantinos Philippou,Luke Rockhold,Blue,Middleweight
+01/15/2014,Brad Tavares,Lorenz Larkin,Red,Middleweight
+01/15/2014,TJ Dillashaw,Mike Easton,Red,Bantamweight
+01/15/2014,Derek Brunson,Yoel Romero,Blue,Middleweight
+01/15/2014,Dustin Ortiz,John Moraga,Blue,Flyweight
+01/15/2014,Cole Miller,Sam Sicilia,Red,Featherweight
+01/15/2014,Ramsey Nijem,Justin Edwards,Red,Lightweight
+01/15/2014,Elias Silverio,Isaac Vallie-Flagg,Red,Lightweight
+01/15/2014,Brian Houston,Trevor Smith,Blue,Middleweight
+01/15/2014,Louis Smolka,Alptekin Ozkilic,Red,Flyweight
+01/15/2014,Garett Whiteley,Vinc Pichel,Blue,Lightweight
+01/15/2014,Beneil Dariush,Charlie Brenneman,Red,Lightweight
+01/04/2014,Tarec Saffiedine,Hyun Gyu Lim,Red,Welterweight
+01/04/2014,Sean Soriano,Tatsuya Kawajiri,Blue,Featherweight
+01/04/2014,Luiz Dutra,Kiichi Kunimoto,Blue,Welterweight
+01/04/2014,Kyung Ho Kang,Shunichi Shimizu,Red,Bantamweight
+01/04/2014,Will Chope,Max Holloway,Blue,Featherweight
+01/04/2014,Katsunori Kikuno,Quinn Mulhern,Red,Lightweight
+01/04/2014,Dave Galera,Royston Wee,Blue,Bantamweight
+01/04/2014,Mairbek Taisumov,Tae Hyun Bang,Red,Lightweight
+01/04/2014,Dustin Kimura,Jon Delos Reyes,Red,Bantamweight
+01/04/2014,Russell Doane,Leandro Issa,Red,Bantamweight
+12/28/2013,Chris Weidman,Anderson Silva,Red,UFC Middleweight Title
+12/28/2013,Miesha Tate,Ronda Rousey,Blue,UFC Women's Bantamweight Title
+12/28/2013,Travis Browne,Josh Barnett,Red,Heavyweight
+12/28/2013,Jim Miller,Fabricio Camoes,Red,Lightweight
+12/28/2013,Dustin Poirier,Diego Brandao,Red,Featherweight
+12/28/2013,Chris Leben,Uriah Hall,Blue,Middleweight
+12/28/2013,Gleison Tibau,Michael Johnson,Blue,Lightweight
+12/28/2013,John Howard,Siyar Bahadurzada,Red,Welterweight
+12/28/2013,William Macario,Bobby Voelker,Red,Welterweight
+12/28/2013,Estevan Payan,Robert Peralta,Blue,Featherweight
+12/14/2013,Joseph Benavidez,Demetrious Johnson,Blue,UFC Flyweight Title
+12/14/2013,Urijah Faber,Michael McDonald,Red,Bantamweight
+12/14/2013,Nik Lentz,Chad Mendes,Blue,Featherweight
+12/14/2013,Joe Lauzon,Mac Danzig,Red,Lightweight
+12/14/2013,Court McGee,Ryan LaFlare,Blue,Welterweight
+12/14/2013,Edson Barboza,Danny Castillo,Red,Lightweight
+12/14/2013,Bobby Green,Pat Healy,Red,Lightweight
+12/14/2013,Zach Makovsky,Scott Jorgensen,Red,Flyweight
+12/14/2013,Sam Stout,Cody McKenzie,Red,Lightweight
+12/14/2013,Roger Bowling,Abel Trujillo,Blue,Lightweight
+12/14/2013,Darren Uyenoyama,Alptekin Ozkilic,Blue,Flyweight
+12/06/2013,Mauricio Rua,James Te Huna,Red,Light Heavyweight
+12/06/2013,Anthony Perosh,Ryan Bader,Blue,Light Heavyweight
+12/06/2013,Soa Palelei,Pat Barry,Red,Heavyweight
+12/06/2013,Clint Hester,Dylan Andrews,Red,Middleweight
+12/06/2013,Bethe Correia,Julie Kedzie,Red,Women's Bantamweight
+12/06/2013,Nam Phan,Takeya Mizugaki,Blue,Bantamweight
+12/06/2013,Caio Magalhaes,Nick Ring,Red,Middleweight
+12/06/2013,Justin Scoggins,Richie Vaculik,Red,Flyweight
+12/06/2013,Krzysztof Jotko,Bruno Santos,Red,Middleweight
+12/06/2013,Ben Wall,Alex Garcia,Blue,Welterweight
+11/30/2013,Nate Diaz,Gray Maynard,Red,Lightweight
+11/30/2013,Jessica Rakoczy,Julianna Pena,Blue,Ultimate Fighter 18 Women's Bantamweight Tournament Title
+11/30/2013,Davey Grant,Chris Holdsworth,Blue,Ultimate Fighter 18 Bantamweight Tournament Title
+11/30/2013,Peggy Morgan,Jessamyn Duke,Blue,Women's Bantamweight
+11/30/2013,Roxanne Modafferi,Raquel Pennington,Blue,Women's Bantamweight
+11/30/2013,Akira Corassani,Maximo Blanco,Red,Featherweight
+11/30/2013,Rani Yahya,Tom Niinimaki,Blue,Featherweight
+11/30/2013,Walt Harris,Jared Rosholt,Blue,Heavyweight
+11/30/2013,Sean Spencer,Drew Dober,Red,Welterweight
+11/30/2013,Josh Sampo,Ryan Benoit,Red,Flyweight
+11/16/2013,Johny Hendricks,Georges St-Pierre,Blue,UFC Welterweight Title
+11/16/2013,Chael Sonnen,Rashad Evans,Blue,Light Heavyweight
+11/16/2013,Rory MacDonald,Robbie Lawler,Blue,Welterweight
+11/16/2013,Tyron Woodley,Josh Koscheck,Red,Welterweight
+11/16/2013,Ali Bagautinov,Tim Elliott,Red,Flyweight
+11/16/2013,Donald Cerrone,Evan Dunham,Red,Lightweight
+11/16/2013,Ed Herman,Thales Leites,Blue,Middleweight
+11/16/2013,Brian Ebersole,Rick Story,Blue,Welterweight
+11/16/2013,Erik Perez,Edwin Figueroa,Red,Bantamweight
+11/16/2013,Jason High,Anthony Lapsley,Red,Welterweight
+11/16/2013,Sergio Pettis,Will Campuzano,Red,Bantamweight
+11/16/2013,Cody Donovan,Gian Villante,Blue,Light Heavyweight
+11/09/2013,Vitor Belfort,Dan Henderson,Red,Light Heavyweight
+11/09/2013,Daniel Sarafian,Cezar Ferreira,Blue,Middleweight
+11/09/2013,Igor Pokrajac,Rafael Cavalcante,Blue,Light Heavyweight
+11/09/2013,Brandon Thatch,Paulo Thiago,Red,Welterweight
+11/09/2013,Santiago Ponzinibbio,Ryan LaFlare,Blue,Welterweight
+11/09/2013,Rony Jason,Jeremy Stephens,Blue,Featherweight
+11/09/2013,Sam Sicilia,Godofredo Pepey,Red,Featherweight
+11/09/2013,Omari Akhmedov,Thiago Perpetuo,Red,Middleweight
+11/09/2013,Justin Salas,Thiago Tavares,Blue,Lightweight
+11/09/2013,Adriano Martins,Daron Cruickshank,Red,Lightweight
+11/09/2013,Jose Maria,Dustin Ortiz,Blue,Flyweight
+11/06/2013,Rafael Natal,Tim Kennedy,Blue,Middleweight
+11/06/2013,Alexis Davis,Liz Carmouche,Red,Women's Bantamweight
+11/06/2013,Yoel Romero,Ronny Markes,Red,Middleweight
+11/06/2013,Rustam Khabilov,Jorge Masvidal,Red,Lightweight
+11/06/2013,Michael Chiesa,Colton Smith,Red,Lightweight
+11/06/2013,Bobby Green,James Krause,Red,Lightweight
+11/06/2013,Francisco Rivera,George Roop,Red,Bantamweight
+11/06/2013,Dennis Bermudez,Steven Siler,Red,Featherweight
+11/06/2013,Germaine de Randamie,Amanda Nunes,Blue,Women's Bantamweight
+11/06/2013,Lorenz Larkin,Chris Camozzi,Red,Middleweight
+11/06/2013,Seth Baczynski,Neil Magny,Red,Welterweight
+11/06/2013,Brian Houston,Derek Brunson,Blue,Middleweight
+10/26/2013,Mark Munoz,Lyoto Machida,Blue,Middleweight
+10/26/2013,Jimi Manuwa,Ryan Jimmo,Red,Light Heavyweight
+10/26/2013,Norman Parke,Jon Tuck,Red,Lightweight
+10/26/2013,Nicholas Musoke,Alessio Sakara,Red,Middleweight
+10/26/2013,Phil Harris,John Lineker,Blue,Flyweight
+10/26/2013,Al Iaquinta,Piotr Hallmann,Red,Lightweight
+10/26/2013,Andrew Craig,Luke Barnatt,Blue,Middleweight
+10/26/2013,Rosi Sexton,Jessica Andrade,Blue,Women's Bantamweight
+10/26/2013,Cole Miller,Andy Ogle,Red,Featherweight
+10/26/2013,Robert Whiteford,Jimy Hettes,Blue,Featherweight
+10/26/2013,Brad Scott,Michael Kuiper,Red,Middleweight
+10/19/2013,Junior Dos Santos,Cain Velasquez,Blue,UFC Heavyweight Title
+10/19/2013,Roy Nelson,Daniel Cormier,Blue,Heavyweight
+10/19/2013,Diego Sanchez,Gilbert Melendez,Blue,Lightweight
+10/19/2013,Gabriel Gonzaga,Shawn Jordan,Red,Heavyweight
+10/19/2013,Darrell Montague,John Dodson,Blue,Flyweight
+10/19/2013,Tim Boetsch,CB Dollaway,Red,Middleweight
+10/19/2013,Nate Marquardt,Hector Lombard,Blue,Welterweight
+10/19/2013,George Sotiropoulos,KJ Noons,Blue,Lightweight
+10/19/2013,Adlan Amagov,TJ Waldburger,Red,Welterweight
+10/19/2013,Mike Rio,Tony Ferguson,Blue,Lightweight
+10/19/2013,Jeremy Larsen,Andre Fili,Blue,Featherweight
+10/19/2013,Kyoji Horiguchi,Dustin Pague,Red,Bantamweight
+10/09/2013,Jake Shields,Demian Maia,Red,Welterweight
+10/09/2013,Erick Silva,Dong Hyun Kim,Blue,Welterweight
+10/09/2013,Matt Hamill,Thiago Silva,Blue,Light Heavyweight
+10/09/2013,Fabio Maldonado,Joey Beltran,Red,Light Heavyweight
+10/09/2013,Mike Pierce,Rousimar Palhares,Blue,Welterweight
+10/09/2013,TJ Dillashaw,Raphael Assuncao,Blue,Bantamweight
+10/09/2013,Ildemar Alcantara,Igor Araujo,Blue,Welterweight
+10/09/2013,Yan Cabral,David Mitchell,Red,Welterweight
+10/09/2013,Iliarde Santos,Chris Cariaso,Blue,Flyweight
+10/09/2013,Alan Patrick,Garett Whiteley,Red,Lightweight
+09/21/2013,Alexander Gustafsson,Jon Jones,Blue,UFC Light Heavyweight Title
+09/21/2013,Eddie Wineland,Renan Barao,Blue,UFC Interim Bantamweight Title
+09/21/2013,Brendan Schaub,Matt Mitrione,Red,Heavyweight
+09/21/2013,Francis Carmont,Constantinos Philippou,Red,Middleweight
+09/21/2013,Khabib Nurmagomedov,Pat Healy,Red,Lightweight
+09/21/2013,Myles Jury,Mike Ricci,Red,Lightweight
+09/21/2013,Ivan Menjivar,Wilson Reis,Blue,Bantamweight
+09/21/2013,Stephen Thompson,Chris Clements,Red,Welterweight
+09/21/2013,Mitch Gagnon,Dustin Kimura,Red,Bantamweight
+09/21/2013,Renee Forte,John Makdessi,Blue,Lightweight
+09/21/2013,Jesse Ronson,Michel Prazeres,Blue,Lightweight
+09/21/2013,Alex Caceres,Roland Delorme,Red,Bantamweight
+09/21/2013,Daniel Omielanczuk,Nandor Guelmino,Red,Heavyweight
+09/04/2013,Glover Teixeira,Ryan Bader,Red,Light Heavyweight
+09/04/2013,Yushin Okami,Jacare Souza,Blue,Middleweight
+09/04/2013,Jussier Formiga,Joseph Benavidez,Blue,Flyweight
+09/04/2013,Francisco Trinaldo,Piotr Hallmann,Blue,Lightweight
+09/04/2013,Tor Troeng,Rafael Natal,Blue,Middleweight
+09/04/2013,Ali Bagautinov,Marcos Vinicius,Red,Flyweight
+09/04/2013,Edimilson Souza,Felipe Arantes,Red,Featherweight
+09/04/2013,Lucas Martins,Ramiro Hernandez,Red,Bantamweight
+09/04/2013,Elias Silverio,Joao Zeferino,Red,Welterweight
+09/04/2013,Keith Wisniewski,Ivan Jorge,Blue,Welterweight
+09/04/2013,Yuri Villefort,Sean Spencer,Blue,Welterweight
+08/31/2013,Anthony Pettis,Benson Henderson,Red,UFC Lightweight Title
+08/31/2013,Frank Mir,Josh Barnett,Blue,Heavyweight
+08/31/2013,Clay Guida,Chad Mendes,Blue,Featherweight
+08/31/2013,Ben Rothwell,Brandon Vera,Red,Heavyweight
+08/31/2013,Dustin Poirier,Erik Koch,Red,Featherweight
+08/31/2013,Jamie Varner,Gleison Tibau,Blue,Lightweight
+08/31/2013,Tim Elliott,Louis Gaudinot,Red,Flyweight
+08/31/2013,Pascal Krauss,Hyun Gyu Lim,Blue,Welterweight
+08/31/2013,Kyung Ho Kang,Chico Camus,Blue,Bantamweight
+08/31/2013,Nikita Krylov,Soa Palelei,Blue,Heavyweight
+08/31/2013,Al Iaquinta,Ryan Couture,Red,Lightweight
+08/31/2013,Jared Hamman,Magnus Cedenblad,Blue,Middleweight
+08/28/2013,Carlos Condit,Martin Kampmann,Red,Welterweight
+08/28/2013,Rafael Dos Anjos,Donald Cerrone,Red,Lightweight
+08/28/2013,Brian Melancon,Kelvin Gastelum,Blue,Welterweight
+08/28/2013,Robert Whittaker,Court McGee,Blue,Welterweight
+08/28/2013,Erik Perez,Takeya Mizugaki,Blue,Bantamweight
+08/28/2013,Robert McDaniel,Brad Tavares,Blue,Middleweight
+08/28/2013,Dylan Andrews,Papy Abedi,Red,Middleweight
+08/28/2013,Justin Edwards,Brandon Thatch,Blue,Welterweight
+08/28/2013,Darren Elkins,Hatsu Hioki,Red,Featherweight
+08/28/2013,James Head,Jason High,Blue,Welterweight
+08/28/2013,Ben Alloway,Zak Cummings,Blue,Welterweight
+08/17/2013,Chael Sonnen,Mauricio Rua,Red,Light Heavyweight
+08/17/2013,Travis Browne,Alistair Overeem,Red,Heavyweight
+08/17/2013,Iuri Alcantara,Urijah Faber,Blue,Bantamweight
+08/17/2013,Matt Brown,Mike Pyle,Red,Welterweight
+08/17/2013,Uriah Hall,John Howard,Blue,Middleweight
+08/17/2013,Michael Johnson,Joe Lauzon,Red,Lightweight
+08/17/2013,Brad Pickett,Michael McDonald,Blue,Bantamweight
+08/17/2013,Conor McGregor,Max Holloway,Red,Featherweight
+08/17/2013,Mike Brown,Steven Siler,Blue,Featherweight
+08/17/2013,Diego Brandao,Daniel Pineda,Red,Featherweight
+08/17/2013,Cole Miller,Manvel Gamburyan,Blue,Featherweight
+08/17/2013,Ovince Saint Preux,Cody Donovan,Red,Light Heavyweight
+08/17/2013,James Vick,Ramsey Nijem,Red,Lightweight
+08/03/2013,Jose Aldo,Chan Sung Jung,Red,UFC Featherweight Title
+08/03/2013,Phil Davis,Lyoto Machida,Red,Light Heavyweight
+08/03/2013,Thiago Santos,Cezar Ferreira,Blue,Middleweight
+08/03/2013,Tom Watson,Thales Leites,Blue,Middleweight
+08/03/2013,Jose Maria,John Lineker,Blue,Flyweight
+08/03/2013,Anthony Perosh,Vinny Magalhaes,Red,Light Heavyweight
+08/03/2013,Amanda Nunes,Sheila Gaff,Red,Women's Bantamweight
+08/03/2013,Sergio Moraes,Neil Magny,Red,Welterweight
+08/03/2013,Ian McCall,Iliarde Santos,Red,Flyweight
+08/03/2013,Josh Clopton,Rani Yahya,Blue,Featherweight
+08/03/2013,Francimar Barroso,Ednaldo Oliveira,Red,Light Heavyweight
+08/03/2013,Bristol Marunde,Viscardi Andrade,Blue,Welterweight
+07/27/2013,Demetrious Johnson,John Moraga,Red,UFC Flyweight Title
+07/27/2013,Rory MacDonald,Jake Ellenberger,Red,Welterweight
+07/27/2013,Bobby Voelker,Robbie Lawler,Blue,Welterweight
+07/27/2013,Liz Carmouche,Jessica Andrade,Red,Women's Bantamweight
+07/27/2013,Michael Chiesa,Jorge Masvidal,Blue,Lightweight
+07/27/2013,Danny Castillo,Tim Means,Red,Lightweight
+07/27/2013,Mac Danzig,Melvin Guillard,Blue,Lightweight
+07/27/2013,Yves Edwards,Daron Cruickshank,Blue,Lightweight
+07/27/2013,Trevor Smith,Ed Herman,Blue,Middleweight
+07/27/2013,Germaine de Randamie,Julie Kedzie,Red,Women's Bantamweight
+07/27/2013,Justin Salas,Aaron Riley,Red,Lightweight
+07/27/2013,Yaotzin Meza,John Albert,Red,Bantamweight
+07/06/2013,Anderson Silva,Chris Weidman,Blue,UFC Middleweight Title
+07/06/2013,Charles Oliveira,Frankie Edgar,Blue,Featherweight
+07/06/2013,Tim Kennedy,Roger Gracie,Red,Middleweight
+07/06/2013,Mark Munoz,Tim Boetsch,Red,Middleweight
+07/06/2013,Cub Swanson,Dennis Siver,Red,Featherweight
+07/06/2013,Chris Leben,Andrew Craig,Blue,Middleweight
+07/06/2013,Kazuki Tokudome,Norman Parke,Blue,Lightweight
+07/06/2013,Dave Herman,Gabriel Gonzaga,Blue,Heavyweight
+07/06/2013,Rafaello Oliveira,Edson Barboza,Blue,Lightweight
+07/06/2013,Brian Melancon,Seth Baczynski,Red,Welterweight
+07/06/2013,David Mitchell,Mike Pierce,Blue,Welterweight
+06/15/2013,Dan Henderson,Rashad Evans,Blue,Light Heavyweight
+06/15/2013,Roy Nelson,Stipe Miocic,Blue,Heavyweight
+06/15/2013,Igor Pokrajac,Ryan Jimmo,Blue,Light Heavyweight
+06/15/2013,Alexis Davis,Rosi Sexton,Red,Women's Bantamweight
+06/15/2013,Shawn Jordan,Pat Barry,Red,Heavyweight
+06/15/2013,Tyron Woodley,Jake Shields,Blue,Welterweight
+06/15/2013,James Krause,Sam Stout,Red,Lightweight
+06/15/2013,Sean Pierson,Kenny Robertson,Red,Welterweight
+06/15/2013,Edwin Figueroa,Roland Delorme,Blue,Bantamweight
+06/15/2013,John Maguire,Mitch Clarke,Blue,Lightweight
+06/15/2013,Yves Jabouin,Dustin Pague,Red,Bantamweight
+06/08/2013,Fabricio Werdum,Antonio Rodrigo Nogueira,Red,Heavyweight
+06/08/2013,William Macario,Leonardo Santos,Blue,Ultimate Fighter Brazil 2 Welterweight Tournament Title
+06/08/2013,Rafael Cavalcante,Thiago Silva,Blue,Light Heavyweight
+06/08/2013,Jason High,Erick Silva,Blue,Welterweight
+06/08/2013,Daniel Sarafian,Eddie Mendez,Red,Middleweight
+06/08/2013,Mike Wilkinson,Rony Jason,Blue,Featherweight
+06/08/2013,Vaughan Lee,Raphael Assuncao,Blue,Bantamweight
+06/08/2013,Felipe Arantes,Godofredo Pepey,Red,Featherweight
+06/08/2013,Leandro Silva,Ildemar Alcantara,Blue,Welterweight
+06/08/2013,Rodrigo Damm,Mizuto Hirota,Red,Featherweight
+06/08/2013,Karlos Vemola,Caio Magalhaes,Blue,Middleweight
+06/08/2013,Anthony Smith,Antonio Braga Neto,Blue,Middleweight
+05/25/2013,Cain Velasquez,Antonio Silva,Red,UFC Heavyweight Title
+05/25/2013,Junior Dos Santos,Mark Hunt,Red,Heavyweight
+05/25/2013,James Te Huna,Glover Teixeira,Blue,Light Heavyweight
+05/25/2013,Gray Maynard,TJ Grant,Blue,Lightweight
+05/25/2013,KJ Noons,Donald Cerrone,Blue,Lightweight
+05/25/2013,Mike Pyle,Rick Story,Red,Welterweight
+05/25/2013,Dennis Bermudez,Max Holloway,Red,Featherweight
+05/25/2013,Robert Whittaker,Colton Smith,Red,Welterweight
+05/25/2013,Abel Trujillo,Khabib Nurmagomedov,Blue,Lightweight
+05/25/2013,Nah-Shon Burrell,Stephen Thompson,Blue,Welterweight
+05/25/2013,George Roop,Brian Bowles,Red,Bantamweight
+05/25/2013,Estevan Payan,Jeremy Stephens,Blue,Featherweight
+05/18/2013,Luke Rockhold,Vitor Belfort,Blue,Middleweight
+05/18/2013,Chris Camozzi,Jacare Souza,Blue,Middleweight
+05/18/2013,Rafael Dos Anjos,Evan Dunham,Red,Lightweight
+05/18/2013,Joao Zeferino,Rafael Natal,Blue,Middleweight
+05/18/2013,Hacran Dias,Nik Lentz,Blue,Featherweight
+05/18/2013,Mike Rio,Francisco Trinaldo,Blue,Lightweight
+05/18/2013,John Cholish,Gleison Tibau,Blue,Lightweight
+05/18/2013,Paulo Thiago,Michel Prazeres,Red,Welterweight
+05/18/2013,Iuri Alcantara,Iliarde Santos,Red,Bantamweight
+05/18/2013,Fabio Maldonado,Roger Hollett,Red,Light Heavyweight
+05/18/2013,Azamat Gashimov,John Lineker,Blue,Flyweight
+05/18/2013,Jussier Formiga,Chris Cariaso,Red,Flyweight
+05/18/2013,Lucas Martins,Jeremy Larsen,Red,Lightweight
+04/27/2013,Jon Jones,Chael Sonnen,Red,UFC Light Heavyweight Title
+04/27/2013,Alan Belcher,Michael Bisping,Blue,Middleweight
+04/27/2013,Cheick Kongo,Roy Nelson,Blue,Heavyweight
+04/27/2013,Phil Davis,Vinny Magalhaes,Red,Light Heavyweight
+04/27/2013,Rustam Khabilov,Yancy Medeiros,Red,Lightweight
+04/27/2013,Gian Villante,Ovince Saint Preux,Blue,Light Heavyweight
+04/27/2013,Sheila Gaff,Sara McMann,Blue,Women's Bantamweight
+04/27/2013,Johnny Bedford,Bryan Caraway,Blue,Bantamweight
+04/27/2013,Leonard Garcia,Cody McKenzie,Blue,Featherweight
+04/27/2013,Kurt Holobaugh,Steven Siler,Blue,Featherweight
+04/20/2013,Gilbert Melendez,Benson Henderson,Blue,UFC Lightweight Title
+04/20/2013,Daniel Cormier,Frank Mir,Red,Heavyweight
+04/20/2013,Nate Diaz,Josh Thomson,Blue,Lightweight
+04/20/2013,Matt Brown,Jordan Mein,Red,Welterweight
+04/20/2013,Darren Elkins,Chad Mendes,Blue,Featherweight
+04/20/2013,Lorenz Larkin,Francis Carmont,Blue,Middleweight
+04/20/2013,Ramsey Nijem,Myles Jury,Blue,Lightweight
+04/20/2013,Darren Uyenoyama,Joseph Benavidez,Blue,Flyweight
+04/20/2013,Tim Means,Jorge Masvidal,Blue,Lightweight
+04/20/2013,Hugo Viana,TJ Dillashaw,Blue,Bantamweight
+04/20/2013,Roger Bowling,Anthony Njokuani,Blue,Lightweight
+04/20/2013,Clifford Starks,Yoel Romero,Blue,Middleweight
+04/13/2013,Scott Jorgensen,Urijah Faber,Blue,Bantamweight
+04/13/2013,Uriah Hall,Kelvin Gastelum,Blue,Ultimate Fighter 17 Middleweight Tournament Title
+04/13/2013,Cat Zingano,Miesha Tate,Red,Women's Bantamweight
+04/13/2013,Gabriel Gonzaga,Travis Browne,Blue,Heavyweight
+04/13/2013,Gilbert Smith,Robert McDaniel,Blue,Middleweight
+04/13/2013,Kevin Casey,Josh Samman,Blue,Middleweight
+04/13/2013,Luke Barnatt,Collin Hart,Red,Middleweight
+04/13/2013,Jimmy Quinlan,Dylan Andrews,Blue,Middleweight
+04/13/2013,Clint Hester,Bristol Marunde,Red,Middleweight
+04/13/2013,Bart Palaszewski,Cole Miller,Blue,Featherweight
+04/13/2013,Maximo Blanco,Sam Sicilia,Red,Featherweight
+04/13/2013,Justin Lawrence,Daniel Pineda,Blue,Featherweight
+04/06/2013,Gegard Mousasi,Ilir Latifi,Red,Light Heavyweight
+04/06/2013,Ryan Couture,Ross Pearson,Blue,Lightweight
+04/06/2013,Matt Mitrione,Philip De Fries,Red,Heavyweight
+04/06/2013,Mike Easton,Brad Pickett,Blue,Bantamweight
+04/06/2013,Pablo Garza,Diego Brandao,Blue,Featherweight
+04/06/2013,Robert Peralta,Akira Corassani,Blue,Featherweight
+04/06/2013,Michael Johnson,Reza Madadi,Blue,Lightweight
+04/06/2013,Tor Troeng,Adam Cella,Red,Middleweight
+04/06/2013,Chris Spang,Adlan Amagov,Blue,Welterweight
+04/06/2013,Marcus Brimage,Conor McGregor,Blue,Featherweight
+04/06/2013,Ryan LaFlare,Ben Alloway,Red,Welterweight
+04/06/2013,Michael Kuiper,Tom Lawlor,Blue,Middleweight
+04/06/2013,Besam Yousef,Papy Abedi,Blue,Welterweight
+03/16/2013,Nick Diaz,Georges St-Pierre,Blue,UFC Welterweight Title
+03/16/2013,Carlos Condit,Johny Hendricks,Blue,Welterweight
+03/16/2013,Jake Ellenberger,Nate Marquardt,Red,Welterweight
+03/16/2013,Nick Ring,Chris Camozzi,Blue,Middleweight
+03/16/2013,Colin Fletcher,Mike Ricci,Blue,Lightweight
+03/16/2013,Bobby Voelker,Patrick Cote,Blue,Welterweight
+03/16/2013,Darren Elkins,Antonio Carvalho,Red,Featherweight
+03/16/2013,Jordan Mein,Dan Miller,Red,Welterweight
+03/16/2013,Daron Cruickshank,John Makdessi,Blue,Lightweight
+03/16/2013,Rick Story,Quinn Mulhern,Red,Welterweight
+03/16/2013,TJ Dillashaw,Issei Tamura,Red,Bantamweight
+03/16/2013,Reuben Duran,George Roop,Blue,Bantamweight
+03/02/2013,Brian Stann,Wanderlei Silva,Blue,Light Heavyweight
+03/02/2013,Mark Hunt,Stefan Struve,Red,Heavyweight
+03/02/2013,Diego Sanchez,Takanori Gomi,Red,Lightweight
+03/02/2013,Hector Lombard,Yushin Okami,Blue,Middleweight
+03/02/2013,Rani Yahya,Mizuto Hirota,Red,Featherweight
+03/02/2013,Dong Hyun Kim,Siyar Bahadurzada,Red,Welterweight
+03/02/2013,Riki Fukuda,Brad Tavares,Blue,Middleweight
+03/02/2013,Takeya Mizugaki,Bryan Caraway,Red,Bantamweight
+03/02/2013,Kazuki Tokudome,Cristiano Marcello,Red,Lightweight
+03/02/2013,Hyun Gyu Lim,Marcelo Guimaraes,Red,Welterweight
+02/23/2013,Liz Carmouche,Ronda Rousey,Blue,UFC Women's Bantamweight Title
+02/23/2013,Dan Henderson,Lyoto Machida,Blue,Light Heavyweight
+02/23/2013,Urijah Faber,Ivan Menjivar,Red,Bantamweight
+02/23/2013,Court McGee,Josh Neer,Red,Welterweight
+02/23/2013,Josh Koscheck,Robbie Lawler,Blue,Welterweight
+02/23/2013,Lavar Johnson,Brendan Schaub,Blue,Heavyweight
+02/23/2013,Anton Kuivanen,Michael Chiesa,Blue,Lightweight
+02/23/2013,Dennis Bermudez,Matt Grice,Red,Featherweight
+02/23/2013,Sam Stout,Caros Fodor,Red,Lightweight
+02/23/2013,Kenny Robertson,Brock Jardine,Red,Welterweight
+02/23/2013,Jon Manley,Neil Magny,Blue,Welterweight
+02/23/2013,Nah-Shon Burrell,Yuri Villefort,Red,Welterweight
+02/16/2013,Michael McDonald,Renan Barao,Blue,UFC Interim Bantamweight Title
+02/16/2013,Dustin Poirier,Cub Swanson,Blue,Featherweight
+02/16/2013,Jimi Manuwa,Cyrille Diabate,Red,Light Heavyweight
+02/16/2013,Jorge Santiago,Gunnar Nelson,Blue,Welterweight
+02/16/2013,James Te Huna,Ryan Jimmo,Red,Light Heavyweight
+02/16/2013,Renee Forte,Terry Etim,Red,Lightweight
+02/16/2013,Danny Castillo,Paul Sass,Red,Lightweight
+02/16/2013,Andy Ogle,Josh Grispi,Red,Featherweight
+02/16/2013,Tom Watson,Stanislav Nedkov,Red,Middleweight
+02/16/2013,Motonobu Tezuka,Vaughan Lee,Blue,Bantamweight
+02/16/2013,Phil Harris,Ulysses Gomez,Red,Flyweight
+02/02/2013,Frankie Edgar,Jose Aldo,Blue,UFC Featherweight Title
+02/02/2013,Rogerio Nogueira,Rashad Evans,Red,Light Heavyweight
+02/02/2013,Alistair Overeem,Antonio Silva,Blue,Heavyweight
+02/02/2013,Jon Fitch,Demian Maia,Blue,Welterweight
+02/02/2013,Ian McCall,Joseph Benavidez,Blue,Flyweight
+02/02/2013,Gleison Tibau,Evan Dunham,Blue,Lightweight
+02/02/2013,Tyron Woodley,Jay Hieron,Red,Welterweight
+02/02/2013,Jacob Volkmann,Bobby Green,Blue,Lightweight
+02/02/2013,Isaac Vallie-Flagg,Yves Edwards,Red,Lightweight
+02/02/2013,Dustin Kimura,Chico Camus,Red,Bantamweight
+02/02/2013,Edwin Figueroa,Francisco Rivera,Blue,Bantamweight
+01/26/2013,John Dodson,Demetrious Johnson,Blue,UFC Flyweight Title
+01/26/2013,Glover Teixeira,Quinton Jackson,Red,Light Heavyweight
+01/26/2013,Anthony Pettis,Donald Cerrone,Red,Lightweight
+01/26/2013,Ricardo Lamas,Erik Koch,Red,Featherweight
+01/26/2013,TJ Grant,Matt Wiman,Red,Lightweight
+01/26/2013,Clay Guida,Hatsu Hioki,Red,Featherweight
+01/26/2013,Mike Stumpf,Pascal Krauss,Blue,Welterweight
+01/26/2013,Vladimir Matyushenko,Ryan Bader,Blue,Light Heavyweight
+01/26/2013,Mike Russow,Shawn Jordan,Blue,Heavyweight
+01/26/2013,Sean Spencer,Rafael Natal,Blue,Middleweight
+01/26/2013,Simeon Thoresen,David Mitchell,Blue,Welterweight
+01/19/2013,Vitor Belfort,Michael Bisping,Red,Middleweight
+01/19/2013,Daniel Sarafian,CB Dollaway,Blue,Middleweight
+01/19/2013,Gabriel Gonzaga,Ben Rothwell,Red,Heavyweight
+01/19/2013,Thiago Tavares,Khabib Nurmagomedov,Blue,Lightweight
+01/19/2013,Godofredo Pepey,Milton Vieira,Red,Featherweight
+01/19/2013,Andrew Craig,Ronny Markes,Blue,Middleweight
+01/19/2013,Diego Nunes,Nik Lentz,Blue,Featherweight
+01/19/2013,Lucas Martins,Edson Barboza,Blue,Lightweight
+01/19/2013,Wagner Prado,Ildemar Alcantara,Blue,Light Heavyweight
+01/19/2013,CJ Keith,Francisco Trinaldo,Blue,Lightweight
+12/29/2012,Cain Velasquez,Junior Dos Santos,Red,UFC Heavyweight Title
+12/29/2012,Jim Miller,Joe Lauzon,Red,Lightweight
+12/29/2012,Constantinos Philippou,Tim Boetsch,Red,Middleweight
+12/29/2012,Alan Belcher,Yushin Okami,Blue,Middleweight
+12/29/2012,Chris Leben,Derek Brunson,Blue,Middleweight
+12/29/2012,Brad Pickett,Eddie Wineland,Blue,Bantamweight
+12/29/2012,Erik Perez,Byron Bloodworth,Red,Bantamweight
+12/29/2012,Jamie Varner,Melvin Guillard,Red,Lightweight
+12/29/2012,Myles Jury,Michael Johnson,Red,Lightweight
+12/29/2012,Philip De Fries,Todd Duffee,Blue,Heavyweight
+12/29/2012,Max Holloway,Leonard Garcia,Red,Featherweight
+12/29/2012,John Moraga,Chris Cariaso,Red,Flyweight
+12/15/2012,Matt Mitrione,Roy Nelson,Blue,Heavyweight
+12/15/2012,Mike Ricci,Colton Smith,Blue,Ultimate Fighter 16 Welterweight Tournament Title
+12/15/2012,Pat Barry,Shane del Rosario,Red,Heavyweight
+12/15/2012,Jonathan Brookins,Dustin Poirier,Blue,Featherweight
+12/15/2012,James Head,Mike Pyle,Blue,Welterweight
+12/15/2012,Marcos Vinicius,Johnny Bedford,Blue,Bantamweight
+12/15/2012,Vinc Pichel,Rustam Khabilov,Blue,Lightweight
+12/15/2012,TJ Waldburger,Nick Catone,Red,Welterweight
+12/15/2012,Reuben Duran,Hugo Viana,Blue,Bantamweight
+12/15/2012,John Cofer,Mike Rio,Blue,Lightweight
+12/15/2012,Tim Elliott,Jared Papazian,Red,Flyweight
+12/14/2012,George Sotiropoulos,Ross Pearson,Blue,Lightweight
+12/14/2012,Brad Scott,Robert Whittaker,Blue,Ultimate Fighter Australia vs. UK Welterweight Tournament Title
+12/14/2012,Colin Fletcher,Norman Parke,Blue,Ultimate Fighter Australia vs. UK Lightweight Tournament Title
+12/14/2012,Rousimar Palhares,Hector Lombard,Blue,Middleweight
+12/14/2012,Yaotzin Meza,Chad Mendes,Blue,Featherweight
+12/14/2012,Mike Pierce,Seth Baczynski,Red,Welterweight
+12/14/2012,Manuel Rodriguez,Ben Alloway,Blue,Welterweight
+12/14/2012,Brendan Loughnane,Mike Wilkinson,Blue,Lightweight
+12/14/2012,Nick Penner,Cody Donovan,Blue,Light Heavyweight
+12/08/2012,Benson Henderson,Nate Diaz,Red,UFC Lightweight Title
+12/08/2012,Mauricio Rua,Alexander Gustafsson,Blue,Light Heavyweight
+12/08/2012,BJ Penn,Rory MacDonald,Blue,Welterweight
+12/08/2012,Matt Brown,Mike Swick,Red,Welterweight
+12/08/2012,Jeremy Stephens,Yves Edwards,Blue,Lightweight
+12/08/2012,Mike Easton,Raphael Assuncao,Blue,Bantamweight
+12/08/2012,Joe Proctor,Ramsey Nijem,Blue,Lightweight
+12/08/2012,Henry Martinez,Daron Cruickshank,Blue,Lightweight
+12/08/2012,Abel Trujillo,Marcus LeVesseur,Red,Lightweight
+12/08/2012,Dennis Siver,Nam Phan,Red,Featherweight
+12/08/2012,John Albert,Scott Jorgensen,Blue,Bantamweight
+11/17/2012,Carlos Condit,Georges St-Pierre,Blue,UFC Welterweight Title
+11/17/2012,Martin Kampmann,Johny Hendricks,Blue,Welterweight
+11/17/2012,Tom Lawlor,Francis Carmont,Blue,Middleweight
+11/17/2012,Rafael Dos Anjos,Mark Bocek,Red,Lightweight
+11/17/2012,Pablo Garza,Mark Hominick,Red,Featherweight
+11/17/2012,Alessio Sakara,Patrick Cote,Blue,Middleweight
+11/17/2012,Chad Griggs,Cyrille Diabate,Blue,Light Heavyweight
+11/17/2012,John Makdessi,Sam Stout,Red,Lightweight
+11/17/2012,Rodrigo Damm,Antonio Carvalho,Blue,Featherweight
+11/17/2012,Matthew Riddle,John Maguire,Red,Welterweight
+11/17/2012,Ivan Menjivar,Azamat Gashimov,Red,Bantamweight
+11/17/2012,Darren Elkins,Steven Siler,Red,Featherweight
+11/10/2012,Cung Le,Rich Franklin,Red,Middleweight
+11/10/2012,Paulo Thiago,Dong Hyun Kim,Blue,Welterweight
+11/10/2012,Takanori Gomi,Mac Danzig,Red,Lightweight
+11/10/2012,Jon Tuck,Zhang Tiequan,Red,Lightweight
+11/10/2012,Takeya Mizugaki,Jeff Hougland,Red,Bantamweight
+11/10/2012,Motonobu Tezuka,Alex Caceres,Blue,Bantamweight
+11/10/2012,John Lineker,Yasuhiro Urushitani,Red,Flyweight
+11/10/2012,Riki Fukuda,Tom DeBlass,Red,Middleweight
+10/13/2012,Stephan Bonnar,Anderson Silva,Blue,Light Heavyweight
+10/13/2012,Dave Herman,Antonio Rodrigo Nogueira,Blue,Heavyweight
+10/13/2012,Glover Teixeira,Fabio Maldonado,Red,Light Heavyweight
+10/13/2012,Jon Fitch,Erick Silva,Red,Welterweight
+10/13/2012,Wagner Prado,Phil Davis,Blue,Light Heavyweight
+10/13/2012,Rick Story,Demian Maia,Blue,Welterweight
+10/13/2012,Sam Sicilia,Rony Jason,Blue,Featherweight
+10/13/2012,Francisco Trinaldo,Gleison Tibau,Blue,Lightweight
+10/13/2012,Joey Gambino,Diego Brandao,Blue,Featherweight
+10/13/2012,Renee Forte,Sergio Moraes,Blue,Welterweight
+10/13/2012,Luiz Cane,Chris Camozzi,Blue,Middleweight
+10/13/2012,Cristiano Marcello,Reza Madadi,Red,Lightweight
+10/05/2012,Antonio Silva,Travis Browne,Red,Heavyweight
+10/05/2012,Jake Ellenberger,Jay Hieron,Red,Welterweight
+10/05/2012,Jussier Formiga,John Dodson,Blue,Flyweight
+10/05/2012,Josh Neer,Justin Edwards,Blue,Welterweight
+10/05/2012,Michael Johnson,Danny Castillo,Red,Lightweight
+10/05/2012,Aaron Simpson,Mike Pierce,Blue,Welterweight
+10/05/2012,Marcus LeVesseur,Carlo Prater,Red,Lightweight
+10/05/2012,Jacob Volkmann,Shane Roller,Red,Lightweight
+10/05/2012,Bart Palaszewski,Diego Nunes,Blue,Featherweight
+10/05/2012,Darren Uyenoyama,Phil Harris,Red,Flyweight
+09/29/2012,Stefan Struve,Stipe Miocic,Red,Heavyweight
+09/29/2012,Amir Sadollah,Dan Hardy,Blue,Welterweight
+09/29/2012,Brad Pickett,Yves Jabouin,Red,Bantamweight
+09/29/2012,Paul Sass,Matt Wiman,Blue,Lightweight
+09/29/2012,John Hathaway,John Maguire,Red,Welterweight
+09/29/2012,Duane Ludwig,Che Mills,Blue,Welterweight
+09/29/2012,Kyle Kingsbury,Jimi Manuwa,Blue,Light Heavyweight
+09/29/2012,Akira Corassani,Andy Ogle,Red,Featherweight
+09/29/2012,Tom Watson,Brad Tavares,Blue,Middleweight
+09/29/2012,Gunnar Nelson,DaMarques Johnson,Red,Catch Weight
+09/29/2012,Jason Young,Robert Peralta,Blue,Featherweight
+09/22/2012,Vitor Belfort,Jon Jones,Blue,UFC Light Heavyweight Title
+09/22/2012,Joseph Benavidez,Demetrious Johnson,Blue,UFC Flyweight Title
+09/22/2012,Brian Stann,Michael Bisping,Blue,Middleweight
+09/22/2012,Roger Hollett,Matt Hamill,Blue,Light Heavyweight
+09/22/2012,Cub Swanson,Charles Oliveira,Red,Featherweight
+09/22/2012,Vinny Magalhaes,Igor Pokrajac,Red,Light Heavyweight
+09/22/2012,Evan Dunham,TJ Grant,Blue,Lightweight
+09/22/2012,Sean Pierson,Lance Benoist,Red,Welterweight
+09/22/2012,Marcus Brimage,Jimy Hettes,Red,Featherweight
+09/22/2012,Simeon Thoresen,Seth Baczynski,Blue,Welterweight
+09/22/2012,Mitch Gagnon,Walel Watson,Red,Bantamweight
+09/22/2012,Kyle Noke,Charlie Brenneman,Red,Welterweight
+08/11/2012,Frankie Edgar,Benson Henderson,Blue,UFC Lightweight Title
+08/11/2012,Donald Cerrone,Melvin Guillard,Red,Lightweight
+08/11/2012,Yushin Okami,Buddy Roberts,Red,Middleweight
+08/11/2012,Justin Lawrence,Max Holloway,Blue,Featherweight
+08/11/2012,Tommy Hayden,Dennis Bermudez,Blue,Featherweight
+08/11/2012,Jared Hamman,Michael Kuiper,Blue,Middleweight
+08/11/2012,Ken Stone,Erik Perez,Blue,Bantamweight
+08/11/2012,Dustin Pague,Chico Camus,Blue,Bantamweight
+08/11/2012,Nik Lentz,Eiji Mitsuoka,Red,Featherweight
+08/04/2012,Brandon Vera,Mauricio Rua,Blue,Light Heavyweight
+08/04/2012,Ryan Bader,Lyoto Machida,Blue,Light Heavyweight
+08/04/2012,Jamie Varner,Joe Lauzon,Blue,Lightweight
+08/04/2012,Mike Swick,DaMarques Johnson,Red,Welterweight
+08/04/2012,Nam Phan,Cole Miller,Red,Featherweight
+08/04/2012,Josh Grispi,Rani Yahya,Blue,Featherweight
+08/04/2012,Philip De Fries,Oli Thompson,Red,Heavyweight
+08/04/2012,Manvel Gamburyan,Michihiro Omigawa,Red,Featherweight
+08/04/2012,John Moraga,Ulysses Gomez,Red,Flyweight
+07/21/2012,Renan Barao,Urijah Faber,Red,UFC Interim Bantamweight Title
+07/21/2012,Hector Lombard,Tim Boetsch,Blue,Middleweight
+07/21/2012,Cheick Kongo,Shawn Jordan,Red,Heavyweight
+07/21/2012,Brian Ebersole,James Head,Blue,Welterweight
+07/21/2012,Court McGee,Nick Ring,Blue,Middleweight
+07/21/2012,Ryan Jimmo,Anthony Perosh,Red,Light Heavyweight
+07/21/2012,Bryan Caraway,Mitch Gagnon,Red,Bantamweight
+07/21/2012,Daniel Pineda,Antonio Carvalho,Blue,Featherweight
+07/21/2012,Anton Kuivanen,Mitch Clarke,Red,Lightweight
+07/11/2012,Chris Weidman,Mark Munoz,Red,Middleweight
+07/11/2012,Joey Beltran,James Te Huna,Blue,Light Heavyweight
+07/11/2012,Kenny Robertson,Aaron Simpson,Blue,Welterweight
+07/11/2012,Karlos Vemola,Francis Carmont,Blue,Middleweight
+07/11/2012,TJ Dillashaw,Vaughan Lee,Red,Bantamweight
+07/11/2012,Rafael Dos Anjos,Anthony Njokuani,Red,Lightweight
+07/11/2012,Alex Caceres,Damacio Page,Red,Bantamweight
+07/11/2012,Chris Cariaso,Josh Ferguson,Red,Flyweight
+07/11/2012,Rafael Natal,Andrew Craig,Blue,Middleweight
+07/11/2012,Dan Stittgen,Marcelo Guimaraes,Blue,Welterweight
+07/11/2012,Raphael Assuncao,Issei Tamura,Red,Bantamweight
+07/07/2012,Chael Sonnen,Anderson Silva,Blue,UFC Middleweight Title
+07/07/2012,Forrest Griffin,Tito Ortiz,Red,Light Heavyweight
+07/07/2012,Cung Le,Patrick Cote,Red,Middleweight
+07/07/2012,Demian Maia,Dong Hyun Kim,Red,Welterweight
+07/07/2012,Chad Mendes,Cody McKenzie,Red,Featherweight
+07/07/2012,Mike Easton,Ivan Menjivar,Red,Bantamweight
+07/07/2012,Fabricio Camoes,Melvin Guillard,Blue,Lightweight
+07/07/2012,Khabib Nurmagomedov,Gleison Tibau,Red,Lightweight
+07/07/2012,Riki Fukuda,Constantinos Philippou,Blue,Middleweight
+07/07/2012,Shane Roller,John Alessio,Red,Lightweight
+07/07/2012,Rafaello Oliveira,Yoislandy Izquierdo,Red,Lightweight
+06/23/2012,Wanderlei Silva,Rich Franklin,Blue,Catch Weight
+06/23/2012,Sergio Moraes,Cezar Ferreira,Blue,Ultimate Fighter Brazil 1 Middleweight Tournament Title
+06/23/2012,Godofredo Pepey,Rony Jason,Blue,Ultimate Fighter Brazil 1 Featherweight Tournament Title
+06/23/2012,Fabricio Werdum,Mike Russow,Red,Heavyweight
+06/23/2012,Hacran Dias,Iuri Alcantara,Red,Featherweight
+06/23/2012,Rodrigo Damm,Anistavio Medeiros,Red,Featherweight
+06/23/2012,Delson Heleno,Francisco Trinaldo,Blue,Middleweight
+06/23/2012,John Teixeira,Hugo Viana,Blue,Featherweight
+06/23/2012,Thiago Perpetuo,Leonardo Mafra,Red,Middleweight
+06/23/2012,Marcos Vinicius,Wagner Campos,Red,Featherweight
+06/22/2012,Gray Maynard,Clay Guida,Red,Lightweight
+06/22/2012,Spencer Fisher,Sam Stout,Blue,Lightweight
+06/22/2012,Brian Ebersole,TJ Waldburger,Red,Welterweight
+06/22/2012,Ross Pearson,Cub Swanson,Blue,Featherweight
+06/22/2012,Ricardo Lamas,Hatsu Hioki,Red,Featherweight
+06/22/2012,Ramsey Nijem,CJ Keith,Red,Lightweight
+06/22/2012,Rick Story,Brock Jardine,Red,Welterweight
+06/22/2012,Steven Siler,Joey Gambino,Red,Featherweight
+06/22/2012,Chris Camozzi,Nick Catone,Red,Middleweight
+06/22/2012,Luis Ramos,Matt Brown,Blue,Welterweight
+06/22/2012,Ricardo Funch,Dan Miller,Blue,Welterweight
+06/22/2012,Ken Stone,Dustin Pague,Red,Bantamweight
+06/08/2012,Demetrious Johnson,Ian McCall,Red,Flyweight
+06/08/2012,Charlie Brenneman,Erick Silva,Blue,Welterweight
+06/08/2012,Josh Neer,Mike Pyle,Blue,Welterweight
+06/08/2012,Scott Jorgensen,Eddie Wineland,Blue,Bantamweight
+06/08/2012,Mike Pierce,Carlos Eduardo Rocha,Red,Welterweight
+06/08/2012,Lance Benoist,Seth Baczynski,Blue,Welterweight
+06/08/2012,Leonard Garcia,Matt Grice,Blue,Featherweight
+06/08/2012,Jared Papazian,Dustin Pague,Blue,Bantamweight
+06/08/2012,Tim Means,Justin Salas,Red,Lightweight
+06/08/2012,Buddy Roberts,Caio Magalhaes,Red,Middleweight
+06/08/2012,Bernardo Magalhaes,Henry Martinez,Blue,Lightweight
+06/08/2012,Jake Hecht,Sean Pierson,Blue,Welterweight
+06/01/2012,Jake Ellenberger,Martin Kampmann,Blue,Welterweight
+06/01/2012,Al Iaquinta,Michael Chiesa,Blue,Ultimate Fighter 15 Lightweight Tournament Title
+06/01/2012,Jonathan Brookins,Charles Oliveira,Blue,Featherweight
+06/01/2012,Max Holloway,Pat Schilling,Red,Featherweight
+06/01/2012,John Cofer,Justin Lawrence,Blue,Lightweight
+06/01/2012,Chris Tickle,Daron Cruickshank,Blue,Lightweight
+06/01/2012,Chris Saunders,Myles Jury,Blue,Lightweight
+06/01/2012,Sam Sicilia,Cristiano Marcello,Red,Lightweight
+06/01/2012,Joe Proctor,Jeremy Larsen,Red,Lightweight
+06/01/2012,John Albert,Erik Perez,Blue,Bantamweight
+05/26/2012,Frank Mir,Junior Dos Santos,Blue,UFC Heavyweight Title
+05/26/2012,Cain Velasquez,Antonio Silva,Red,Heavyweight
+05/26/2012,Roy Nelson,Dave Herman,Red,Heavyweight
+05/26/2012,Stipe Miocic,Shane del Rosario,Red,Heavyweight
+05/26/2012,Lavar Johnson,Stefan Struve,Blue,Heavyweight
+05/26/2012,Diego Brandao,Darren Elkins,Blue,Featherweight
+05/26/2012,Edson Barboza,Jamie Varner,Blue,Lightweight
+05/26/2012,CB Dollaway,Jason Miller,Red,Middleweight
+05/26/2012,Duane Ludwig,Dan Hardy,Blue,Welterweight
+05/26/2012,Jacob Volkmann,Paul Sass,Blue,Lightweight
+05/26/2012,Kyle Kingsbury,Glover Teixeira,Blue,Light Heavyweight
+05/26/2012,Daniel Pineda,Mike Brown,Blue,Featherweight
+05/15/2012,Dustin Poirier,Chan Sung Jung,Blue,Featherweight
+05/15/2012,Amir Sadollah,Jorge Lopez,Red,Welterweight
+05/15/2012,Donald Cerrone,Jeremy Stephens,Red,Lightweight
+05/15/2012,Jeff Hougland,Yves Jabouin,Blue,Bantamweight
+05/15/2012,Fabio Maldonado,Igor Pokrajac,Blue,Light Heavyweight
+05/15/2012,Tom Lawlor,Jason MacDonald,Red,Middleweight
+05/15/2012,Dongi Yang,Brad Tavares,Blue,Middleweight
+05/15/2012,Marcus LeVesseur,Cody McKenzie,Blue,Lightweight
+05/15/2012,TJ Grant,Carlo Prater,Red,Lightweight
+05/15/2012,Rafael Dos Anjos,Kamal Shalorus,Red,Lightweight
+05/15/2012,Johnny Eduardo,Jeff Curran,Red,Bantamweight
+05/15/2012,Alex Soto,Francisco Rivera,Blue,Bantamweight
+05/05/2012,Nate Diaz,Jim Miller,Red,Lightweight
+05/05/2012,Josh Koscheck,Johny Hendricks,Blue,Welterweight
+05/05/2012,Rousimar Palhares,Alan Belcher,Blue,Middleweight
+05/05/2012,Pat Barry,Lavar Johnson,Blue,Heavyweight
+05/05/2012,Michael Johnson,Tony Ferguson,Red,Lightweight
+05/05/2012,John Dodson,Tim Elliott,Red,Flyweight
+05/05/2012,Pascal Krauss,John Hathaway,Blue,Welterweight
+05/05/2012,John Lineker,Louis Gaudinot,Blue,Flyweight
+05/05/2012,Danny Castillo,John Cholish,Red,Lightweight
+05/05/2012,Dennis Bermudez,Pablo Garza,Red,Featherweight
+05/05/2012,Roland Delorme,Nick Denis,Red,Bantamweight
+05/05/2012,Karlos Vemola,Mike Massenzio,Red,Middleweight
+04/21/2012,Jon Jones,Rashad Evans,Red,UFC Light Heavyweight Title
+04/21/2012,Rory MacDonald,Che Mills,Red,Welterweight
+04/21/2012,Brendan Schaub,Ben Rothwell,Blue,Heavyweight
+04/21/2012,Michael McDonald,Miguel Torres,Red,Bantamweight
+04/21/2012,Eddie Yagin,Mark Hominick,Red,Featherweight
+04/21/2012,John Alessio,Mark Bocek,Blue,Lightweight
+04/21/2012,Travis Browne,Chad Griggs,Red,Heavyweight
+04/21/2012,Matt Brown,Stephen Thompson,Red,Welterweight
+04/21/2012,John Makdessi,Anthony Njokuani,Blue,Lightweight
+04/21/2012,Mac Danzig,Efrain Escudero,Red,Lightweight
+04/21/2012,Chris Clements,Keith Wisniewski,Red,Welterweight
+04/21/2012,Marcus Brimage,Maximo Blanco,Red,Featherweight
+04/14/2012,Thiago Silva,Alexander Gustafsson,Blue,Light Heavyweight
+04/14/2012,Brian Stann,Alessio Sakara,Red,Middleweight
+04/14/2012,Paulo Thiago,Siyar Bahadurzada,Blue,Welterweight
+04/14/2012,Diego Nunes,Dennis Siver,Blue,Featherweight
+04/14/2012,John Maguire,DaMarques Johnson,Red,Welterweight
+04/14/2012,Damacio Page,Brad Pickett,Blue,Bantamweight
+04/14/2012,Papy Abedi,James Head,Blue,Welterweight
+04/14/2012,Cyrille Diabate,Tom DeBlass,Red,Light Heavyweight
+04/14/2012,Francis Carmont,Magnus Cedenblad,Red,Middleweight
+04/14/2012,Reza Madadi,Yoislandy Izquierdo,Red,Lightweight
+04/14/2012,Simeon Thoresen,Besam Yousef,Red,Welterweight
+04/14/2012,Jason Young,Eric Wisely,Red,Featherweight
+03/02/2012,Martin Kampmann,Thiago Alves,Red,Welterweight
+03/02/2012,Joseph Benavidez,Yasuhiro Urushitani,Red,Flyweight
+03/02/2012,Court McGee,Constantinos Philippou,Blue,Middleweight
+03/02/2012,Aaron Rosa,James Te Huna,Blue,Light Heavyweight
+03/02/2012,Anthony Perosh,Nick Penner,Red,Light Heavyweight
+03/02/2012,Cole Miller,Steven Siler,Blue,Featherweight
+03/02/2012,Andrew Craig,Kyle Noke,Red,Middleweight
+03/02/2012,Jake Hecht,TJ Waldburger,Blue,Welterweight
+03/02/2012,Daniel Pineda,Mackens Semerzier,Red,Featherweight
+03/02/2012,Shawn Jordan,Oli Thompson,Red,Heavyweight
+02/25/2012,Frankie Edgar,Benson Henderson,Blue,UFC Lightweight Title
+02/25/2012,Quinton Jackson,Ryan Bader,Blue,Light Heavyweight
+02/25/2012,Cheick Kongo,Mark Hunt,Blue,Heavyweight
+02/25/2012,Yoshihiro Akiyama,Jake Shields,Blue,Welterweight
+02/25/2012,Yushin Okami,Tim Boetsch,Blue,Middleweight
+02/25/2012,Hatsu Hioki,Bart Palaszewski,Red,Featherweight
+02/25/2012,Anthony Pettis,Joe Lauzon,Red,Lightweight
+02/25/2012,Eiji Mitsuoka,Takanori Gomi,Blue,Lightweight
+02/25/2012,Vaughan Lee,Norifumi Yamamoto,Red,Bantamweight
+02/25/2012,Riki Fukuda,Steve Cantwell,Red,Middleweight
+02/25/2012,Chris Cariaso,Takeya Mizugaki,Red,Bantamweight
+02/25/2012,Issei Tamura,Zhang Tiequan,Red,Featherweight
+02/15/2012,Diego Sanchez,Jake Ellenberger,Blue,Welterweight
+02/15/2012,Dave Herman,Stefan Struve,Blue,Heavyweight
+02/15/2012,Ronny Markes,Aaron Simpson,Red,Middleweight
+02/15/2012,Philip De Fries,Stipe Miocic,Blue,Heavyweight
+02/15/2012,TJ Dillashaw,Walel Watson,Red,Bantamweight
+02/15/2012,John Albert,Ivan Menjivar,Blue,Bantamweight
+02/15/2012,Vagner Rocha,Jonathan Brookins,Blue,Featherweight
+02/15/2012,Justin Salas,Anton Kuivanen,Red,Lightweight
+02/15/2012,Tim Means,Bernardo Magalhaes,Red,Lightweight
+02/04/2012,Carlos Condit,Nick Diaz,Red,UFC Interim Welterweight Title
+02/04/2012,Roy Nelson,Fabricio Werdum,Blue,Heavyweight
+02/04/2012,Mike Pierce,Josh Koscheck,Blue,Welterweight
+02/04/2012,Scott Jorgensen,Renan Barao,Blue,Bantamweight
+02/04/2012,Clifford Starks,Ed Herman,Blue,Middleweight
+02/04/2012,Dustin Poirier,Max Holloway,Red,Featherweight
+02/04/2012,Alex Caceres,Edwin Figueroa,Blue,Bantamweight
+02/04/2012,Chris Cope,Matt Brown,Blue,Welterweight
+02/04/2012,Matthew Riddle,Henry Martinez,Red,Welterweight
+02/04/2012,Rafael Natal,Michael Kuiper,Red,Middleweight
+02/04/2012,Dan Stittgen,Stephen Thompson,Blue,Welterweight
+01/28/2012,Phil Davis,Rashad Evans,Blue,Light Heavyweight
+01/28/2012,Chael Sonnen,Michael Bisping,Red,Middleweight
+01/28/2012,Demian Maia,Chris Weidman,Blue,Middleweight
+01/28/2012,Evan Dunham,Nik Lentz,Red,Lightweight
+01/28/2012,Mike Russow,Jon Olav Einemo,Red,Heavyweight
+01/28/2012,Cub Swanson,George Roop,Red,Featherweight
+01/28/2012,Charles Oliveira,Eric Wisely,Red,Featherweight
+01/28/2012,Michael Johnson,Shane Roller,Red,Lightweight
+01/28/2012,Joey Beltran,Lavar Johnson,Blue,Heavyweight
+01/28/2012,Dustin Jacoby,Chris Camozzi,Blue,Middleweight
+01/20/2012,Jim Miller,Melvin Guillard,Red,Lightweight
+01/20/2012,Josh Neer,Duane Ludwig,Red,Welterweight
+01/20/2012,Jared Papazian,Mike Easton,Blue,Bantamweight
+01/20/2012,Christian Morecraft,Pat Barry,Blue,Heavyweight
+01/20/2012,Eric Schafer,Jorge Rivera,Blue,Middleweight
+01/20/2012,Khabib Nurmagomedov,Kamal Shalorus,Red,Lightweight
+01/20/2012,Daniel Roberts,Charlie Brenneman,Blue,Welterweight
+01/20/2012,Fabricio Camoes,Tommy Hayden,Red,Lightweight
+01/20/2012,Pat Schilling,Daniel Pineda,Blue,Featherweight
+01/20/2012,Nick Denis,Joseph Sandoval,Red,Bantamweight
+01/14/2012,Jose Aldo,Chad Mendes,Red,UFC Featherweight Title
+01/14/2012,Anthony Johnson,Vitor Belfort,Blue,Middleweight
+01/14/2012,Rousimar Palhares,Mike Massenzio,Red,Middleweight
+01/14/2012,Carlo Prater,Erick Silva,Red,Welterweight
+01/14/2012,Edson Barboza,Terry Etim,Red,Lightweight
+01/14/2012,Thiago Tavares,Sam Stout,Red,Lightweight
+01/14/2012,Gabriel Gonzaga,Ednaldo Oliveira,Red,Heavyweight
+01/14/2012,Iuri Alcantara,Michihiro Omigawa,Red,Featherweight
+01/14/2012,Ricardo Funch,Mike Pyle,Blue,Welterweight
+01/14/2012,Felipe Arantes,Antonio Carvalho,Red,Featherweight
+12/30/2011,Alistair Overeem,Brock Lesnar,Red,Heavyweight
+12/30/2011,Donald Cerrone,Nate Diaz,Blue,Lightweight
+12/30/2011,Johny Hendricks,Jon Fitch,Red,Welterweight
+12/30/2011,Vladimir Matyushenko,Alexander Gustafsson,Blue,Light Heavyweight
+12/30/2011,Nam Phan,Jimy Hettes,Blue,Featherweight
+12/30/2011,Ross Pearson,Junior Assuncao,Red,Featherweight
+12/30/2011,Danny Castillo,Anthony Njokuani,Red,Lightweight
+12/30/2011,Dong Hyun Kim,Sean Pierson,Red,Welterweight
+12/30/2011,Jacob Volkmann,Efrain Escudero,Red,Lightweight
+12/30/2011,Diego Nunes,Manvel Gamburyan,Red,Featherweight
+12/10/2011,Lyoto Machida,Jon Jones,Blue,UFC Light Heavyweight Title
+12/10/2011,Frank Mir,Antonio Rodrigo Nogueira,Red,Heavyweight
+12/10/2011,Rogerio Nogueira,Tito Ortiz,Red,Light Heavyweight
+12/10/2011,Brian Ebersole,Claude Patrick,Red,Welterweight
+12/10/2011,Mark Hominick,Chan Sung Jung,Blue,Featherweight
+12/10/2011,Igor Pokrajac,Krzysztof Soszynski,Red,Light Heavyweight
+12/10/2011,Constantinos Philippou,Jared Hamman,Red,Middleweight
+12/10/2011,Dennis Hallman,John Makdessi,Red,Lightweight
+12/10/2011,Walel Watson,Yves Jabouin,Blue,Bantamweight
+12/10/2011,Nik Lentz,Mark Bocek,Blue,Lightweight
+12/10/2011,Rich Attonito,Jake Hecht,Blue,Welterweight
+12/10/2011,John Cholish,Mitch Clarke,Red,Lightweight
+12/03/2011,Jason Miller,Michael Bisping,Blue,Middleweight
+12/03/2011,Dennis Bermudez,Diego Brandao,Blue,Ultimate Fighter 14 Featherweight Tournament Title
+12/03/2011,TJ Dillashaw,John Dodson,Blue,Ultimate Fighter 14 Bantamweight Tournament Title
+12/03/2011,Yves Edwards,Tony Ferguson,Blue,Lightweight
+12/03/2011,Johnny Bedford,Louis Gaudinot,Red,Bantamweight
+12/03/2011,Stephen Bass,Marcus Brimage,Blue,Featherweight
+12/03/2011,Dustin Pague,John Albert,Blue,Bantamweight
+12/03/2011,Josh Ferguson,Roland Delorme,Blue,Bantamweight
+12/03/2011,Josh Clopton,Steven Siler,Blue,Featherweight
+12/03/2011,Dustin Neace,Bryan Caraway,Blue,Featherweight
+11/19/2011,Dan Henderson,Mauricio Rua,Red,Light Heavyweight
+11/19/2011,Wanderlei Silva,Cung Le,Red,Middleweight
+11/19/2011,Urijah Faber,Brian Bowles,Red,Bantamweight
+11/19/2011,Martin Kampmann,Rick Story,Red,Welterweight
+11/19/2011,Stephan Bonnar,Kyle Kingsbury,Red,Light Heavyweight
+11/19/2011,Ryan Bader,Jason Brilz,Red,Light Heavyweight
+11/19/2011,Alex Soto,Michael McDonald,Blue,Bantamweight
+11/19/2011,Tom Lawlor,Chris Weidman,Blue,Middleweight
+11/19/2011,Gleison Tibau,Rafael Dos Anjos,Red,Lightweight
+11/19/2011,Nick Pace,Miguel Torres,Blue,Bantamweight
+11/19/2011,Matt Brown,Seth Baczynski,Blue,Welterweight
+11/19/2011,Danny Castillo,Shamar Bailey,Red,Lightweight
+11/12/2011,Cain Velasquez,Junior Dos Santos,Blue,UFC Heavyweight Title
+11/12/2011,Clay Guida,Benson Henderson,Blue,Lightweight
+11/12/2011,Pablo Garza,Dustin Poirier,Blue,Featherweight
+11/12/2011,Cub Swanson,Ricardo Lamas,Blue,Featherweight
+11/12/2011,Clay Harvison,DaMarques Johnson,Blue,Welterweight
+11/12/2011,Norifumi Yamamoto,Darren Uyenoyama,Blue,Bantamweight
+11/12/2011,Alex Caceres,Cole Escovedo,Red,Bantamweight
+11/12/2011,Mike Pierce,Paul Bradley,Red,Welterweight
+11/12/2011,Aaron Rosa,Matt Lucas,Red,Light Heavyweight
+11/05/2011,Chris Leben,Mark Munoz,Blue,Middleweight
+11/05/2011,Brad Pickett,Renan Barao,Blue,Bantamweight
+11/05/2011,Thiago Alves,Papy Abedi,Red,Welterweight
+11/05/2011,Anthony Perosh,Cyrille Diabate,Red,Light Heavyweight
+11/05/2011,Edward Faaloloto,Terry Etim,Blue,Lightweight
+11/05/2011,John Maguire,Justin Edwards,Red,Welterweight
+11/05/2011,Philip De Fries,Rob Broughton,Red,Heavyweight
+11/05/2011,Michihiro Omigawa,Jason Young,Red,Featherweight
+11/05/2011,Chris Cope,Che Mills,Blue,Welterweight
+11/05/2011,Chris Cariaso,Vaughan Lee,Red,Bantamweight
+10/29/2011,BJ Penn,Nick Diaz,Blue,Welterweight
+10/29/2011,Cheick Kongo,Matt Mitrione,Red,Heavyweight
+10/29/2011,Roy Nelson,Mirko Filipovic,Red,Heavyweight
+10/29/2011,Jeff Curran,Scott Jorgensen,Blue,Bantamweight
+10/29/2011,Hatsu Hioki,George Roop,Red,Featherweight
+10/29/2011,Dennis Siver,Donald Cerrone,Blue,Lightweight
+10/29/2011,Tyson Griffin,Bart Palaszewski,Blue,Featherweight
+10/29/2011,Eliot Marshall,Brandon Vera,Blue,Light Heavyweight
+10/29/2011,Ramsey Nijem,Danny Downes,Red,Lightweight
+10/29/2011,Francis Carmont,Chris Camozzi,Red,Middleweight
+10/29/2011,Dustin Jacoby,Clifford Starks,Blue,Middleweight
+10/08/2011,Frankie Edgar,Gray Maynard,Red,UFC Lightweight Title
+10/08/2011,Jose Aldo,Kenny Florian,Red,UFC Featherweight Title
+10/08/2011,Brian Stann,Chael Sonnen,Blue,Middleweight
+10/08/2011,Leonard Garcia,Nam Phan,Blue,Featherweight
+10/08/2011,Melvin Guillard,Joe Lauzon,Blue,Lightweight
+10/08/2011,Jorge Santiago,Demian Maia,Blue,Middleweight
+10/08/2011,Jeremy Stephens,Anthony Pettis,Blue,Lightweight
+10/08/2011,Stipe Miocic,Joey Beltran,Red,Heavyweight
+10/08/2011,Darren Elkins,Zhang Tiequan,Red,Featherweight
+10/08/2011,Aaron Simpson,Eric Schafer,Red,Middleweight
+10/08/2011,Steve Cantwell,Mike Massenzio,Blue,Middleweight
+10/01/2011,Demetrious Johnson,Dominick Cruz,Blue,UFC Bantamweight Title
+10/01/2011,Stefan Struve,Pat Barry,Red,Heavyweight
+10/01/2011,Charlie Brenneman,Anthony Johnson,Blue,Welterweight
+10/01/2011,Matt Wiman,Mac Danzig,Red,Lightweight
+10/01/2011,Yves Edwards,Rafaello Oliveira,Red,Lightweight
+10/01/2011,Michael Johnson,Paul Sass,Blue,Lightweight
+10/01/2011,Byron Bloodworth,Mike Easton,Blue,Bantamweight
+10/01/2011,Shane Roller,TJ Grant,Blue,Lightweight
+10/01/2011,Keith Wisniewski,Josh Neer,Blue,Welterweight
+10/01/2011,Walel Watson,Joseph Sandoval,Red,Bantamweight
+09/24/2011,Jon Jones,Quinton Jackson,Red,UFC Light Heavyweight Title
+09/24/2011,Matt Hughes,Josh Koscheck,Blue,Welterweight
+09/24/2011,Mark Hunt,Ben Rothwell,Red,Heavyweight
+09/24/2011,Rob Broughton,Travis Browne,Blue,Heavyweight
+09/24/2011,Takanori Gomi,Nate Diaz,Blue,Lightweight
+09/24/2011,Aaron Riley,Tony Ferguson,Blue,Lightweight
+09/24/2011,Nick Ring,Tim Boetsch,Blue,Middleweight
+09/24/2011,Junior Assuncao,Eddie Yagin,Red,Featherweight
+09/24/2011,Takeya Mizugaki,Cole Escovedo,Red,Bantamweight
+09/24/2011,Ricardo Romero,James Te Huna,Blue,Light Heavyweight
+09/17/2011,Jake Ellenberger,Jake Shields,Red,Welterweight
+09/17/2011,Court McGee,Dongi Yang,Red,Middleweight
+09/17/2011,Erik Koch,Jonathan Brookins,Red,Featherweight
+09/17/2011,Jason MacDonald,Alan Belcher,Blue,Middleweight
+09/17/2011,Cody McKenzie,Vagner Rocha,Blue,Lightweight
+09/17/2011,Shamar Bailey,Evan Dunham,Blue,Lightweight
+09/17/2011,Lance Benoist,Matthew Riddle,Red,Welterweight
+09/17/2011,Ken Stone,Donny Walker,Red,Bantamweight
+09/17/2011,Seth Baczynski,Clay Harvison,Red,Welterweight
+09/17/2011,Mike Stumpf,TJ Waldburger,Blue,Welterweight
+09/17/2011,Mike Lullo,Robert Peralta,Blue,Featherweight
+09/17/2011,Justin Edwards,Jorge Lopez,Red,Welterweight
+08/27/2011,Yushin Okami,Anderson Silva,Blue,UFC Middleweight Title
+08/27/2011,Mauricio Rua,Forrest Griffin,Red,Light Heavyweight
+08/27/2011,Ross Pearson,Edson Barboza,Blue,Lightweight
+08/27/2011,Brendan Schaub,Antonio Rodrigo Nogueira,Blue,Heavyweight
+08/27/2011,Luiz Cane,Stanislav Nedkov,Blue,Light Heavyweight
+08/27/2011,Thiago Tavares,Spencer Fisher,Red,Lightweight
+08/27/2011,Dan Miller,Rousimar Palhares,Blue,Middleweight
+08/27/2011,David Mitchell,Paulo Thiago,Blue,Welterweight
+08/27/2011,Johnny Eduardo,Raphael Assuncao,Blue,Bantamweight
+08/27/2011,Luis Ramos,Erick Silva,Blue,Welterweight
+08/27/2011,Iuri Alcantara,Felipe Arantes,Red,Featherweight
+08/27/2011,Yves Jabouin,Ian Loveland,Red,Bantamweight
+08/14/2011,Chris Lytle,Dan Hardy,Red,Welterweight
+08/14/2011,Jim Miller,Benson Henderson,Blue,Lightweight
+08/14/2011,Charles Oliveira,Donald Cerrone,Blue,Lightweight
+08/14/2011,Duane Ludwig,Amir Sadollah,Red,Welterweight
+08/14/2011,Jared Hamman,CB Dollaway,Red,Middleweight
+08/14/2011,Joseph Benavidez,Eddie Wineland,Red,Bantamweight
+08/14/2011,Ed Herman,Kyle Noke,Red,Middleweight
+08/14/2011,Ronny Markes,Karlos Vemola,Red,Light Heavyweight
+08/14/2011,Jimy Hettes,Alex Caceres,Red,Featherweight
+08/14/2011,TJ O'Brien,Cole Miller,Blue,Lightweight
+08/14/2011,Jacob Volkmann,Danny Castillo,Red,Lightweight
+08/14/2011,Edwin Figueroa,Jason Reinhardt,Red,Bantamweight
+08/06/2011,Rashad Evans,Tito Ortiz,Red,Light Heavyweight
+08/06/2011,Yoshihiro Akiyama,Vitor Belfort,Blue,Middleweight
+08/06/2011,Dennis Hallman,Brian Ebersole,Blue,Welterweight
+08/06/2011,Constantinos Philippou,Jorge Rivera,Red,Middleweight
+08/06/2011,Mike Pyle,Rory MacDonald,Blue,Welterweight
+08/06/2011,Matt Hamill,Alexander Gustafsson,Blue,Light Heavyweight
+08/06/2011,Chad Mendes,Rani Yahya,Red,Featherweight
+08/06/2011,Nick Pace,Ivan Menjivar,Blue,Bantamweight
+08/06/2011,Mike Pierce,Johny Hendricks,Blue,Welterweight
+08/06/2011,Mike Brown,Nam Phan,Red,Featherweight
+08/06/2011,Paul Bradley,Rafael Natal,Blue,Middleweight
+07/02/2011,Urijah Faber,Dominick Cruz,Blue,UFC Bantamweight Title
+07/02/2011,Chris Leben,Wanderlei Silva,Red,Middleweight
+07/02/2011,Matt Wiman,Dennis Siver,Blue,Lightweight
+07/02/2011,Ryan Bader,Tito Ortiz,Blue,Light Heavyweight
+07/02/2011,Dong Hyun Kim,Carlos Condit,Blue,Welterweight
+07/02/2011,Melvin Guillard,Shane Roller,Red,Lightweight
+07/02/2011,George Sotiropoulos,Rafael Dos Anjos,Blue,Lightweight
+07/02/2011,Takeya Mizugaki,Brian Bowles,Blue,Bantamweight
+07/02/2011,Brad Tavares,Aaron Simpson,Blue,Middleweight
+07/02/2011,Andre Winner,Anthony Njokuani,Blue,Lightweight
+07/02/2011,Jeff Hougland,Donny Walker,Red,Bantamweight
+06/26/2011,Pat Barry,Cheick Kongo,Blue,Heavyweight
+06/26/2011,Charlie Brenneman,Rick Story,Red,Welterweight
+06/26/2011,Matt Brown,John Howard,Red,Welterweight
+06/26/2011,Matt Mitrione,Christian Morecraft,Red,Heavyweight
+06/26/2011,Tyson Griffin,Manvel Gamburyan,Red,Featherweight
+06/26/2011,Javier Vazquez,Joe Stevenson,Red,Featherweight
+06/26/2011,Joe Lauzon,Curt Warburton,Red,Lightweight
+06/26/2011,Daniel Roberts,Rich Attonito,Blue,Welterweight
+06/26/2011,Matt Grice,Ricardo Lamas,Blue,Featherweight
+06/26/2011,Michael Johnson,Edward Faaloloto,Red,Lightweight
+06/11/2011,Shane Carwin,Junior Dos Santos,Blue,Heavyweight
+06/11/2011,Kenny Florian,Diego Nunes,Red,Featherweight
+06/11/2011,Demian Maia,Mark Munoz,Blue,Middleweight
+06/11/2011,Jon Olav Einemo,Dave Herman,Blue,Heavyweight
+06/11/2011,Vagner Rocha,Donald Cerrone,Blue,Lightweight
+06/11/2011,Yves Edwards,Sam Stout,Blue,Lightweight
+06/11/2011,Jesse Bongfeldt,Chris Weidman,Blue,Middleweight
+06/11/2011,Krzysztof Soszynski,Mike Massenzio,Red,Light Heavyweight
+06/11/2011,Nick Ring,James Head,Red,Middleweight
+06/11/2011,Dustin Poirier,Jason Young,Red,Featherweight
+06/11/2011,Aaron Rosa,Joey Beltran,Blue,Heavyweight
+06/11/2011,Darren Elkins,Michihiro Omigawa,Red,Featherweight
+06/04/2011,Ramsey Nijem,Tony Ferguson,Blue,Ultimate Fighter 13 Welterweight Tournament Title
+06/04/2011,Anthony Pettis,Clay Guida,Blue,Lightweight
+06/04/2011,Ed Herman,Tim Credeur,Red,Middleweight
+06/04/2011,Kyle Kingsbury,Fabio Maldonado,Red,Light Heavyweight
+06/04/2011,Chuck O'Neil,Chris Cope,Blue,Welterweight
+06/04/2011,Danny Downes,Jeremy Stephens,Blue,Lightweight
+06/04/2011,George Roop,Josh Grispi,Red,Featherweight
+06/04/2011,Shamar Bailey,Ryan McGillivray,Red,Welterweight
+06/04/2011,Clay Harvison,Justin Edwards,Red,Welterweight
+06/04/2011,Scott Jorgensen,Ken Stone,Red,Bantamweight
+06/04/2011,Reuben Duran,Francisco Rivera,Red,Bantamweight
+05/28/2011,Matt Hamill,Quinton Jackson,Blue,Light Heavyweight
+05/28/2011,Roy Nelson,Frank Mir,Blue,Heavyweight
+05/28/2011,Stefan Struve,Travis Browne,Blue,Heavyweight
+05/28/2011,Thiago Alves,Rick Story,Blue,Welterweight
+05/28/2011,Jorge Santiago,Brian Stann,Blue,Middleweight
+05/28/2011,Demetrious Johnson,Miguel Torres,Red,Bantamweight
+05/28/2011,Tim Boetsch,Kendall Grove,Red,Middleweight
+05/28/2011,Rafaello Oliveira,Gleison Tibau,Blue,Lightweight
+05/28/2011,Chris Cariaso,Michael McDonald,Blue,Bantamweight
+05/28/2011,Renan Barao,Cole Escovedo,Red,Bantamweight
+04/30/2011,Georges St-Pierre,Jake Shields,Red,UFC Welterweight Title
+04/30/2011,Jose Aldo,Mark Hominick,Red,UFC Featherweight Title
+04/30/2011,Lyoto Machida,Randy Couture,Red,Light Heavyweight
+04/30/2011,Vladimir Matyushenko,Jason Brilz,Red,Light Heavyweight
+04/30/2011,Benson Henderson,Mark Bocek,Red,Lightweight
+04/30/2011,Nate Diaz,Rory MacDonald,Blue,Welterweight
+04/30/2011,Jake Ellenberger,Sean Pierson,Red,Welterweight
+04/30/2011,Claude Patrick,Daniel Roberts,Red,Welterweight
+04/30/2011,Ivan Menjivar,Charlie Valencia,Red,Bantamweight
+04/30/2011,Jason MacDonald,Ryan Jensen,Red,Middleweight
+04/30/2011,John Makdessi,Kyle Watson,Red,Lightweight
+04/30/2011,Yves Jabouin,Pablo Garza,Blue,Featherweight
+03/26/2011,Phil Davis,Rogerio Nogueira,Red,Light Heavyweight
+03/26/2011,Dan Hardy,Anthony Johnson,Blue,Welterweight
+03/26/2011,DaMarques Johnson,Amir Sadollah,Blue,Welterweight
+03/26/2011,Leonard Garcia,Chan Sung Jung,Blue,Featherweight
+03/26/2011,Jon Madsen,Mike Russow,Blue,Heavyweight
+03/26/2011,Mackens Semerzier,Alex Caceres,Red,Featherweight
+03/26/2011,Kris McCray,John Hathaway,Blue,Welterweight
+03/26/2011,Edwin Figueroa,Michael McDonald,Blue,Bantamweight
+03/26/2011,Sean McCorkle,Christian Morecraft,Blue,Heavyweight
+03/26/2011,TJ Waldburger,Johny Hendricks,Blue,Welterweight
+03/26/2011,Aaron Simpson,Mario Miranda,Red,Middleweight
+03/26/2011,Waylon Lowe,Nik Lentz,Blue,Lightweight
+03/19/2011,Mauricio Rua,Jon Jones,Blue,UFC Light Heavyweight Title
+03/19/2011,Urijah Faber,Eddie Wineland,Red,Bantamweight
+03/19/2011,Kamal Shalorus,Jim Miller,Blue,Lightweight
+03/19/2011,Nate Marquardt,Dan Miller,Red,Middleweight
+03/19/2011,Brendan Schaub,Mirko Filipovic,Red,Heavyweight
+03/19/2011,Eliot Marshall,Luiz Cane,Blue,Light Heavyweight
+03/19/2011,Anthony Njokuani,Edson Barboza,Blue,Lightweight
+03/19/2011,Mike Pyle,Ricardo Almeida,Red,Welterweight
+03/19/2011,Gleison Tibau,Kurt Pellegrino,Red,Lightweight
+03/19/2011,Joseph Benavidez,Ian Loveland,Red,Bantamweight
+03/19/2011,Nick Catone,Constantinos Philippou,Red,Catch Weight
+03/19/2011,Raphael Assuncao,Erik Koch,Blue,Featherweight
+03/03/2011,Martin Kampmann,Diego Sanchez,Blue,Welterweight
+03/03/2011,CB Dollaway,Mark Munoz,Blue,Middleweight
+03/03/2011,Alessio Sakara,Chris Weidman,Blue,Middleweight
+03/03/2011,Brian Bowles,Damacio Page,Red,Bantamweight
+03/03/2011,Cyrille Diabate,Steve Cantwell,Red,Light Heavyweight
+03/03/2011,Danny Castillo,Joe Stevenson,Red,Lightweight
+03/03/2011,Shane Roller,Thiago Tavares,Red,Lightweight
+03/03/2011,Takeya Mizugaki,Reuben Duran,Red,Bantamweight
+03/03/2011,Rob Kimmons,Dongi Yang,Blue,Middleweight
+03/03/2011,Rousimar Palhares,David Branch,Red,Middleweight
+03/03/2011,Igor Pokrajac,Todd Brown,Red,Light Heavyweight
+02/26/2011,Michael Bisping,Jorge Rivera,Red,Middleweight
+02/26/2011,George Sotiropoulos,Dennis Siver,Blue,Lightweight
+02/26/2011,Chris Lytle,Brian Ebersole,Blue,Welterweight
+02/26/2011,Chris Camozzi,Kyle Noke,Blue,Middleweight
+02/26/2011,Spencer Fisher,Ross Pearson,Blue,Lightweight
+02/26/2011,Alexander Gustafsson,James Te Huna,Red,Light Heavyweight
+02/26/2011,Nick Ring,Riki Fukuda,Red,Middleweight
+02/26/2011,Anthony Perosh,Tom Blackledge,Red,Light Heavyweight
+02/26/2011,Jason Reinhardt,Zhang Tiequan,Blue,Featherweight
+02/26/2011,Mark Hunt,Chris Tuchscherer,Red,Heavyweight
+02/26/2011,Maciej Jewtuszko,Curt Warburton,Blue,Lightweight
+02/05/2011,Vitor Belfort,Anderson Silva,Blue,UFC Middleweight Title
+02/05/2011,Forrest Griffin,Rich Franklin,Red,Light Heavyweight
+02/05/2011,Ryan Bader,Jon Jones,Blue,Light Heavyweight
+02/05/2011,Jake Ellenberger,Carlos Eduardo Rocha,Red,Welterweight
+02/05/2011,Miguel Torres,Antonio Banuelos,Red,Bantamweight
+02/05/2011,Paul Kelly,Donald Cerrone,Blue,Lightweight
+02/05/2011,Michihiro Omigawa,Chad Mendes,Blue,Featherweight
+02/05/2011,Demetrious Johnson,Norifumi Yamamoto,Red,Bantamweight
+02/05/2011,Gabe Ruediger,Paul Taylor,Blue,Lightweight
+02/05/2011,Ricardo Romero,Kyle Kingsbury,Blue,Light Heavyweight
+02/05/2011,Mike Pierce,Kenny Robertson,Red,Welterweight
+01/22/2011,Melvin Guillard,Evan Dunham,Red,Lightweight
+01/22/2011,Tim Hague,Matt Mitrione,Blue,Heavyweight
+01/22/2011,George Roop,Mark Hominick,Blue,Featherweight
+01/22/2011,Pat Barry,Joey Beltran,Red,Heavyweight
+01/22/2011,Cole Miller,Matt Wiman,Blue,Lightweight
+01/22/2011,Cody McKenzie,Yves Edwards,Blue,Lightweight
+01/22/2011,Mike Guymon,DaMarques Johnson,Blue,Welterweight
+01/22/2011,Rani Yahya,Mike Brown,Red,Featherweight
+01/22/2011,Waylon Lowe,Willamy Freire,Red,Lightweight
+01/22/2011,Charlie Brenneman,Amilcar Alves,Red,Welterweight
+01/22/2011,Chris Cariaso,Will Campuzano,Red,Bantamweight
+01/01/2011,Brian Stann,Chris Leben,Red,Middleweight
+01/01/2011,Dong Hyun Kim,Nate Diaz,Red,Welterweight
+01/01/2011,Takanori Gomi,Clay Guida,Blue,Lightweight
+01/01/2011,Jeremy Stephens,Marcus Davis,Red,Lightweight
+01/01/2011,Josh Grispi,Dustin Poirier,Blue,Featherweight
+01/01/2011,Phil Baroni,Brad Tavares,Blue,Middleweight
+01/01/2011,Mike Brown,Diego Nunes,Blue,Featherweight
+01/01/2011,Greg Soto,Daniel Roberts,Blue,Welterweight
+01/01/2011,Jacob Volkmann,Antonio McKee,Red,Lightweight
+12/11/2010,Josh Koscheck,Georges St-Pierre,Blue,UFC Welterweight Title
+12/11/2010,Sean McCorkle,Stefan Struve,Blue,Heavyweight
+12/11/2010,Charles Oliveira,Jim Miller,Blue,Lightweight
+12/11/2010,Joe Stevenson,Mac Danzig,Blue,Lightweight
+12/11/2010,Thiago Alves,John Howard,Red,Welterweight
+12/11/2010,Dan Miller,Joe Doerksen,Red,Middleweight
+12/11/2010,Mark Bocek,Dustin Hazelett,Red,Lightweight
+12/11/2010,Matthew Riddle,Sean Pierson,Blue,Welterweight
+12/11/2010,TJ Grant,Ricardo Almeida,Blue,Welterweight
+12/11/2010,John Makdessi,Pat Audinwood,Red,Lightweight
+12/04/2010,Michael Johnson,Jonathan Brookins,Blue,Ultimate Fighter 12 Lightweight Tournament Title
+12/04/2010,Stephan Bonnar,Igor Pokrajac,Red,Light Heavyweight
+12/04/2010,Demian Maia,Kendall Grove,Red,Middleweight
+12/04/2010,Johny Hendricks,Rick Story,Blue,Welterweight
+12/04/2010,Nam Phan,Leonard Garcia,Blue,Featherweight
+12/04/2010,Aaron Wilkinson,Cody McKenzie,Blue,Lightweight
+12/04/2010,Tyler Toner,Ian Loveland,Blue,Featherweight
+12/04/2010,Kyle Watson,Sako Chivitchian,Red,Lightweight
+12/04/2010,Nick Pace,Will Campuzano,Red,Bantamweight
+12/04/2010,Fredson Paixao,Pablo Garza,Blue,Featherweight
+12/04/2010,Rich Attonito,David Branch,Blue,Middleweight
+11/20/2010,Lyoto Machida,Quinton Jackson,Blue,Light Heavyweight
+11/20/2010,BJ Penn,Matt Hughes,Red,Welterweight
+11/20/2010,Gerald Harris,Maiquel Falcao,Blue,Middleweight
+11/20/2010,Tim Boetsch,Phil Davis,Blue,Light Heavyweight
+11/20/2010,George Sotiropoulos,Joe Lauzon,Red,Lightweight
+11/20/2010,Brian Foster,Matt Brown,Red,Welterweight
+11/20/2010,Mark Munoz,Aaron Simpson,Red,Middleweight
+11/20/2010,Karo Parisyan,Dennis Hallman,Blue,Welterweight
+11/20/2010,Mike Lullo,Edson Barboza,Blue,Lightweight
+11/20/2010,Paul Kelly,TJ O'Brien,Red,Lightweight
+11/20/2010,Nik Lentz,Tyson Griffin,Red,Lightweight
+11/13/2010,Yushin Okami,Nate Marquardt,Red,Middleweight
+11/13/2010,Dennis Siver,Andre Winner,Red,Lightweight
+11/13/2010,Peter Sobotta,Amir Sadollah,Blue,Welterweight
+11/13/2010,Goran Reljic,Krzysztof Soszynski,Blue,Light Heavyweight
+11/13/2010,Duane Ludwig,Nick Osipczak,Red,Welterweight
+11/13/2010,Alexandre Ferreira,Vladimir Matyushenko,Blue,Light Heavyweight
+11/13/2010,Pascal Krauss,Mark Scanlon,Red,Welterweight
+11/13/2010,Rob Kimmons,Kyle Noke,Blue,Middleweight
+11/13/2010,Seth Petruzelli,Karlos Vemola,Blue,Light Heavyweight
+11/13/2010,Kris McCray,Carlos Eduardo Rocha,Blue,Welterweight
+10/23/2010,Brock Lesnar,Cain Velasquez,Blue,UFC Heavyweight Title
+10/23/2010,Martin Kampmann,Jake Shields,Blue,Welterweight
+10/23/2010,Diego Sanchez,Paulo Thiago,Red,Welterweight
+10/23/2010,Matt Hamill,Tito Ortiz,Red,Light Heavyweight
+10/23/2010,Gabriel Gonzaga,Brendan Schaub,Blue,Heavyweight
+10/23/2010,Ryan Jensen,Court McGee,Blue,Middleweight
+10/23/2010,Patrick Cote,Tom Lawlor,Blue,Middleweight
+10/23/2010,Daniel Roberts,Mike Guymon,Red,Welterweight
+10/23/2010,Paul Taylor,Sam Stout,Blue,Lightweight
+10/23/2010,Chris Camozzi,Dongi Yang,Red,Middleweight
+10/23/2010,Gilbert Yvel,Jon Madsen,Blue,Heavyweight
+10/16/2010,Michael Bisping,Yoshihiro Akiyama,Red,Middleweight
+10/16/2010,Carlos Condit,Dan Hardy,Red,Welterweight
+10/16/2010,John Hathaway,Mike Pyle,Blue,Welterweight
+10/16/2010,Claude Patrick,James Wilks,Red,Welterweight
+10/16/2010,Alexander Gustafsson,Cyrille Diabate,Red,Light Heavyweight
+10/16/2010,Vinicius Queiroz,Rob Broughton,Blue,Heavyweight
+10/16/2010,Mark Holst,Paul Sass,Blue,Lightweight
+10/16/2010,Spencer Fisher,Curt Warburton,Red,Lightweight
+10/16/2010,Fabio Maldonado,James McSweeney,Red,Light Heavyweight
+09/25/2010,Mirko Filipovic,Frank Mir,Blue,Heavyweight
+09/25/2010,Rogerio Nogueira,Ryan Bader,Blue,Light Heavyweight
+09/25/2010,Chris Lytle,Matt Serra,Red,Welterweight
+09/25/2010,Sean Sherk,Evan Dunham,Red,Lightweight
+09/25/2010,Melvin Guillard,Jeremy Stephens,Red,Lightweight
+09/25/2010,CB Dollaway,Joe Doerksen,Red,Middleweight
+09/25/2010,Joey Beltran,Matt Mitrione,Blue,Heavyweight
+09/25/2010,Thiago Tavares,Pat Audinwood,Red,Lightweight
+09/25/2010,Steve Lopez,Waylon Lowe,Blue,Lightweight
+09/25/2010,Julio Paulino,TJ Grant,Blue,Welterweight
+09/25/2010,Mark Hunt,Sean McCorkle,Blue,Heavyweight
+09/15/2010,Nate Marquardt,Rousimar Palhares,Red,Middleweight
+09/15/2010,Charles Oliveira,Efrain Escudero,Red,Lightweight
+09/15/2010,Jim Miller,Gleison Tibau,Red,Lightweight
+09/15/2010,Cole Miller,Ross Pearson,Red,Lightweight
+09/15/2010,John Gunderson,Yves Edwards,Blue,Lightweight
+09/15/2010,Kyle Kingsbury,Jared Hamman,Red,Light Heavyweight
+09/15/2010,David Branch,Tomasz Drwal,Red,Middleweight
+09/15/2010,Rafael Natal,Rich Attonito,Blue,Middleweight
+09/15/2010,TJ Waldburger,David Mitchell,Red,Welterweight
+09/15/2010,Forrest Petz,Brian Foster,Blue,Welterweight
+08/28/2010,Frankie Edgar,BJ Penn,Red,UFC Lightweight Title
+08/28/2010,James Toney,Randy Couture,Blue,Heavyweight
+08/28/2010,Demian Maia,Mario Miranda,Red,Middleweight
+08/28/2010,Gray Maynard,Kenny Florian,Red,Lightweight
+08/28/2010,Marcus Davis,Nate Diaz,Blue,Welterweight
+08/28/2010,Gabe Ruediger,Joe Lauzon,Blue,Lightweight
+08/28/2010,Andre Winner,Nik Lentz,Blue,Lightweight
+08/28/2010,John Salter,Dan Miller,Blue,Middleweight
+08/28/2010,Greg Soto,Nick Osipczak,Red,Welterweight
+08/28/2010,Mike Pierce,Amilcar Alves,Red,Welterweight
+08/07/2010,Anderson Silva,Chael Sonnen,Red,UFC Middleweight Title
+08/07/2010,Thiago Alves,Jon Fitch,Blue,Welterweight
+08/07/2010,Rafael Dos Anjos,Clay Guida,Blue,Lightweight
+08/07/2010,Matt Hughes,Ricardo Almeida,Red,Welterweight
+08/07/2010,Junior Dos Santos,Roy Nelson,Red,Heavyweight
+08/07/2010,Rick Story,Dustin Hazelett,Red,Welterweight
+08/07/2010,Phil Davis,Rodney Wallace,Red,Light Heavyweight
+08/07/2010,Johny Hendricks,Charlie Brenneman,Red,Welterweight
+08/07/2010,Todd Brown,Tim Boetsch,Blue,Light Heavyweight
+08/07/2010,Stefan Struve,Christian Morecraft,Red,Heavyweight
+08/07/2010,Dennis Hallman,Ben Saunders,Red,Welterweight
+08/01/2010,Vladimir Matyushenko,Jon Jones,Blue,Light Heavyweight
+08/01/2010,Yushin Okami,Mark Munoz,Red,Middleweight
+08/01/2010,Jake Ellenberger,John Howard,Red,Welterweight
+08/01/2010,Tyson Griffin,Takanori Gomi,Blue,Lightweight
+08/01/2010,Jacob Volkmann,Paul Kelly,Red,Lightweight
+08/01/2010,DaMarques Johnson,Matthew Riddle,Blue,Welterweight
+08/01/2010,Igor Pokrajac,James Irvin,Red,Light Heavyweight
+08/01/2010,Brian Stann,Mike Massenzio,Red,Middleweight
+08/01/2010,Darren Elkins,Charles Oliveira,Blue,Lightweight
+08/01/2010,Rob Kimmons,Steve Steinbeiss,Red,Middleweight
+07/03/2010,Brock Lesnar,Shane Carwin,Red,UFC Heavyweight Title
+07/03/2010,Yoshihiro Akiyama,Chris Leben,Blue,Middleweight
+07/03/2010,Matt Brown,Chris Lytle,Blue,Welterweight
+07/03/2010,Krzysztof Soszynski,Stephan Bonnar,Blue,Light Heavyweight
+07/03/2010,Kurt Pellegrino,George Sotiropoulos,Blue,Lightweight
+07/03/2010,Chris Tuchscherer,Brendan Schaub,Blue,Heavyweight
+07/03/2010,Seth Petruzelli,Ricardo Romero,Blue,Light Heavyweight
+07/03/2010,Kendall Grove,Goran Reljic,Red,Middleweight
+07/03/2010,David Branch,Gerald Harris,Blue,Middleweight
+07/03/2010,Daniel Roberts,Forrest Petz,Red,Welterweight
+07/03/2010,Jon Madsen,Karlos Vemola,Red,Heavyweight
+06/19/2010,Kris McCray,Court McGee,Blue,Ultimate Fighter 11 Middleweight Tournament Title
+06/19/2010,Keith Jardine,Matt Hamill,Blue,Light Heavyweight
+06/19/2010,Chris Leben,Aaron Simpson,Red,Middleweight
+06/19/2010,Spencer Fisher,Dennis Siver,Blue,Lightweight
+06/19/2010,Jamie Yager,Rich Attonito,Blue,Middleweight
+06/19/2010,Mark Holst,John Gunderson,Blue,Lightweight
+06/19/2010,Seth Baczynski,Brad Tavares,Blue,Middleweight
+06/19/2010,Josh Bryant,Kyle Noke,Blue,Middleweight
+06/19/2010,Chris Camozzi,James Hammortree,Red,Middleweight
+06/19/2010,Travis Browne,James McSweeney,Red,Heavyweight
+06/12/2010,Rich Franklin,Chuck Liddell,Red,Light Heavyweight
+06/12/2010,Mirko Filipovic,Pat Barry,Red,Heavyweight
+06/12/2010,Martin Kampmann,Paulo Thiago,Red,Welterweight
+06/12/2010,Gilbert Yvel,Ben Rothwell,Blue,Heavyweight
+06/12/2010,Rory MacDonald,Carlos Condit,Blue,Welterweight
+06/12/2010,Tyson Griffin,Evan Dunham,Blue,Lightweight
+06/12/2010,Mac Danzig,Matt Wiman,Blue,Lightweight
+06/12/2010,Mario Miranda,David Loiseau,Red,Middleweight
+06/12/2010,James Wilks,Peter Sobotta,Red,Welterweight
+06/12/2010,Claude Patrick,Ricardo Funch,Red,Welterweight
+06/12/2010,Jesse Lennox,Mike Pyle,Blue,Welterweight
+05/29/2010,Rashad Evans,Quinton Jackson,Red,Light Heavyweight
+05/29/2010,Dan Miller,Michael Bisping,Blue,Middleweight
+05/29/2010,Mike Russow,Todd Duffee,Red,Heavyweight
+05/29/2010,Jason Brilz,Rogerio Nogueira,Blue,Light Heavyweight
+05/29/2010,John Hathaway,Diego Sanchez,Red,Welterweight
+05/29/2010,Amir Sadollah,Dong Hyun Kim,Blue,Welterweight
+05/29/2010,Dan Lauzon,Efrain Escudero,Blue,Lightweight
+05/29/2010,Melvin Guillard,Waylon Lowe,Red,Lightweight
+05/29/2010,Cyrille Diabate,Luiz Cane,Red,Light Heavyweight
+05/29/2010,Aaron Riley,Joe Brammer,Red,Lightweight
+05/29/2010,Jesse Forbes,Ryan Jensen,Blue,Middleweight
+05/08/2010,Lyoto Machida,Mauricio Rua,Blue,UFC Light Heavyweight Title
+05/08/2010,Josh Koscheck,Paul Daley,Red,Welterweight
+05/08/2010,Sam Stout,Jeremy Stephens,Blue,Lightweight
+05/08/2010,Matt Mitrione,Kevin Ferguson,Red,Heavyweight
+05/08/2010,Patrick Cote,Alan Belcher,Blue,Middleweight
+05/08/2010,Tom Lawlor,Joe Doerksen,Blue,Middleweight
+05/08/2010,Jonathan Goulet,Marcus Davis,Blue,Welterweight
+05/08/2010,Johny Hendricks,TJ Grant,Red,Welterweight
+05/08/2010,Tim Hague,Joey Beltran,Blue,Heavyweight
+05/08/2010,Mike Guymon,Yoshiyuki Yoshida,Red,Welterweight
+05/08/2010,John Salter,Jason MacDonald,Red,Middleweight
+04/10/2010,Demian Maia,Anderson Silva,Blue,UFC Middleweight Title
+04/10/2010,Frankie Edgar,BJ Penn,Red,UFC Lightweight Title
+04/10/2010,Matt Hughes,Renzo Gracie,Red,Welterweight
+04/10/2010,Rafael Dos Anjos,Terry Etim,Red,Lightweight
+04/10/2010,Kendall Grove,Mark Munoz,Blue,Middleweight
+04/10/2010,Phil Davis,Alexander Gustafsson,Red,Light Heavyweight
+04/10/2010,Nick Osipczak,Rick Story,Blue,Welterweight
+04/10/2010,DaMarques Johnson,Brad Blackburn,Red,Welterweight
+04/10/2010,Paul Kelly,Matt Veach,Red,Lightweight
+04/10/2010,Mostapha Al-Turk,Jon Madsen,Blue,Heavyweight
+03/31/2010,Takanori Gomi,Kenny Florian,Blue,Lightweight
+03/31/2010,Stefan Struve,Roy Nelson,Blue,Heavyweight
+03/31/2010,Nate Quarry,Jorge Rivera,Blue,Middleweight
+03/31/2010,Dennis Siver,Ross Pearson,Blue,Lightweight
+03/31/2010,Rafaello Oliveira,Andre Winner,Blue,Lightweight
+03/31/2010,Jacob Volkmann,Ronys Torres,Red,Lightweight
+03/31/2010,Rob Emerson,Nik Lentz,Blue,Lightweight
+03/31/2010,Gleison Tibau,Caol Uno,Red,Lightweight
+03/31/2010,Lucio Linhares,Yushin Okami,Blue,Middleweight
+03/31/2010,Gerald Harris,Mario Miranda,Red,Middleweight
+03/31/2010,Jason High,Charlie Brenneman,Blue,Welterweight
+03/27/2010,Dan Hardy,Georges St-Pierre,Blue,UFC Welterweight Title
+03/27/2010,Shane Carwin,Frank Mir,Red,UFC Interim Heavyweight Title
+03/27/2010,Kurt Pellegrino,Fabricio Camoes,Red,Lightweight
+03/27/2010,Jon Fitch,Ben Saunders,Red,Welterweight
+03/27/2010,Jim Miller,Mark Bocek,Red,Lightweight
+03/27/2010,Rory Markham,Nate Diaz,Blue,Welterweight
+03/27/2010,Ricardo Almeida,Matt Brown,Red,Welterweight
+03/27/2010,Rousimar Palhares,Tomasz Drwal,Red,Middleweight
+03/27/2010,Rodney Wallace,Jared Hamman,Blue,Light Heavyweight
+03/27/2010,Greg Soto,Matthew Riddle,Blue,Welterweight
+03/21/2010,Brandon Vera,Jon Jones,Blue,Light Heavyweight
+03/21/2010,Junior Dos Santos,Gabriel Gonzaga,Red,Heavyweight
+03/21/2010,Cheick Kongo,Paul Buentello,Red,Heavyweight
+03/21/2010,Alessio Sakara,James Irvin,Red,Middleweight
+03/21/2010,Shannon Gugerty,Clay Guida,Blue,Lightweight
+03/21/2010,Vladimir Matyushenko,Eliot Marshall,Red,Light Heavyweight
+03/21/2010,Darren Elkins,Duane Ludwig,Red,Lightweight
+03/21/2010,Daniel Roberts,John Howard,Blue,Welterweight
+03/21/2010,Brendan Schaub,Chase Gormley,Red,Heavyweight
+03/21/2010,Julio Paulino,Mike Pierce,Blue,Welterweight
+03/21/2010,Jason Brilz,Eric Schafer,Red,Light Heavyweight
+02/20/2010,Antonio Rodrigo Nogueira,Cain Velasquez,Blue,Heavyweight
+02/20/2010,Wanderlei Silva,Michael Bisping,Red,Middleweight
+02/20/2010,George Sotiropoulos,Joe Stevenson,Red,Lightweight
+02/20/2010,Ryan Bader,Keith Jardine,Red,Light Heavyweight
+02/20/2010,Mirko Filipovic,Anthony Perosh,Red,Heavyweight
+02/20/2010,Krzysztof Soszynski,Stephan Bonnar,Red,Light Heavyweight
+02/20/2010,Chris Lytle,Brian Foster,Red,Welterweight
+02/20/2010,CB Dollaway,Goran Reljic,Red,Middleweight
+02/20/2010,James Te Huna,Igor Pokrajac,Red,Light Heavyweight
+02/06/2010,Randy Couture,Mark Coleman,Red,Light Heavyweight
+02/06/2010,Nate Marquardt,Chael Sonnen,Blue,Middleweight
+02/06/2010,Paulo Thiago,Mike Swick,Red,Welterweight
+02/06/2010,Dan Miller,Demian Maia,Blue,Middleweight
+02/06/2010,Frank Trigg,Matt Serra,Blue,Welterweight
+02/06/2010,Justin Buchholz,Mac Danzig,Blue,Lightweight
+02/06/2010,Ronys Torres,Melvin Guillard,Blue,Lightweight
+02/06/2010,Phillipe Nover,Rob Emerson,Blue,Lightweight
+02/06/2010,Phil Davis,Brian Stann,Red,Light Heavyweight
+02/06/2010,Chris Tuchscherer,Tim Hague,Red,Heavyweight
+02/06/2010,Joey Beltran,Rolles Gracie,Red,Heavyweight
+01/11/2010,Gray Maynard,Nate Diaz,Red,Lightweight
+01/11/2010,Evan Dunham,Efrain Escudero,Red,Lightweight
+01/11/2010,Tom Lawlor,Aaron Simpson,Blue,Middleweight
+01/11/2010,Amir Sadollah,Brad Blackburn,Red,Welterweight
+01/11/2010,Chris Leben,Jay Silva,Red,Middleweight
+01/11/2010,Jesse Lennox,Rick Story,Blue,Welterweight
+01/11/2010,Rory MacDonald,Mike Guymon,Red,Welterweight
+01/11/2010,Rafael Dos Anjos,Kyle Bradley,Red,Lightweight
+01/11/2010,Gerald Harris,John Salter,Red,Middleweight
+01/11/2010,Jesse Forbes,Nick Catone,Blue,Middleweight
+01/02/2010,Rashad Evans,Thiago Silva,Red,Light Heavyweight
+01/02/2010,Paul Daley,Dustin Hazelett,Red,Welterweight
+01/02/2010,Joe Lauzon,Sam Stout,Blue,Lightweight
+01/02/2010,Duane Ludwig,Jim Miller,Blue,Lightweight
+01/02/2010,Junior Dos Santos,Gilbert Yvel,Red,Heavyweight
+01/02/2010,Jacob Volkmann,Martin Kampmann,Blue,Welterweight
+01/02/2010,Dan Lauzon,Cole Miller,Blue,Lightweight
+01/02/2010,Mark Munoz,Ryan Jensen,Red,Middleweight
+01/02/2010,Jake Ellenberger,Mike Pyle,Red,Welterweight
+01/02/2010,John Gunderson,Rafaello Oliveira,Blue,Lightweight
+12/12/2009,Diego Sanchez,BJ Penn,Blue,UFC Lightweight Title
+12/12/2009,Cheick Kongo,Frank Mir,Blue,Heavyweight
+12/12/2009,Jon Fitch,Mike Pierce,Red,Welterweight
+12/12/2009,Kenny Florian,Clay Guida,Red,Lightweight
+12/12/2009,Stefan Struve,Paul Buentello,Red,Heavyweight
+12/12/2009,Wilson Gouveia,Alan Belcher,Blue,Catch Weight
+12/12/2009,Matt Wiman,Shane Nelson,Red,Lightweight
+12/12/2009,Ricardo Funch,Johny Hendricks,Blue,Welterweight
+12/12/2009,Rousimar Palhares,Lucio Linhares,Red,Middleweight
+12/12/2009,Edgar Garcia,DaMarques Johnson,Blue,Welterweight
+12/12/2009,Kevin Burns,TJ Grant,Blue,Welterweight
+12/05/2009,Brendan Schaub,Roy Nelson,Blue,Ultimate Fighter 10 Heavyweight Tournament Title
+12/05/2009,Jon Jones,Matt Hamill,Blue,Light Heavyweight
+12/05/2009,Kevin Ferguson,Houston Alexander,Red,Catch Weight
+12/05/2009,Matt Veach,Frankie Edgar,Blue,Lightweight
+12/05/2009,Matt Mitrione,Marcus Jones,Red,Heavyweight
+12/05/2009,James McSweeney,Darrill Schoonover,Red,Heavyweight
+12/05/2009,Justin Wren,Jon Madsen,Blue,Heavyweight
+12/05/2009,Brian Stann,Rodney Wallace,Red,Light Heavyweight
+12/05/2009,John Howard,Dennis Hallman,Red,Welterweight
+12/05/2009,Joe Brammer,Mark Bocek,Blue,Lightweight
+11/21/2009,Tito Ortiz,Forrest Griffin,Blue,Light Heavyweight
+11/21/2009,Anthony Johnson,Josh Koscheck,Blue,Welterweight
+11/21/2009,Jacob Volkmann,Paulo Thiago,Blue,Welterweight
+11/21/2009,Rogerio Nogueira,Luiz Cane,Red,Light Heavyweight
+11/21/2009,Phil Baroni,Amir Sadollah,Blue,Welterweight
+11/21/2009,Ben Saunders,Marcus Davis,Red,Welterweight
+11/21/2009,Jake Rosholt,Kendall Grove,Blue,Middleweight
+11/21/2009,Brock Larson,Brian Foster,Blue,Welterweight
+11/21/2009,George Sotiropoulos,Jason Dent,Red,Lightweight
+11/14/2009,Randy Couture,Brandon Vera,Red,Light Heavyweight
+11/14/2009,Dan Hardy,Mike Swick,Red,Welterweight
+11/14/2009,Denis Kang,Michael Bisping,Blue,Middleweight
+11/14/2009,Matt Brown,James Wilks,Red,Welterweight
+11/14/2009,Ross Pearson,Aaron Riley,Red,Lightweight
+11/14/2009,Paul Taylor,John Hathaway,Blue,Welterweight
+11/14/2009,Shannon Gugerty,Terry Etim,Blue,Lightweight
+11/14/2009,Nick Osipczak,Matthew Riddle,Red,Welterweight
+11/14/2009,Paul Kelly,Dennis Siver,Blue,Lightweight
+11/14/2009,Alexander Gustafsson,Jared Hamman,Red,Light Heavyweight
+11/14/2009,Andre Winner,Rolando Delgado,Red,Lightweight
+10/24/2009,Lyoto Machida,Mauricio Rua,Red,UFC Light Heavyweight Title
+10/24/2009,Cain Velasquez,Ben Rothwell,Red,Heavyweight
+10/24/2009,Josh Neer,Gleison Tibau,Blue,Lightweight
+10/24/2009,Joe Stevenson,Spencer Fisher,Red,Lightweight
+10/24/2009,Yoshiyuki Yoshida,Anthony Johnson,Blue,Welterweight
+10/24/2009,Ryan Bader,Eric Schafer,Red,Light Heavyweight
+10/24/2009,Antoni Hardonk,Pat Barry,Blue,Heavyweight
+10/24/2009,Yushin Okami,Chael Sonnen,Blue,Middleweight
+10/24/2009,Jorge Rivera,Rob Kimmons,Red,Middleweight
+10/24/2009,Razak Al-Hassan,Kyle Kingsbury,Blue,Light Heavyweight
+10/24/2009,Chase Gormley,Stefan Struve,Blue,Heavyweight
+09/19/2009,Vitor Belfort,Rich Franklin,Red,Catch Weight
+09/19/2009,Mirko Filipovic,Junior Dos Santos,Blue,Heavyweight
+09/19/2009,Paul Daley,Martin Kampmann,Red,Welterweight
+09/19/2009,Josh Koscheck,Frank Trigg,Red,Welterweight
+09/19/2009,Tyson Griffin,Hermes Franca,Red,Lightweight
+09/19/2009,Efrain Escudero,Cole Miller,Red,Lightweight
+09/19/2009,Drew McFedries,Tomasz Drwal,Blue,Middleweight
+09/19/2009,Jim Miller,Steve Lopez,Red,Lightweight
+09/19/2009,Nik Lentz,Rafaello Oliveira,Red,Lightweight
+09/19/2009,Rick Story,Brian Foster,Red,Welterweight
+09/19/2009,Jason Brilz,Eliot Marshall,Blue,Light Heavyweight
+09/19/2009,Igor Pokrajac,Vladimir Matyushenko,Blue,Light Heavyweight
+09/19/2009,Rafael Dos Anjos,Rob Emerson,Red,Lightweight
+09/16/2009,Nate Diaz,Melvin Guillard,Red,Lightweight
+09/16/2009,Roger Huerta,Gray Maynard,Blue,Lightweight
+09/16/2009,Jake Ellenberger,Carlos Condit,Blue,Welterweight
+09/16/2009,Nate Quarry,Tim Credeur,Red,Middleweight
+09/16/2009,Steve Cantwell,Brian Stann,Blue,Light Heavyweight
+09/16/2009,Chris Wilson,Mike Pyle,Blue,Welterweight
+09/16/2009,CB Dollaway,Jay Silva,Red,Middleweight
+09/16/2009,Justin Buchholz,Jeremy Stephens,Blue,Lightweight
+09/16/2009,Brock Larson,Mike Pierce,Blue,Welterweight
+09/16/2009,Ryan Jensen,Steve Steinbeiss,Red,Middleweight
+08/29/2009,Randy Couture,Antonio Rodrigo Nogueira,Blue,Heavyweight
+08/29/2009,Keith Jardine,Thiago Silva,Blue,Light Heavyweight
+08/29/2009,Chris Leben,Jake Rosholt,Blue,Middleweight
+08/29/2009,Nate Marquardt,Demian Maia,Red,Middleweight
+08/29/2009,Krzysztof Soszynski,Brandon Vera,Blue,Light Heavyweight
+08/29/2009,Aaron Simpson,Ed Herman,Red,Middleweight
+08/29/2009,Gabriel Gonzaga,Chris Tuchscherer,Red,Heavyweight
+08/29/2009,Justin McCully,Mike Russow,Blue,Heavyweight
+08/29/2009,Todd Duffee,Tim Hague,Red,Heavyweight
+08/29/2009,Nick Catone,Mark Munoz,Blue,Middleweight
+08/29/2009,Evan Dunham,Marcus Aurelio,Red,Lightweight
+08/08/2009,Kenny Florian,BJ Penn,Blue,UFC Lightweight Title
+08/08/2009,Anderson Silva,Forrest Griffin,Red,Light Heavyweight
+08/08/2009,Aaron Riley,Shane Nelson,Red,Lightweight
+08/08/2009,Amir Sadollah,Johny Hendricks,Blue,Welterweight
+08/08/2009,Kendall Grove,Ricardo Almeida,Blue,Middleweight
+08/08/2009,Josh Neer,Kurt Pellegrino,Blue,Lightweight
+08/08/2009,Tamdan McCrory,John Howard,Blue,Welterweight
+08/08/2009,Thales Leites,Alessio Sakara,Blue,Middleweight
+08/08/2009,Dan Cramer,Matthew Riddle,Blue,Welterweight
+08/08/2009,George Roop,George Sotiropoulos,Blue,Lightweight
+08/08/2009,Danillo Villefort,Jesse Lennox,Blue,Welterweight
+07/11/2009,Jon Fitch,Paulo Thiago,Red,Welterweight
+07/11/2009,Frank Mir,Brock Lesnar,Blue,UFC Heavyweight Title
+07/11/2009,Thiago Alves,Georges St-Pierre,Blue,UFC Welterweight Title
+07/11/2009,Michael Bisping,Dan Henderson,Blue,Middleweight
+07/11/2009,Alan Belcher,Yoshihiro Akiyama,Blue,Middleweight
+07/11/2009,Mark Coleman,Stephan Bonnar,Red,Light Heavyweight
+07/11/2009,Mac Danzig,Jim Miller,Blue,Lightweight
+07/11/2009,Jake O'Brien,Jon Jones,Blue,Light Heavyweight
+07/11/2009,Dong Hyun Kim,TJ Grant,Red,Welterweight
+07/11/2009,Tom Lawlor,CB Dollaway,Red,Middleweight
+07/11/2009,Matt Grice,Shannon Gugerty,Blue,Lightweight
+06/20/2009,Diego Sanchez,Clay Guida,Red,Lightweight
+06/20/2009,DaMarques Johnson,James Wilks,Blue,Ultimate Fighter 9 Welterweight Tournament Title
+06/20/2009,Chris Lytle,Kevin Burns,Red,Welterweight
+06/20/2009,Andre Winner,Ross Pearson,Blue,Ultimate Fighter 9 Lightweight Tournament Title
+06/20/2009,Nate Diaz,Joe Stevenson,Blue,Lightweight
+06/20/2009,Melvin Guillard,Gleison Tibau,Red,Lightweight
+06/20/2009,Brad Blackburn,Edgar Garcia,Red,Welterweight
+06/20/2009,Tomasz Drwal,Mike Ciesnolevicz,Red,Light Heavyweight
+06/20/2009,Frank Lester,Nick Osipczak,Blue,Welterweight
+06/20/2009,Cameron Dollar,Jason Dent,Blue,Lightweight
+06/13/2009,Rich Franklin,Wanderlei Silva,Red,Catch Weight
+06/13/2009,Cain Velasquez,Cheick Kongo,Red,Heavyweight
+06/13/2009,Mostapha Al-Turk,Mirko Filipovic,Blue,Heavyweight
+06/13/2009,Ben Saunders,Mike Swick,Blue,Welterweight
+06/13/2009,Spencer Fisher,Caol Uno,Red,Lightweight
+06/13/2009,Marcus Davis,Dan Hardy,Blue,Welterweight
+06/13/2009,Terry Etim,Justin Buchholz,Red,Lightweight
+06/13/2009,Dale Hartt,Dennis Siver,Blue,Lightweight
+06/13/2009,Peter Sobotta,Paul Taylor,Blue,Welterweight
+06/13/2009,Rolando Delgado,Paul Kelly,Blue,Lightweight
+06/13/2009,Stefan Struve,Denis Stojnic,Red,Heavyweight
+06/13/2009,Rick Story,John Hathaway,Blue,Welterweight
+05/23/2009,Lyoto Machida,Rashad Evans,Red,UFC Light Heavyweight Title
+05/23/2009,Matt Serra,Matt Hughes,Blue,Welterweight
+05/23/2009,Drew McFedries,Xavier Foupa-Pokam,Red,Middleweight
+05/23/2009,Dan Miller,Chael Sonnen,Blue,Middleweight
+05/23/2009,Sean Sherk,Frankie Edgar,Blue,Lightweight
+05/23/2009,Mike Pyle,Brock Larson,Blue,Welterweight
+05/23/2009,Pat Barry,Tim Hague,Blue,Heavyweight
+05/23/2009,Kyle Bradley,Phillipe Nover,Red,Lightweight
+05/23/2009,Andre Gusmao,Krzysztof Soszynski,Blue,Light Heavyweight
+05/23/2009,Yoshiyuki Yoshida,Brandon Wolff,Red,Welterweight
+05/23/2009,George Roop,David Kaplan,Red,Lightweight
+04/18/2009,Anderson Silva,Thales Leites,Red,UFC Middleweight Title
+04/18/2009,Matt Wiman,Sam Stout,Blue,Lightweight
+04/18/2009,Chuck Liddell,Mauricio Rua,Blue,Light Heavyweight
+04/18/2009,Krzysztof Soszynski,Brian Stann,Red,Light Heavyweight
+04/18/2009,Antoni Hardonk,Cheick Kongo,Blue,Heavyweight
+04/18/2009,Steve Cantwell,Luiz Cane,Blue,Light Heavyweight
+04/18/2009,Denis Kang,Xavier Foupa-Pokam,Red,Middleweight
+04/18/2009,Jason MacDonald,Nate Quarry,Blue,Middleweight
+04/18/2009,David Loiseau,Ed Herman,Blue,Middleweight
+04/18/2009,David Bielkheden,Mark Bocek,Blue,Lightweight
+04/18/2009,TJ Grant,Ryo Chonan,Red,Welterweight
+04/18/2009,Vinny Magalhaes,Eliot Marshall,Blue,Light Heavyweight
+04/01/2009,Carlos Condit,Martin Kampmann,Blue,Welterweight
+04/01/2009,Ryan Bader,Carmelo Marrero,Red,Light Heavyweight
+04/01/2009,Tyson Griffin,Rafael Dos Anjos,Red,Lightweight
+04/01/2009,Junie Browning,Cole Miller,Blue,Lightweight
+04/01/2009,Jeremy Stephens,Gleison Tibau,Blue,Lightweight
+04/01/2009,Matt Horwich,Ricardo Almeida,Blue,Middleweight
+04/01/2009,Brock Larson,Jesse Sanders,Red,Welterweight
+04/01/2009,Nick Catone,Tim Credeur,Blue,Middleweight
+04/01/2009,Jorge Rivera,Nissen Osterneck,Red,Middleweight
+04/01/2009,Rob Kimmons,Joe Vedepo,Red,Middleweight
+04/01/2009,Tim McKenzie,Aaron Simpson,Blue,Middleweight
+03/07/2009,Quinton Jackson,Keith Jardine,Red,Light Heavyweight
+03/07/2009,Gabriel Gonzaga,Shane Carwin,Blue,Heavyweight
+03/07/2009,Matt Brown,Pete Sell,Red,Welterweight
+03/07/2009,Matt Hamill,Mark Munoz,Red,Light Heavyweight
+03/07/2009,Gray Maynard,Jim Miller,Red,Lightweight
+03/07/2009,Ryan Madigan,Tamdan McCrory,Blue,Welterweight
+03/07/2009,Jason Day,Kendall Grove,Blue,Middleweight
+03/07/2009,Jason Brilz,Tim Boetsch,Red,Light Heavyweight
+03/07/2009,Michael Patt,Brandon Vera,Blue,Light Heavyweight
+03/07/2009,Aaron Riley,Shane Nelson,Blue,Lightweight
+02/21/2009,Diego Sanchez,Joe Stevenson,Red,Lightweight
+02/21/2009,Dan Hardy,Rory Markham,Red,Welterweight
+02/21/2009,Nate Marquardt,Wilson Gouveia,Red,Middleweight
+02/21/2009,Demian Maia,Chael Sonnen,Red,Middleweight
+02/21/2009,Josh Koscheck,Paulo Thiago,Blue,Welterweight
+02/21/2009,Terry Etim,Brian Cobb,Red,Lightweight
+02/21/2009,Stefan Struve,Junior Dos Santos,Blue,Heavyweight
+02/21/2009,Per Eklund,Evan Dunham,Blue,Lightweight
+02/21/2009,Neil Grove,Mike Ciesnolevicz,Blue,Heavyweight
+02/21/2009,Paul Kelly,Troy Mandaloniz,Red,Welterweight
+02/07/2009,Jeremy Stephens,Joe Lauzon,Blue,Lightweight
+02/07/2009,Cain Velasquez,Denis Stojnic,Red,Heavyweight
+02/07/2009,Mac Danzig,Josh Neer,Blue,Lightweight
+02/07/2009,Anthony Johnson,Luigi Fioravanti,Red,Welterweight
+02/07/2009,Kurt Pellegrino,Rob Emerson,Red,Lightweight
+02/07/2009,Jake Rosholt,Dan Miller,Blue,Middleweight
+02/07/2009,Matt Veach,Matt Grice,Red,Lightweight
+02/07/2009,Gleison Tibau,Rich Clementi,Red,Lightweight
+02/07/2009,Nick Catone,Derek Downey,Red,Middleweight
+02/07/2009,Steve Bruno,Matthew Riddle,Blue,Welterweight
+01/31/2009,Georges St-Pierre,BJ Penn,Red,UFC Welterweight Title
+01/31/2009,Thiago Silva,Lyoto Machida,Blue,Light Heavyweight
+01/31/2009,Jon Jones,Stephan Bonnar,Red,Light Heavyweight
+01/31/2009,Nate Diaz,Clay Guida,Blue,Lightweight
+01/31/2009,Jon Fitch,Akihiro Gono,Red,Welterweight
+01/31/2009,Manvel Gamburyan,Thiago Tavares,Blue,Lightweight
+01/31/2009,John Howard,Chris Wilson,Red,Welterweight
+01/31/2009,Jake O'Brien,Christian Wellisch,Red,Light Heavyweight
+01/31/2009,Dan Cramer,Matt Arroyo,Red,Welterweight
+01/17/2009,Dan Henderson,Rich Franklin,Red,Light Heavyweight
+01/17/2009,Mauricio Rua,Mark Coleman,Red,Light Heavyweight
+01/17/2009,Rousimar Palhares,Jeremy Horn,Red,Middleweight
+01/17/2009,Denis Kang,Alan Belcher,Blue,Middleweight
+01/17/2009,Marcus Davis,Chris Lytle,Red,Welterweight
+01/17/2009,John Hathaway,Tom Egan,Red,Welterweight
+01/17/2009,Martin Kampmann,Alexandre Barros,Red,Welterweight
+01/17/2009,Eric Schafer,Antonio Mendes,Red,Light Heavyweight
+01/17/2009,Ivan Serati,Tomasz Drwal,Blue,Light Heavyweight
+01/17/2009,Nate Mohr,Dennis Siver,Blue,Lightweight
+12/27/2008,Forrest Griffin,Rashad Evans,Blue,UFC Light Heavyweight Title
+12/27/2008,Antonio Rodrigo Nogueira,Frank Mir,Blue,UFC Interim Heavyweight Title
+12/27/2008,Mike Massenzio,CB Dollaway,Blue,Middleweight
+12/27/2008,Quinton Jackson,Wanderlei Silva,Red,Light Heavyweight
+12/27/2008,Mostapha Al-Turk,Cheick Kongo,Blue,Heavyweight
+12/27/2008,Yushin Okami,Dean Lister,Red,Middleweight
+12/27/2008,Antoni Hardonk,Mike Wessel,Red,Heavyweight
+12/27/2008,Matt Hamill,Reese Andy,Red,Light Heavyweight
+12/27/2008,Brad Blackburn,Ryo Chonan,Red,Welterweight
+12/27/2008,Pat Barry,Dan Evensen,Red,Heavyweight
+12/13/2008,Phillipe Nover,Efrain Escudero,Blue,Ultimate Fighter 8 Lightweight Tournament Title
+12/13/2008,Vinny Magalhaes,Ryan Bader,Blue,Ultimate Fighter 8 Light Heavyweight Tournament Title
+12/13/2008,Anthony Johnson,Kevin Burns,Red,Welterweight
+12/13/2008,Jason MacDonald,Wilson Gouveia,Blue,Middleweight
+12/13/2008,David Kaplan,Junie Browning,Blue,Lightweight
+12/13/2008,Krzysztof Soszynski,Shane Primm,Red,Light Heavyweight
+12/13/2008,Eliot Marshall,Jules Bruchez,Red,Light Heavyweight
+12/13/2008,Kyle Kingsbury,Tom Lawlor,Blue,Light Heavyweight
+12/13/2008,George Roop,Shane Nelson,Blue,Lightweight
+12/13/2008,John Polakowski,Rolando Delgado,Blue,Lightweight
+12/10/2008,Yoshiyuki Yoshida,Josh Koscheck,Blue,Welterweight
+12/10/2008,Mike Swick,Jonathan Goulet,Red,Welterweight
+12/10/2008,Razak Al-Hassan,Steve Cantwell,Blue,Light Heavyweight
+12/10/2008,Tim Credeur,Nate Loughran,Red,Middleweight
+12/10/2008,Matt Wiman,Jim Miller,Blue,Lightweight
+12/10/2008,Luigi Fioravanti,Brodie Farber,Red,Catch Weight
+12/10/2008,Steve Bruno,Johnny Rees,Red,Welterweight
+12/10/2008,Brandon Wolff,Ben Saunders,Blue,Welterweight
+12/10/2008,Corey Hill,Dale Hartt,Blue,Lightweight
+12/10/2008,Justin McCully,Eddie Sanchez,Red,Heavyweight
+11/15/2008,Randy Couture,Brock Lesnar,Blue,UFC Heavyweight Title
+11/15/2008,Joe Stevenson,Kenny Florian,Blue,Lightweight
+11/15/2008,Dustin Hazelett,Tamdan McCrory,Red,Welterweight
+11/15/2008,Gabriel Gonzaga,Josh Hendricks,Red,Heavyweight
+11/15/2008,Nate Quarry,Demian Maia,Blue,Middleweight
+11/15/2008,Jorge Gurgel,Aaron Riley,Blue,Lightweight
+11/15/2008,Jeremy Stephens,Rafael Dos Anjos,Red,Lightweight
+11/15/2008,Alvin Robinson,Mark Bocek,Blue,Lightweight
+11/15/2008,Matt Brown,Ryan Thomas,Red,Welterweight
+10/25/2008,Patrick Cote,Anderson Silva,Blue,UFC Middleweight Title
+10/25/2008,Josh Koscheck,Thiago Alves,Blue,Welterweight
+10/25/2008,Gray Maynard,Rich Clementi,Red,Lightweight
+10/25/2008,Junior Dos Santos,Fabricio Werdum,Red,Heavyweight
+10/25/2008,Tyson Griffin,Sean Sherk,Blue,Lightweight
+10/25/2008,Drew McFedries,Thales Leites,Blue,Middleweight
+10/25/2008,Spencer Fisher,Shannon Gugerty,Red,Lightweight
+10/25/2008,Dan Miller,Matt Horwich,Red,Middleweight
+10/25/2008,Marcus Aurelio,Hermes Franca,Blue,Lightweight
+10/25/2008,Joshua Burkman,Pete Sell,Blue,Welterweight
+10/18/2008,Michael Bisping,Chris Leben,Red,Middleweight
+10/18/2008,Keith Jardine,Brandon Vera,Red,Light Heavyweight
+10/18/2008,Rameau Thierry Sokoudjou,Luiz Cane,Blue,Light Heavyweight
+10/18/2008,Paul Taylor,Chris Lytle,Blue,Welterweight
+10/18/2008,Paul Kelly,Marcus Davis,Blue,Welterweight
+10/18/2008,Dan Hardy,Akihiro Gono,Red,Welterweight
+10/18/2008,Neil Wain,Shane Carwin,Blue,Heavyweight
+10/18/2008,Jess Liaudin,David Bielkheden,Blue,Lightweight
+10/18/2008,Sam Stout,Terry Etim,Blue,Lightweight
+10/18/2008,David Baron,Jim Miller,Blue,Lightweight
+10/18/2008,Per Eklund,Samy Schiavo,Red,Lightweight
+09/17/2008,Josh Neer,Nate Diaz,Blue,Lightweight
+09/17/2008,Clay Guida,Mac Danzig,Red,Lightweight
+09/17/2008,Ed Herman,Alan Belcher,Blue,Middleweight
+09/17/2008,Eric Schafer,Houston Alexander,Red,Light Heavyweight
+09/17/2008,Alessio Sakara,Joe Vedepo,Red,Middleweight
+09/17/2008,Wilson Gouveia,Ryan Jensen,Red,Middleweight
+09/17/2008,Kyle Bradley,Joe Lauzon,Blue,Lightweight
+09/17/2008,Brad Morris,Jason Brilz,Blue,Light Heavyweight
+09/17/2008,Drew McFedries,Mike Massenzio,Blue,Middleweight
+09/17/2008,Dan Miller,Rob Kimmons,Red,Middleweight
+09/06/2008,Chuck Liddell,Rashad Evans,Blue,Light Heavyweight
+09/06/2008,Matt Hamill,Rich Franklin,Blue,Light Heavyweight
+09/06/2008,Rousimar Palhares,Dan Henderson,Blue,Middleweight
+09/06/2008,Martin Kampmann,Nate Marquardt,Blue,Middleweight
+09/06/2008,Dong Hyun Kim,Matt Brown,Red,Welterweight
+09/06/2008,Thiago Tavares,Kurt Pellegrino,Blue,Lightweight
+09/06/2008,Michael Patt,Tim Boetsch,Blue,Light Heavyweight
+09/06/2008,Jason MacDonald,Jason Lambert,Red,Middleweight
+09/06/2008,Roan Carneiro,Ryo Chonan,Blue,Welterweight
+08/09/2008,Georges St-Pierre,Jon Fitch,Red,UFC Welterweight Title
+08/09/2008,Brock Lesnar,Heath Herring,Red,Heavyweight
+08/09/2008,Manvel Gamburyan,Rob Emerson,Blue,Lightweight
+08/09/2008,Roger Huerta,Kenny Florian,Blue,Lightweight
+08/09/2008,Demian Maia,Jason MacDonald,Red,Middleweight
+08/09/2008,Luke Cummo,Tamdan McCrory,Blue,Welterweight
+08/09/2008,Dan Evensen,Cheick Kongo,Blue,Heavyweight
+08/09/2008,Jon Jones,Andre Gusmao,Red,Light Heavyweight
+08/09/2008,Chris Wilson,Steve Bruno,Red,Welterweight
+08/09/2008,Ryan Thomas,Ben Saunders,Blue,Welterweight
+07/19/2008,Anderson Silva,James Irvin,Red,Light Heavyweight
+07/19/2008,Reese Andy,Brandon Vera,Blue,Light Heavyweight
+07/19/2008,Frankie Edgar,Hermes Franca,Red,Lightweight
+07/19/2008,Jake O'Brien,Cain Velasquez,Blue,Heavyweight
+07/19/2008,Kevin Burns,Anthony Johnson,Red,Welterweight
+07/19/2008,CB Dollaway,Jesse Taylor,Red,Middleweight
+07/19/2008,Cale Yarbrough,Tim Credeur,Blue,Middleweight
+07/19/2008,Rory Markham,Brodie Farber,Red,Welterweight
+07/19/2008,Nate Loughran,Johnny Rees,Red,Middleweight
+07/19/2008,Brad Blackburn,James Giboo,Red,Welterweight
+07/19/2008,Shannon Gugerty,Dale Hartt,Red,Lightweight
+07/05/2008,Quinton Jackson,Forrest Griffin,Blue,UFC Light Heavyweight Title
+07/05/2008,Ricardo Almeida,Patrick Cote,Blue,Middleweight
+07/05/2008,Joe Stevenson,Gleison Tibau,Red,Lightweight
+07/05/2008,Chris Lytle,Josh Koscheck,Blue,Welterweight
+07/05/2008,Marcus Aurelio,Tyson Griffin,Blue,Lightweight
+07/05/2008,Justin McCully,Gabriel Gonzaga,Blue,Heavyweight
+07/05/2008,Jorge Gurgel,Cole Miller,Blue,Lightweight
+07/05/2008,Melvin Guillard,Dennis Siver,Red,Lightweight
+07/05/2008,Corey Hill,Justin Buchholz,Blue,Lightweight
+06/21/2008,Evan Tanner,Kendall Grove,Blue,Middleweight
+06/21/2008,CB Dollaway,Amir Sadollah,Blue,Ultimate Fighter 7 Middleweight Tournament Title
+06/21/2008,Diego Sanchez,Luigi Fioravanti,Red,Welterweight
+06/21/2008,Jeremy Stephens,Spencer Fisher,Blue,Lightweight
+06/21/2008,Matthew Riddle,Dante Rivera,Red,Middleweight
+06/21/2008,Joshua Burkman,Dustin Hazelett,Blue,Welterweight
+06/21/2008,Marvin Eastman,Drew McFedries,Blue,Middleweight
+06/21/2008,Matt Arroyo,Matt Brown,Blue,Welterweight
+06/21/2008,Jeremy Horn,Dean Lister,Blue,Middleweight
+06/21/2008,Rob Kimmons,Rob Yundt,Red,Middleweight
+06/07/2008,Thiago Alves,Matt Hughes,Red,Welterweight
+06/07/2008,Michael Bisping,Jason Day,Red,Middleweight
+06/07/2008,Mike Swick,Marcus Davis,Red,Welterweight
+06/07/2008,Nate Marquardt,Thales Leites,Blue,Middleweight
+06/07/2008,Brandon Vera,Fabricio Werdum,Blue,Heavyweight
+06/07/2008,Martin Kampmann,Jorge Rivera,Red,Middleweight
+06/07/2008,Matt Wiman,Thiago Tavares,Red,Lightweight
+06/07/2008,Roan Carneiro,Kevin Burns,Blue,Welterweight
+06/07/2008,Jason Lambert,Luiz Cane,Blue,Light Heavyweight
+06/07/2008,Paul Taylor,Jess Liaudin,Red,Welterweight
+06/07/2008,Antoni Hardonk,Eddie Sanchez,Red,Heavyweight
+05/24/2008,BJ Penn,Sean Sherk,Red,UFC Lightweight Title
+05/24/2008,Wanderlei Silva,Keith Jardine,Red,Light Heavyweight
+05/24/2008,Goran Reljic,Wilson Gouveia,Red,Light Heavyweight
+05/24/2008,Tito Ortiz,Lyoto Machida,Blue,Light Heavyweight
+05/24/2008,Thiago Silva,Antonio Mendes,Red,Light Heavyweight
+05/24/2008,Rousimar Palhares,Ivan Salaverry,Red,Middleweight
+05/24/2008,Kazuhiro Nakamura,Rameau Thierry Sokoudjou,Blue,Light Heavyweight
+05/24/2008,Terry Etim,Rich Clementi,Blue,Lightweight
+05/24/2008,War Machine,Yoshiyuki Yoshida,Blue,Welterweight
+05/24/2008,Dong Hyun Kim,Jason Tan,Red,Welterweight
+05/24/2008,Christian Wellisch,Shane Carwin,Blue,Heavyweight
+04/19/2008,Georges St-Pierre,Matt Serra,Red,UFC Welterweight Title
+04/19/2008,Travis Lutter,Rich Franklin,Blue,Middleweight
+04/19/2008,Nate Quarry,Kalib Starnes,Red,Middleweight
+04/19/2008,Charles McCarthy,Michael Bisping,Blue,Middleweight
+04/19/2008,Mac Danzig,Mark Bocek,Red,Lightweight
+04/19/2008,Joe Doerksen,Jason MacDonald,Blue,Middleweight
+04/19/2008,Jason Day,Alan Belcher,Red,Middleweight
+04/19/2008,Ed Herman,Demian Maia,Blue,Middleweight
+04/19/2008,Rich Clementi,Sam Stout,Red,Lightweight
+04/19/2008,Cain Velasquez,Brad Morris,Red,Heavyweight
+04/19/2008,Kuniyoshi Hironaka,Jonathan Goulet,Blue,Welterweight
+04/02/2008,Kenny Florian,Joe Lauzon,Red,Lightweight
+04/02/2008,Gray Maynard,Frankie Edgar,Red,Lightweight
+04/02/2008,Thiago Alves,Karo Parisyan,Red,Welterweight
+04/02/2008,Matt Hamill,Tim Boetsch,Red,Light Heavyweight
+04/02/2008,Nate Diaz,Kurt Pellegrino,Red,Lightweight
+04/02/2008,James Irvin,Houston Alexander,Red,Light Heavyweight
+04/02/2008,Josh Neer,Din Thomas,Red,Lightweight
+04/02/2008,Marcus Aurelio,Ryan Roberts,Red,Lightweight
+04/02/2008,Jeff Cox,Manvel Gamburyan,Blue,Lightweight
+04/02/2008,Clay Guida,Samy Schiavo,Red,Lightweight
+04/02/2008,Roman Mitichyan,George Sotiropoulos,Blue,Welterweight
+04/02/2008,Anthony Johnson,Tommy Speer,Red,Welterweight
+03/01/2008,Dan Henderson,Anderson Silva,Blue,UFC Middleweight Title
+03/01/2008,Heath Herring,Cheick Kongo,Red,Heavyweight
+03/01/2008,Alessio Sakara,Chris Leben,Blue,Middleweight
+03/01/2008,Evan Tanner,Yushin Okami,Blue,Middleweight
+03/01/2008,Chris Wilson,Jon Fitch,Blue,Welterweight
+03/01/2008,Andrei Arlovski,Jake O'Brien,Red,Heavyweight
+03/01/2008,Luigi Fioravanti,Luke Cummo,Red,Welterweight
+03/01/2008,Dustin Hazelett,Josh Koscheck,Blue,Welterweight
+03/01/2008,Diego Sanchez,David Bielkheden,Red,Welterweight
+03/01/2008,John Halverson,Jorge Gurgel,Blue,Lightweight
+02/02/2008,Antonio Rodrigo Nogueira,Tim Sylvia,Red,UFC Interim Heavyweight Title
+02/02/2008,Brock Lesnar,Frank Mir,Blue,Heavyweight
+02/02/2008,Nate Marquardt,Jeremy Horn,Red,Middleweight
+02/02/2008,Rob Yundt,Ricardo Almeida,Blue,Middleweight
+02/02/2008,Tyson Griffin,Gleison Tibau,Red,Lightweight
+02/02/2008,Kyle Bradley,Chris Lytle,Blue,Welterweight
+02/02/2008,Tim Boetsch,David Heath,Red,Light Heavyweight
+02/02/2008,Terry Martin,Marvin Eastman,Blue,Middleweight
+02/02/2008,Keita Nakamura,Rob Emerson,Blue,Lightweight
+01/23/2008,Joshua Burkman,Mike Swick,Blue,Welterweight
+01/23/2008,Patrick Cote,Drew McFedries,Red,Middleweight
+01/23/2008,Thiago Tavares,Michihiro Omigawa,Red,Lightweight
+01/23/2008,Nate Diaz,Alvin Robinson,Red,Lightweight
+01/23/2008,Alberto Crane,Kurt Pellegrino,Blue,Lightweight
+01/23/2008,Gray Maynard,Dennis Siver,Red,Lightweight
+01/23/2008,Cole Miller,Jeremy Stephens,Blue,Lightweight
+01/23/2008,Joe Veres,Corey Hill,Blue,Lightweight
+01/23/2008,Justin Buchholz,Matt Wiman,Blue,Lightweight
+01/19/2008,BJ Penn,Joe Stevenson,Red,UFC Lightweight Title
+01/19/2008,Fabricio Werdum,Gabriel Gonzaga,Red,Heavyweight
+01/19/2008,Jess Liaudin,Marcus Davis,Blue,Welterweight
+01/19/2008,Jason Lambert,Wilson Gouveia,Blue,Light Heavyweight
+01/19/2008,Kendall Grove,Jorge Rivera,Blue,Middleweight
+01/19/2008,Colin Robinson,Antoni Hardonk,Blue,Heavyweight
+01/19/2008,Paul Kelly,Paul Taylor,Red,Welterweight
+01/19/2008,James Lee,Alessio Sakara,Blue,Light Heavyweight
+01/19/2008,Per Eklund,Sam Stout,Blue,Lightweight
+12/29/2007,Matt Hughes,Georges St-Pierre,Blue,UFC Interim Welterweight Title
+12/29/2007,Chuck Liddell,Wanderlei Silva,Red,Light Heavyweight
+12/29/2007,Soa Palelei,Eddie Sanchez,Blue,Heavyweight
+12/29/2007,Lyoto Machida,Rameau Thierry Sokoudjou,Red,Light Heavyweight
+12/29/2007,Rich Clementi,Melvin Guillard,Red,Lightweight
+12/29/2007,Luiz Cane,James Irvin,Blue,Light Heavyweight
+12/29/2007,Manvel Gamburyan,Nate Mohr,Red,Lightweight
+12/29/2007,Jordan Radev,Dean Lister,Blue,Middleweight
+12/29/2007,Roan Carneiro,Tony DeSouza,Red,Welterweight
+12/29/2007,Mark Bocek,Doug Evans,Red,Lightweight
+12/08/2007,Clay Guida,Roger Huerta,Blue,Lightweight
+12/08/2007,Tommy Speer,Mac Danzig,Blue,Ultimate Fighter 6 Welterweight Tournament Title
+12/08/2007,Jared Rollins,War Machine,Blue,Welterweight
+12/08/2007,Billy Miles,George Sotiropoulos,Blue,Welterweight
+12/08/2007,Ben Saunders,Dan Barrera,Red,Welterweight
+12/08/2007,Troy Mandaloniz,Richie Hightower,Red,Welterweight
+12/08/2007,Matt Arroyo,John Kolosci,Red,Welterweight
+12/08/2007,Roman Mitichyan,Dorian Price,Red,Welterweight
+12/08/2007,Jonathan Goulet,Paul Georgieff,Red,Welterweight
+11/17/2007,Michael Bisping,Rashad Evans,Blue,Light Heavyweight
+11/17/2007,Thiago Silva,Houston Alexander,Red,Light Heavyweight
+11/17/2007,Ryo Chonan,Karo Parisyan,Blue,Welterweight
+11/17/2007,Ed Herman,Joe Doerksen,Red,Middleweight
+11/17/2007,Frankie Edgar,Spencer Fisher,Red,Lightweight
+11/17/2007,Thiago Alves,Chris Lytle,Red,Welterweight
+11/17/2007,Joe Lauzon,Jason Reinhardt,Red,Lightweight
+11/17/2007,Marcus Aurelio,Luke Caudillo,Red,Lightweight
+11/17/2007,Tamdan McCrory,Akihiro Gono,Blue,Welterweight
+10/20/2007,Rich Franklin,Anderson Silva,Blue,UFC Middleweight Title
+10/20/2007,Tim Sylvia,Brandon Vera,Red,Heavyweight
+10/20/2007,Jorge Gurgel,Alvin Robinson,Blue,Lightweight
+10/20/2007,Stephan Bonnar,Eric Schafer,Red,Light Heavyweight
+10/20/2007,Kalib Starnes,Alan Belcher,Blue,Middleweight
+10/20/2007,Jason MacDonald,Yushin Okami,Blue,Middleweight
+10/20/2007,Ryan Jensen,Demian Maia,Blue,Middleweight
+10/20/2007,Joshua Burkman,Forrest Petz,Red,Welterweight
+10/20/2007,Jason Black,Matt Grice,Blue,Lightweight
+09/22/2007,Chuck Liddell,Keith Jardine,Blue,Light Heavyweight
+09/22/2007,Forrest Griffin,Mauricio Rua,Red,Light Heavyweight
+09/22/2007,Jon Fitch,Diego Sanchez,Red,Welterweight
+09/22/2007,Lyoto Machida,Kazuhiro Nakamura,Red,Light Heavyweight
+09/22/2007,Thiago Tavares,Tyson Griffin,Blue,Lightweight
+09/22/2007,Rich Clementi,Anthony Johnson,Red,Welterweight
+09/22/2007,Jeremy Stephens,Diego Saraiva,Red,Lightweight
+09/22/2007,Scott Junk,Christian Wellisch,Blue,Heavyweight
+09/22/2007,Matt Wiman,Michihiro Omigawa,Red,Lightweight
+09/19/2007,Kenny Florian,Din Thomas,Red,Lightweight
+09/19/2007,Chris Leben,Terry Martin,Red,Middleweight
+09/19/2007,Junior Assuncao,Nate Diaz,Blue,Lightweight
+09/19/2007,Nate Quarry,Pete Sell,Red,Middleweight
+09/19/2007,Luke Cummo,Edilberto de Oliveira,Red,Welterweight
+09/19/2007,Cole Miller,Leonard Garcia,Red,Lightweight
+09/19/2007,Gray Maynard,Joe Veres,Red,Lightweight
+09/19/2007,Kuniyoshi Hironaka,Thiago Alves,Blue,Welterweight
+09/19/2007,Jonathan Goulet,Dustin Hazelett,Blue,Welterweight
+09/08/2007,Quinton Jackson,Dan Henderson,Red,UFC Light Heavyweight Title
+09/08/2007,Michael Bisping,Matt Hamill,Red,Light Heavyweight
+09/08/2007,Cheick Kongo,Mirko Filipovic,Red,Heavyweight
+09/08/2007,Paul Taylor,Marcus Davis,Blue,Welterweight
+09/08/2007,Houston Alexander,Alessio Sakara,Red,Light Heavyweight
+09/08/2007,Terry Etim,Gleison Tibau,Blue,Lightweight
+09/08/2007,Thiago Silva,Tomasz Drwal,Red,Light Heavyweight
+09/08/2007,Naoyuki Kotani,Dennis Siver,Blue,Lightweight
+09/08/2007,Anthony Torres,Jess Liaudin,Blue,Welterweight
+08/25/2007,Randy Couture,Gabriel Gonzaga,Red,UFC Heavyweight Title
+08/25/2007,Georges St-Pierre,Josh Koscheck,Red,Welterweight
+08/25/2007,Alberto Crane,Roger Huerta,Blue,Lightweight
+08/25/2007,Kurt Pellegrino,Joe Stevenson,Blue,Lightweight
+08/25/2007,Patrick Cote,Kendall Grove,Red,Middleweight
+08/25/2007,David Heath,Renato Sobral,Blue,Light Heavyweight
+08/25/2007,Antoni Hardonk,Frank Mir,Blue,Heavyweight
+08/25/2007,Thales Leites,Ryan Jensen,Red,Middleweight
+08/25/2007,Marcus Aurelio,Clay Guida,Blue,Lightweight
+07/07/2007,Kenny Florian,Alvin Robinson,Red,Lightweight
+07/07/2007,Anderson Silva,Nate Marquardt,Red,UFC Middleweight Title
+07/07/2007,Hermes Franca,Sean Sherk,Blue,UFC Lightweight Title
+07/07/2007,Heath Herring,Antonio Rodrigo Nogueira,Blue,Heavyweight
+07/07/2007,Mike Nickels,Stephan Bonnar,Blue,Light Heavyweight
+07/07/2007,Jorge Gurgel,Diego Saraiva,Red,Lightweight
+07/07/2007,Jason Gilliam,Chris Lytle,Blue,Welterweight
+07/07/2007,Mark Bocek,Frankie Edgar,Blue,Lightweight
+06/23/2007,BJ Penn,Jens Pulver,Red,Lightweight
+06/23/2007,Manvel Gamburyan,Nate Diaz,Blue,Ultimate Fighter 5 Lightweight Tournament Title
+06/23/2007,Thales Leites,Floyd Sword,Red,Middleweight
+06/23/2007,Doug Evans,Roger Huerta,Blue,Lightweight
+06/23/2007,Brandon Melendez,Joe Lauzon,Blue,Lightweight
+06/23/2007,Andy Wang,Cole Miller,Blue,Lightweight
+06/23/2007,Allen Berube,Leonard Garcia,Blue,Lightweight
+06/23/2007,Brian Geraghty,Matt Wiman,Blue,Lightweight
+06/16/2007,Yushin Okami,Rich Franklin,Blue,Middleweight
+06/16/2007,Forrest Griffin,Hector Ramirez,Red,Light Heavyweight
+06/16/2007,Jason MacDonald,Rory Singer,Red,Middleweight
+06/16/2007,Tyson Griffin,Clay Guida,Red,Lightweight
+06/16/2007,Ed Herman,Scott Smith,Red,Middleweight
+06/16/2007,Marcus Davis,Jason Tan,Red,Welterweight
+06/16/2007,Colin Robinson,Eddie Sanchez,Blue,Heavyweight
+06/16/2007,Dustin Hazelett,Stevie Lynch,Red,Welterweight
+06/12/2007,Spencer Fisher,Sam Stout,Red,Lightweight
+06/12/2007,Roan Carneiro,Jon Fitch,Blue,Welterweight
+06/12/2007,Jordan Radev,Drew McFedries,Blue,Middleweight
+06/12/2007,Thiago Tavares,Jason Black,Red,Lightweight
+06/12/2007,Forrest Petz,Luigi Fioravanti,Red,Welterweight
+06/12/2007,Tamdan McCrory,Pete Spratt,Red,Welterweight
+06/12/2007,Gleison Tibau,Jeff Cox,Red,Lightweight
+06/12/2007,Anthony Johnson,Chad Reiner,Red,Welterweight
+06/12/2007,Nate Mohr,Luke Caudillo,Red,Lightweight
+05/26/2007,Chuck Liddell,Quinton Jackson,Blue,UFC Light Heavyweight Title
+05/26/2007,Joshua Burkman,Karo Parisyan,Blue,Welterweight
+05/26/2007,Terry Martin,Ivan Salaverry,Red,Middleweight
+05/26/2007,Keith Jardine,Houston Alexander,Blue,Light Heavyweight
+05/26/2007,Kalib Starnes,Chris Leben,Red,Middleweight
+05/26/2007,James Irvin,Thiago Silva,Blue,Light Heavyweight
+05/26/2007,Alan Belcher,Sean Salmon,Red,Light Heavyweight
+05/26/2007,Din Thomas,Jeremy Stephens,Red,Lightweight
+05/26/2007,Carmelo Marrero,Wilson Gouveia,Blue,Light Heavyweight
+04/21/2007,Mirko Filipovic,Gabriel Gonzaga,Blue,Heavyweight
+04/21/2007,Andrei Arlovski,Fabricio Werdum,Red,Heavyweight
+04/21/2007,Elvis Sinosic,Michael Bisping,Blue,Light Heavyweight
+04/21/2007,Lyoto Machida,David Heath,Red,Light Heavyweight
+04/21/2007,Cheick Kongo,Assuerio Silva,Red,Heavyweight
+04/21/2007,Matt Grice,Terry Etim,Blue,Lightweight
+04/21/2007,Junior Assuncao,David Lee,Red,Lightweight
+04/21/2007,Victor Valimaki,Alessio Sakara,Blue,Light Heavyweight
+04/21/2007,Jess Liaudin,Dennis Siver,Red,Welterweight
+04/21/2007,Edilberto de Oliveira,Paul Taylor,Blue,Welterweight
+04/07/2007,Georges St-Pierre,Matt Serra,Blue,UFC Welterweight Title
+04/07/2007,Josh Koscheck,Diego Sanchez,Red,Welterweight
+04/07/2007,Leonard Garcia,Roger Huerta,Blue,Lightweight
+04/07/2007,Yushin Okami,Mike Swick,Red,Middleweight
+04/07/2007,Alan Belcher,Kendall Grove,Blue,Middleweight
+04/07/2007,Brad Imes,Heath Herring,Blue,Heavyweight
+04/07/2007,Thales Leites,Pete Sell,Red,Middleweight
+04/07/2007,Pete Spratt,Marcus Davis,Blue,Welterweight
+04/07/2007,Luke Cummo,Josh Haynes,Red,Welterweight
+04/05/2007,Joe Stevenson,Melvin Guillard,Red,Lightweight
+04/05/2007,Justin McCully,Antoni Hardonk,Red,Heavyweight
+04/05/2007,Kenny Florian,Dokonjonosuke Mishima,Red,Lightweight
+04/05/2007,Seth Petruzelli,Wilson Gouveia,Blue,Light Heavyweight
+04/05/2007,Keita Nakamura,Drew Fickett,Blue,Welterweight
+04/05/2007,Kurt Pellegrino,Nate Mohr,Red,Lightweight
+04/05/2007,Kuniyoshi Hironaka,Forrest Petz,Red,Welterweight
+04/05/2007,Rich Clementi,Roan Carneiro,Blue,Welterweight
+04/05/2007,Thiago Tavares,Naoyuki Kotani,Red,Lightweight
+03/03/2007,Tim Sylvia,Randy Couture,Blue,UFC Heavyweight Title
+03/03/2007,Martin Kampmann,Drew McFedries,Red,Middleweight
+03/03/2007,Rich Franklin,Jason MacDonald,Red,Middleweight
+03/03/2007,Matt Hughes,Chris Lytle,Red,Welterweight
+03/03/2007,Renato Sobral,Jason Lambert,Blue,Light Heavyweight
+03/03/2007,Matt Hamill,Rex Holman,Red,Light Heavyweight
+03/03/2007,Jon Fitch,Luigi Fioravanti,Red,Welterweight
+03/03/2007,Gleison Tibau,Jason Dent,Red,Lightweight
+03/03/2007,Jason Gilliam,Jamie Varner,Blue,Lightweight
+02/03/2007,Anderson Silva,Travis Lutter,Red,Middleweight
+02/03/2007,Eddie Sanchez,Mirko Filipovic,Blue,Heavyweight
+02/03/2007,John Halverson,Roger Huerta,Blue,Lightweight
+02/03/2007,Quinton Jackson,Marvin Eastman,Red,Light Heavyweight
+02/03/2007,Scott Smith,Patrick Cote,Blue,Middleweight
+02/03/2007,Terry Martin,Jorge Rivera,Red,Middleweight
+02/03/2007,Frankie Edgar,Tyson Griffin,Red,Lightweight
+02/03/2007,Lyoto Machida,Sam Hoger,Red,Light Heavyweight
+02/03/2007,Diego Saraiva,Dustin Hazelett,Blue,Lightweight
+01/25/2007,Sean Salmon,Rashad Evans,Blue,Light Heavyweight
+01/25/2007,Jake O'Brien,Heath Herring,Red,Heavyweight
+01/25/2007,Spencer Fisher,Hermes Franca,Blue,Lightweight
+01/25/2007,Nate Marquardt,Dean Lister,Red,Middleweight
+01/25/2007,Chad Reiner,Joshua Burkman,Blue,Welterweight
+01/25/2007,Ed Herman,Chris Price,Red,Middleweight
+01/25/2007,Din Thomas,Clay Guida,Red,Lightweight
+01/25/2007,Rich Clementi,Ross Pointon,Red,Welterweight
+12/30/2006,Chuck Liddell,Tito Ortiz,Red,UFC Light Heavyweight Title
+12/30/2006,Forrest Griffin,Keith Jardine,Blue,Light Heavyweight
+12/30/2006,Chris Leben,Jason MacDonald,Blue,Middleweight
+12/30/2006,Andrei Arlovski,Marcio Cruz,Red,Heavyweight
+12/30/2006,Michael Bisping,Eric Schafer,Red,Light Heavyweight
+12/30/2006,Tony DeSouza,Thiago Alves,Blue,Welterweight
+12/30/2006,Gabriel Gonzaga,Carmelo Marrero,Red,Heavyweight
+12/30/2006,Yushin Okami,Rory Singer,Red,Middleweight
+12/30/2006,Anthony Perosh,Christian Wellisch,Blue,Heavyweight
+12/13/2006,Diego Sanchez,Joe Riggs,Red,Welterweight
+12/13/2006,Jeff Joslin,Josh Koscheck,Blue,Welterweight
+12/13/2006,Karo Parisyan,Drew Fickett,Red,Welterweight
+12/13/2006,Marcus Davis,Shonie Carter,Red,Welterweight
+12/13/2006,Victor Valimaki,David Heath,Blue,Light Heavyweight
+12/13/2006,Jorge Santiago,Alan Belcher,Blue,Middleweight
+12/13/2006,Luigi Fioravanti,Dave Menne,Red,Welterweight
+12/13/2006,Keita Nakamura,Brock Larson,Blue,Welterweight
+12/13/2006,Steve Byrnes,Logan Clark,Blue,Middleweight
+11/18/2006,Matt Hughes,Georges St-Pierre,Blue,UFC Welterweight Title
+11/18/2006,Tim Sylvia,Jeff Monson,Red,UFC Heavyweight Title
+11/18/2006,Drew McFedries,Alessio Sakara,Red,Light Heavyweight
+11/18/2006,Brandon Vera,Frank Mir,Red,Heavyweight
+11/18/2006,Dokonjonosuke Mishima,Joe Stevenson,Blue,Lightweight
+11/18/2006,Gleison Tibau,Nick Diaz,Blue,Welterweight
+11/18/2006,Antoni Hardonk,Sherman Pendergarst,Red,Heavyweight
+11/18/2006,James Irvin,Hector Ramirez,Red,Light Heavyweight
+11/18/2006,Jake O'Brien,Josh Shockman,Red,Heavyweight
+11/11/2006,Chris Lytle,Matt Serra,Blue,Ultimate Fighter 4 Welterweight Tournament Title
+11/11/2006,Patrick Cote,Travis Lutter,Blue,Ultimate Fighter 4 Middleweight Tournament Title
+11/11/2006,Rich Clementi,Din Thomas,Blue,Lightweight
+11/11/2006,Edwin DeWees,Jorge Rivera,Blue,Middleweight
+11/11/2006,Jeremy Jackson,Pete Spratt,Blue,Welterweight
+11/11/2006,Pete Sell,Scott Smith,Blue,Middleweight
+11/11/2006,Charles McCarthy,Gideon Ray,Red,Middleweight
+11/11/2006,Martin Kampmann,Thales Leites,Red,Middleweight
+10/14/2006,Anderson Silva,Rich Franklin,Red,UFC Middleweight Title
+10/14/2006,Sean Sherk,Kenny Florian,Red,UFC Lightweight Title
+10/14/2006,Jon Fitch,Kuniyoshi Hironaka,Red,Welterweight
+10/14/2006,Cheick Kongo,Carmelo Marrero,Blue,Heavyweight
+10/14/2006,Spencer Fisher,Dan Lauzon,Red,Lightweight
+10/14/2006,Kalib Starnes,Yushin Okami,Blue,Middleweight
+10/14/2006,Clay Guida,Justin James,Red,Lightweight
+10/14/2006,Kurt Pellegrino,Junior Assuncao,Red,Lightweight
+10/10/2006,Tito Ortiz,Ken Shamrock,Red,Light Heavyweight
+10/10/2006,Kendall Grove,Chris Price,Red,Middleweight
+10/10/2006,Ed Herman,Jason MacDonald,Blue,Middleweight
+10/10/2006,Matt Hamill,Seth Petruzelli,Red,Light Heavyweight
+10/10/2006,Crafton Wallace,Nate Marquardt,Blue,Middleweight
+10/10/2006,Tony DeSouza,Dustin Hazelett,Red,Welterweight
+10/10/2006,Rory Singer,Josh Haynes,Red,Middleweight
+10/10/2006,John Alessio,Thiago Alves,Blue,Welterweight
+10/10/2006,Forrest Petz,Marcus Davis,Blue,Welterweight
+09/23/2006,Matt Hughes,BJ Penn,Red,UFC Welterweight Title
+09/23/2006,David Loiseau,Mike Swick,Blue,Middleweight
+09/23/2006,Gabe Ruediger,Melvin Guillard,Blue,Lightweight
+09/23/2006,Rashad Evans,Jason Lambert,Red,Light Heavyweight
+09/23/2006,Jens Pulver,Joe Lauzon,Blue,Lightweight
+09/23/2006,Jason Dent,Roger Huerta,Blue,Lightweight
+09/23/2006,Eddie Sanchez,Mario Neto,Red,Heavyweight
+09/23/2006,Jorge Gurgel,Danny Abbadi,Red,Lightweight
+09/23/2006,David Lee,Tyson Griffin,Blue,Lightweight
+08/26/2006,Renato Sobral,Chuck Liddell,Blue,UFC Light Heavyweight Title
+08/26/2006,Stephan Bonnar,Forrest Griffin,Blue,Light Heavyweight
+08/26/2006,Josh Neer,Nick Diaz,Blue,Welterweight
+08/26/2006,Christian Wellisch,Cheick Kongo,Blue,Heavyweight
+08/26/2006,Hermes Franca,Jamie Varner,Red,Lightweight
+08/26/2006,Eric Schafer,Rob MacDonald,Red,Light Heavyweight
+08/26/2006,Wes Combs,Wilson Gouveia,Blue,Light Heavyweight
+08/26/2006,Cory Walmsley,David Heath,Blue,Light Heavyweight
+08/26/2006,Yushin Okami,Alan Belcher,Red,Middleweight
+08/17/2006,Karo Parisyan,Diego Sanchez,Blue,Welterweight
+08/17/2006,Jorge Santiago,Chris Leben,Blue,Middleweight
+08/17/2006,Yuki Sasaki,Dean Lister,Blue,Middleweight
+08/17/2006,Jonathan Goulet,Josh Koscheck,Blue,Welterweight
+08/17/2006,Crafton Wallace,Martin Kampmann,Blue,Middleweight
+08/17/2006,Joe Riggs,Jason Von Flue,Red,Welterweight
+08/17/2006,Kristof Midoux,Jake O'Brien,Blue,Heavyweight
+08/17/2006,Forrest Petz,Sammy Morgan,Red,Welterweight
+08/17/2006,Anthony Torres,Pat Healy,Red,Welterweight
+07/08/2006,Andrei Arlovski,Tim Sylvia,Blue,UFC Heavyweight Title
+07/08/2006,Joshua Burkman,Josh Neer,Red,Welterweight
+07/08/2006,Tito Ortiz,Ken Shamrock,Red,Light Heavyweight
+07/08/2006,Dan Christison,Frank Mir,Blue,Heavyweight
+07/08/2006,Joe Stevenson,Yves Edwards,Red,Lightweight
+07/08/2006,Joe Jordan,Hermes Franca,Blue,Catch Weight
+07/08/2006,Jeff Monson,Anthony Perosh,Red,Heavyweight
+07/08/2006,Cheick Kongo,Gilbert Aldana,Red,Heavyweight
+07/08/2006,Kurt Pellegrino,Drew Fickett,Blue,Welterweight
+06/28/2006,Luke Cummo,Jonathan Goulet,Blue,Welterweight
+06/28/2006,Chris Leben,Anderson Silva,Blue,Middleweight
+06/28/2006,Rashad Evans,Stephan Bonnar,Red,Light Heavyweight
+06/28/2006,Jorge Gurgel,Mark Hominick,Blue,Lightweight
+06/28/2006,Josh Koscheck,Dave Menne,Red,Welterweight
+06/28/2006,Branden Lee Hinkle,Jason Lambert,Blue,Light Heavyweight
+06/28/2006,Thiago Alves,Jon Fitch,Blue,Welterweight
+06/28/2006,Rob MacDonald,Kristian Rothaermel,Red,Light Heavyweight
+06/28/2006,Jorge Santiago,Justin Levens,Red,Middleweight
+06/24/2006,Kenny Florian,Sam Stout,Red,Lightweight
+06/24/2006,Josh Haynes,Michael Bisping,Blue,Ultimate Fighter 3 Light Heavyweight Tournament Title
+06/24/2006,Ed Herman,Kendall Grove,Blue,Ultimate Fighter 3 Middleweight Tournament Title
+06/24/2006,Keith Jardine,Wilson Gouveia,Red,Light Heavyweight
+06/24/2006,Rory Singer,Ross Pointon,Red,Middleweight
+06/24/2006,Kalib Starnes,Danny Abbadi,Red,Middleweight
+06/24/2006,Luigi Fioravanti,Solomon Hutcherson,Red,Middleweight
+06/24/2006,Matt Hamill,Jesse Forbes,Red,Light Heavyweight
+06/24/2006,Wes Combs,Mike Nickels,Blue,Light Heavyweight
+05/27/2006,Matt Hughes,Royce Gracie,Red,Catch Weight
+05/27/2006,Dean Lister,Alessio Sakara,Red,Light Heavyweight
+05/27/2006,John Alessio,Diego Sanchez,Blue,Welterweight
+05/27/2006,Assuerio Silva,Brandon Vera,Blue,Heavyweight
+05/27/2006,Joe Riggs,Mike Swick,Blue,Middleweight
+05/27/2006,Chael Sonnen,Jeremy Horn,Blue,Middleweight
+05/27/2006,Matt Wiman,Spencer Fisher,Blue,Lightweight
+05/27/2006,Gabriel Gonzaga,Fabiano Scherner,Red,Heavyweight
+05/27/2006,Melvin Guillard,Rick Davis,Red,Lightweight
+04/15/2006,Tim Sylvia,Andrei Arlovski,Red,UFC Heavyweight Title
+04/15/2006,Nick Diaz,Sean Sherk,Blue,Welterweight
+04/15/2006,Tito Ortiz,Forrest Griffin,Red,Light Heavyweight
+04/15/2006,Evan Tanner,Justin Levens,Red,Middleweight
+04/15/2006,Marcio Cruz,Jeff Monson,Blue,Heavyweight
+04/15/2006,Nick Thompson,Karo Parisyan,Blue,Welterweight
+04/15/2006,Scott Smith,David Terrell,Blue,Middleweight
+04/15/2006,Terry Martin,Jason Lambert,Blue,Light Heavyweight
+04/15/2006,Thiago Alves,Derrick Noble,Red,Welterweight
+04/06/2006,Stephan Bonnar,Keith Jardine,Red,Light Heavyweight
+04/06/2006,Sam Hoger,Rashad Evans,Blue,Light Heavyweight
+04/06/2006,Josh Neer,Joe Stevenson,Red,Welterweight
+04/06/2006,Chris Leben,Luigi Fioravanti,Red,Middleweight
+04/06/2006,Luke Cummo,Jason Von Flue,Red,Welterweight
+04/06/2006,Joshua Burkman,Jon Fitch,Blue,Welterweight
+04/06/2006,Brad Imes,Dan Christison,Blue,Heavyweight
+04/06/2006,Ansar Chalangov,Josh Koscheck,Blue,Welterweight
+04/06/2006,Trevor Prangley,Chael Sonnen,Blue,Middleweight
+03/04/2006,David Loiseau,Rich Franklin,Blue,UFC Middleweight Title
+03/04/2006,Steve Vigneault,Mike Swick,Blue,Middleweight
+03/04/2006,Georges St-Pierre,BJ Penn,Red,Welterweight
+03/04/2006,Joe Doerksen,Nate Marquardt,Blue,Middleweight
+03/04/2006,Yves Edwards,Mark Hominick,Blue,Lightweight
+03/04/2006,Sam Stout,Spencer Fisher,Red,Lightweight
+03/04/2006,Jason Lambert,Rob MacDonald,Red,Light Heavyweight
+03/04/2006,Tom Murphy,Icho Larenas,Red,Heavyweight
+02/04/2006,Randy Couture,Chuck Liddell,Blue,UFC Light Heavyweight Title
+02/04/2006,Brandon Vera,Justin Eilers,Red,Heavyweight
+02/04/2006,Frank Mir,Marcio Cruz,Blue,Heavyweight
+02/04/2006,Mike van Arsdale,Renato Sobral,Blue,Light Heavyweight
+02/04/2006,Joe Riggs,Nick Diaz,Red,Welterweight
+02/04/2006,Elvis Sinosic,Alessio Sakara,Blue,Light Heavyweight
+02/04/2006,Gilbert Aldana,Paul Buentello,Blue,Heavyweight
+02/04/2006,Jeff Monson,Branden Lee Hinkle,Red,Heavyweight
+02/04/2006,Mike Whitehead,Keith Jardine,Blue,Light Heavyweight
+01/16/2006,Tim Sylvia,Assuerio Silva,Red,Heavyweight
+01/16/2006,Stephan Bonnar,James Irvin,Red,Light Heavyweight
+01/16/2006,Joshua Burkman,Drew Fickett,Red,Welterweight
+01/16/2006,Chris Leben,Jorge Rivera,Red,Middleweight
+01/16/2006,Melvin Guillard,Josh Neer,Blue,Welterweight
+01/16/2006,Duane Ludwig,Jonathan Goulet,Red,Welterweight
+01/16/2006,Spencer Fisher,Aaron Riley,Red,Welterweight
+01/16/2006,Alex Karalexis,Jason Von Flue,Blue,Welterweight
+11/19/2005,Nate Quarry,Rich Franklin,Blue,UFC Middleweight Title
+11/19/2005,Kevin Jordan,Gabriel Gonzaga,Blue,Heavyweight
+11/19/2005,Joe Riggs,Matt Hughes,Blue,Welterweight
+11/19/2005,Sean Sherk,Georges St-Pierre,Blue,Welterweight
+11/19/2005,Jeremy Horn,Trevor Prangley,Red,Middleweight
+11/19/2005,Sam Hoger,Jeff Newton,Red,Light Heavyweight
+11/19/2005,Ansar Chalangov,Thiago Alves,Blue,Welterweight
+11/19/2005,Nick Thompson,Keith Wisniewski,Red,Welterweight
+11/05/2005,Nick Diaz,Diego Sanchez,Blue,Welterweight
+11/05/2005,Brad Imes,Rashad Evans,Blue,Ultimate Fighter 2 Heavyweight Tournament Title
+11/05/2005,Luke Cummo,Joe Stevenson,Blue,Ultimate Fighter 2 Welterweight Tournament Title
+11/05/2005,Kit Cope,Kenny Florian,Blue,Welterweight
+11/05/2005,Sammy Morgan,Joshua Burkman,Blue,Welterweight
+11/05/2005,Melvin Guillard,Marcus Davis,Red,Welterweight
+11/05/2005,Keith Jardine,Kerry Schall,Red,Heavyweight
+10/07/2005,Paul Buentello,Andrei Arlovski,Blue,UFC Heavyweight Title
+10/07/2005,Branden Lee Hinkle,Sean Gannon,Red,Heavyweight
+10/07/2005,Elvis Sinosic,Forrest Griffin,Blue,Light Heavyweight
+10/07/2005,Chael Sonnen,Renato Sobral,Blue,Light Heavyweight
+10/07/2005,Chris Lytle,Joe Riggs,Blue,Welterweight
+10/07/2005,Jorge Rivera,Dennis Hallman,Red,Middleweight
+10/07/2005,Keigo Kunihara,Marcio Cruz,Blue,Heavyweight
+10/03/2005,David Loiseau,Evan Tanner,Red,Middleweight
+10/03/2005,Chris Leben,Edwin DeWees,Red,Middleweight
+10/03/2005,Brandon Vera,Fabiano Scherner,Red,Heavyweight
+10/03/2005,Josh Koscheck,Drew Fickett,Blue,Welterweight
+10/03/2005,Spencer Fisher,Thiago Alves,Red,Welterweight
+10/03/2005,Jon Fitch,Brock Larson,Red,Middleweight
+10/03/2005,Jonathan Goulet,Jay Hieron,Red,Welterweight
+08/20/2005,Chuck Liddell,Jeremy Horn,Red,UFC Light Heavyweight Title
+08/20/2005,Tra Telligman,Tim Sylvia,Blue,Heavyweight
+08/20/2005,Mike van Arsdale,Randy Couture,Blue,Light Heavyweight
+08/20/2005,Diego Sanchez,Brian Gassaway,Red,Welterweight
+08/20/2005,Frank Trigg,Georges St-Pierre,Blue,Welterweight
+08/20/2005,Matt Lindland,Joe Doerksen,Red,Middleweight
+08/20/2005,Travis Lutter,Trevor Prangley,Blue,Middleweight
+08/20/2005,James Irvin,Terry Martin,Red,Light Heavyweight
+08/06/2005,Ivan Salaverry,Nate Marquardt,Blue,Middleweight
+08/06/2005,Chris Leben,Patrick Cote,Red,Middleweight
+08/06/2005,Stephan Bonnar,Sam Hoger,Red,Light Heavyweight
+08/06/2005,Pete Sell,Nate Quarry,Blue,Middleweight
+08/06/2005,Josh Koscheck,Pete Spratt,Red,Welterweight
+08/06/2005,Gideon Ray,Mike Swick,Blue,Middleweight
+08/06/2005,Kenny Florian,Alex Karalexis,Red,Welterweight
+08/06/2005,Drew Fickett,Josh Neer,Red,Welterweight
+06/04/2005,Justin Eilers,Andrei Arlovski,Blue,UFC Interim Heavyweight Title
+06/04/2005,Matt Serra,Karo Parisyan,Blue,Welterweight
+06/04/2005,Rich Franklin,Evan Tanner,Red,UFC Middleweight Title
+06/04/2005,Bill Mahood,Forrest Griffin,Blue,Light Heavyweight
+06/04/2005,Paul Buentello,Kevin Jordan,Red,Heavyweight
+06/04/2005,Nate Quarry,Shonie Carter,Red,Middleweight
+06/04/2005,Charles McCarthy,David Loiseau,Blue,Middleweight
+06/04/2005,Nick Diaz,Koji Oishi,Red,Welterweight
+04/16/2005,Randy Couture,Chuck Liddell,Blue,UFC Light Heavyweight Title
+04/16/2005,Renato Sobral,Travis Wiuff,Red,Light Heavyweight
+04/16/2005,Frank Trigg,Matt Hughes,Blue,UFC Welterweight Title
+04/16/2005,Matt Lindland,Travis Lutter,Red,Middleweight
+04/16/2005,Georges St-Pierre,Jason Miller,Red,Welterweight
+04/16/2005,Joe Riggs,Ivan Salaverry,Blue,Middleweight
+04/16/2005,Joe Doerksen,Patrick Cote,Red,Middleweight
+04/16/2005,Mike van Arsdale,John Marsh,Red,Heavyweight
+04/09/2005,Rich Franklin,Ken Shamrock,Red,Light Heavyweight
+04/09/2005,Stephan Bonnar,Forrest Griffin,Blue,Ultimate Fighter 1 Light Heavyweight Tournament Title
+04/09/2005,Kenny Florian,Diego Sanchez,Blue,Ultimate Fighter 1 Middleweight Tournament Title
+04/09/2005,Bobby Southworth,Sam Hoger,Blue,Light Heavyweight
+04/09/2005,Chris Leben,Jason Thacker,Red,Middleweight
+04/09/2005,Josh Koscheck,Chris Sanford,Red,Middleweight
+04/09/2005,Nate Quarry,Lodune Sincaid,Red,Middleweight
+04/09/2005,Mike Swick,Alex Schoenauer,Red,Middleweight
+04/09/2005,Alex Karalexis,Josh Rafferty,Red,Welterweight
+02/05/2005,Vitor Belfort,Tito Ortiz,Blue,Light Heavyweight
+02/05/2005,Phil Baroni,Pete Sell,Blue,Middleweight
+02/05/2005,Tim Sylvia,Andrei Arlovski,Blue,UFC Interim Heavyweight Title
+02/05/2005,David Terrell,Evan Tanner,Blue,UFC Middleweight Title
+02/05/2005,Paul Buentello,Justin Eilers,Red,Heavyweight
+02/05/2005,James Irvin,Mike Kyle,Blue,Heavyweight
+02/05/2005,David Loiseau,Gideon Ray,Red,Middleweight
+02/05/2005,Karo Parisyan,Chris Lytle,Red,Welterweight
+02/05/2005,Drew Fickett,Nick Diaz,Blue,Welterweight
+10/22/2004,Tito Ortiz,Patrick Cote,Red,Light Heavyweight
+10/22/2004,Rich Franklin,Jorge Rivera,Red,Middleweight
+10/22/2004,Matt Hughes,Georges St-Pierre,Red,UFC Welterweight Title
+10/22/2004,Frank Trigg,Renato Verissimo,Red,Welterweight
+10/22/2004,Evan Tanner,Robbie Lawler,Red,Middleweight
+10/22/2004,Tony Fryklund,Ivan Salaverry,Blue,Middleweight
+10/22/2004,Travis Lutter,Marvin Eastman,Red,Light Heavyweight
+08/21/2004,Randy Couture,Vitor Belfort,Red,UFC Light Heavyweight Title
+08/21/2004,Joe Riggs,Joe Doerksen,Red,Middleweight
+08/21/2004,Vernon White,Chuck Liddell,Blue,Light Heavyweight
+08/21/2004,Matt Lindland,David Terrell,Blue,Middleweight
+08/21/2004,Mike Kyle,Justin Eilers,Blue,Heavyweight
+08/21/2004,Chris Lytle,Ronald Jhun,Red,Welterweight
+08/21/2004,Karo Parisyan,Nick Diaz,Red,Welterweight
+08/21/2004,Josh Thomson,Yves Edwards,Blue,Lightweight
+06/19/2004,Ken Shamrock,Kimo Leopoldo,Red,Heavyweight
+06/19/2004,Dennis Hallman,Frank Trigg,Blue,Welterweight
+06/19/2004,Tim Sylvia,Frank Mir,Blue,UFC Heavyweight Title
+06/19/2004,Renato Verissimo,Matt Hughes,Blue,Welterweight
+06/19/2004,Evan Tanner,Phil Baroni,Red,Middleweight
+06/19/2004,Ivan Menjivar,Matt Serra,Blue,Lightweight
+06/19/2004,Jay Hieron,Georges St-Pierre,Blue,Welterweight
+06/19/2004,Curtis Stout,Trevor Prangley,Blue,Middleweight
+04/02/2004,Tito Ortiz,Chuck Liddell,Blue,Light Heavyweight
+04/02/2004,Chris Lytle,Tiki Ghosn,Red,Welterweight
+04/02/2004,Yves Edwards,Hermes Franca,Red,Lightweight
+04/02/2004,Andrei Arlovski,Wesley Correira,Red,Heavyweight
+04/02/2004,Robbie Lawler,Nick Diaz,Blue,Welterweight
+04/02/2004,Mike Kyle,Wes Sims,Red,Heavyweight
+04/02/2004,Wade Shipp,Jonathan Wiezorek,Blue,Heavyweight
+04/02/2004,Genki Sudo,Mike Brown,Red,Lightweight
+01/31/2004,Randy Couture,Vitor Belfort,Blue,UFC Light Heavyweight Title
+01/31/2004,Renato Verissimo,Carlos Newton,Red,Welterweight
+01/31/2004,Matt Hughes,BJ Penn,Blue,UFC Welterweight Title
+01/31/2004,Wes Sims,Frank Mir,Blue,Heavyweight
+01/31/2004,Jorge Rivera,Lee Murray,Blue,Middleweight
+01/31/2004,Karo Parisyan,Georges St-Pierre,Blue,Welterweight
+01/31/2004,Hermes Franca,Josh Thomson,Blue,Lightweight
+01/31/2004,Jeff Curran,Matt Serra,Blue,Lightweight
+11/21/2003,Matt Hughes,Frank Trigg,Red,UFC Welterweight Title
+11/21/2003,Falaniko Vitale,Matt Lindland,Blue,Middleweight
+11/21/2003,David Abbott,Wesley Correira,Blue,Heavyweight
+11/21/2003,Phil Baroni,Evan Tanner,Blue,Middleweight
+11/21/2003,Chris Lytle,Robbie Lawler,Blue,Welterweight
+11/21/2003,Ricco Rodriguez,Pedro Rizzo,Blue,Heavyweight
+11/21/2003,Keith Rockel,Chris Liguori,Red,Middleweight
+11/21/2003,Yves Edwards,Nick Agallar,Red,Lightweight
+09/26/2003,Randy Couture,Tito Ortiz,Red,UFC Light Heavyweight Title
+09/26/2003,Andrei Arlovski,Vladimir Matyushenko,Red,Heavyweight
+09/26/2003,Tim Sylvia,Gan McGee,Red,UFC Heavyweight Title
+09/26/2003,David Loiseau,Jorge Rivera,Blue,Middleweight
+09/26/2003,Rich Franklin,Edwin DeWees,Red,Light Heavyweight
+09/26/2003,Dave Strasser,Karo Parisyan,Blue,Welterweight
+09/26/2003,Josh Thomson,Gerald Strebendt,Red,Lightweight
+09/26/2003,Jeremy Jackson,Nick Diaz,Blue,Welterweight
+09/26/2003,Caol Uno,Hermes Franca,Blue,Lightweight
+06/06/2003,Chuck Liddell,Randy Couture,Blue,UFC Interim Light Heavyweight Title
+06/06/2003,Kimo Leopoldo,David Abbott,Red,Heavyweight
+06/06/2003,Marvin Eastman,Vitor Belfort,Blue,Light Heavyweight
+06/06/2003,Wes Sims,Frank Mir,Blue,Heavyweight
+06/06/2003,Yves Edwards,Eddie Ruiz,Red,Lightweight
+06/06/2003,Matt Lindland,Falaniko Vitale,Blue,Middleweight
+06/06/2003,Tra Telligman,Pedro Rizzo,Blue,Heavyweight
+04/25/2003,Matt Hughes,Sean Sherk,Red,UFC Welterweight Title
+04/25/2003,Robbie Lawler,Pete Spratt,Blue,Welterweight
+04/25/2003,Romie Aram,Dave Strasser,Blue,Welterweight
+04/25/2003,Wesley Correira,Sean Alvarez,Red,Heavyweight
+04/25/2003,Evan Tanner,Rich Franklin,Blue,Light Heavyweight
+04/25/2003,Duane Ludwig,Genki Sudo,Red,Lightweight
+04/25/2003,Richard Crunkilton,Hermes Franca,Blue,Lightweight
+04/25/2003,David Loiseau,Mark Weir,Red,Middleweight
+02/28/2003,Tim Sylvia,Ricco Rodriguez,Red,UFC Heavyweight Title
+02/28/2003,Frank Mir,David Abbott,Red,Heavyweight
+02/28/2003,Phil Baroni,Matt Lindland,Blue,Middleweight
+02/28/2003,Pedro Rizzo,Vladimir Matyushenko,Blue,Heavyweight
+02/28/2003,Matt Serra,Din Thomas,Blue,Lightweight
+02/28/2003,Alexandre Dantas,Gan McGee,Blue,Heavyweight
+02/28/2003,Yves Edwards,Rich Clementi,Red,Lightweight
+11/22/2002,Tito Ortiz,Ken Shamrock,Red,UFC Light Heavyweight Title
+11/22/2002,Renato Sobral,Chuck Liddell,Blue,Light Heavyweight
+11/22/2002,Matt Hughes,Gil Castillo,Red,UFC Welterweight Title
+11/22/2002,Carlos Newton,Pete Spratt,Red,Welterweight
+11/22/2002,Robbie Lawler,Tiki Ghosn,Red,Welterweight
+11/22/2002,Ian Freeman,Andrei Arlovski,Blue,Heavyweight
+11/22/2002,Vladimir Matyushenko,Travis Wiuff,Red,Heavyweight
+11/22/2002,Mark Weir,Phillip Miller,Blue,Middleweight
+09/27/2002,Ricco Rodriguez,Randy Couture,Red,UFC Heavyweight Title
+09/27/2002,Tim Sylvia,Wesley Correira,Red,Heavyweight
+09/27/2002,Matt Serra,BJ Penn,Blue,Lightweight
+09/27/2002,Din Thomas,Caol Uno,Blue,Lightweight
+09/27/2002,Gan McGee,Pedro Rizzo,Red,Heavyweight
+09/27/2002,Phil Baroni,Dave Menne,Red,Middleweight
+09/27/2002,Matt Lindland,Ivan Salaverry,Red,Middleweight
+09/27/2002,Sean Sherk,Benji Radach,Red,Welterweight
+07/13/2002,Matt Hughes,Carlos Newton,Red,UFC Welterweight Title
+07/13/2002,Ian Freeman,Frank Mir,Red,Heavyweight
+07/13/2002,Mark Weir,Eugene Jackson,Red,Middleweight
+07/13/2002,Leigh Remedios,Genki Sudo,Blue,Lightweight
+07/13/2002,James Zikic,Phillip Miller,Blue,Light Heavyweight
+07/13/2002,Renato Sobral,Elvis Sinosic,Red,Light Heavyweight
+07/13/2002,Chris Haseman,Evan Tanner,Blue,Light Heavyweight
+06/22/2002,Vitor Belfort,Chuck Liddell,Blue,Light Heavyweight
+06/22/2002,Nick Serra,Benji Radach,Blue,Welterweight
+06/22/2002,Zach Light,Pete Spratt,Blue,Welterweight
+06/22/2002,Steve Berger,Robbie Lawler,Blue,Welterweight
+06/22/2002,Rodrigo Ruas,Tony Fryklund,Blue,Middleweight
+06/22/2002,Joao Pierini,Yves Edwards,Blue,Lightweight
+05/10/2002,Murilo Bustamante,Matt Lindland,Red,UFC Middleweight Title
+05/10/2002,Tsuyoshi Kohsaka,Ricco Rodriguez,Blue,Heavyweight
+05/10/2002,Paul Creighton,BJ Penn,Blue,Lightweight
+05/10/2002,Phil Baroni,Amar Suloev,Red,Middleweight
+05/10/2002,Yves Edwards,Caol Uno,Blue,Lightweight
+05/10/2002,Ivan Salaverry,Andrei Semenov,Red,Middleweight
+05/10/2002,Robbie Lawler,Aaron Riley,Red,Welterweight
+03/22/2002,Josh Barnett,Randy Couture,Red,UFC Heavyweight Title
+03/22/2002,Andrei Arlovski,Pedro Rizzo,Blue,Heavyweight
+03/22/2002,Matt Hughes,Hayato Sakurai,Red,UFC Welterweight Title
+03/22/2002,Pat Miletich,Matt Lindland,Blue,Middleweight
+03/22/2002,Elvis Sinosic,Evan Tanner,Blue,Light Heavyweight
+03/22/2002,Pete Williams,Frank Mir,Blue,Heavyweight
+03/22/2002,Matt Serra,Kelly Dullanty,Red,Lightweight
+03/22/2002,Jutaro Nakao,Sean Sherk,Blue,Welterweight
+01/11/2002,BJ Penn,Jens Pulver,Blue,UFC Lightweight Title
+01/11/2002,Ricco Rodriguez,Jeff Monson,Red,Heavyweight
+01/11/2002,Dave Menne,Murilo Bustamante,Blue,UFC Middleweight Title
+01/11/2002,Chuck Liddell,Amar Suloev,Red,Light Heavyweight
+01/11/2002,Ricardo Almeida,Andrei Semenov,Blue,Middleweight
+01/11/2002,Kevin Randleman,Renato Sobral,Red,Light Heavyweight
+01/11/2002,Gil Castillo,Chris Brennan,Red,Welterweight
+01/11/2002,Eugene Jackson,Keith Rockel,Red,Middleweight
+11/02/2001,Pedro Rizzo,Randy Couture,Blue,UFC Heavyweight Title
+11/02/2001,Pete Williams,Ricco Rodriguez,Blue,Heavyweight
+11/02/2001,Matt Hughes,Carlos Newton,Red,UFC Welterweight Title
+11/02/2001,BJ Penn,Caol Uno,Red,Lightweight
+11/02/2001,Bobby Hoffman,Josh Barnett,Blue,Heavyweight
+11/02/2001,Evan Tanner,Homer Moore,Red,Light Heavyweight
+11/02/2001,Phil Baroni,Matt Lindland,Blue,Middleweight
+11/02/2001,Roberto Traven,Frank Mir,Blue,Heavyweight
+09/28/2001,Vladimir Matyushenko,Tito Ortiz,Blue,UFC Light Heavyweight Title
+09/28/2001,Dennis Hallman,Jens Pulver,Blue,UFC Lightweight Title
+09/28/2001,Chuck Liddell,Murilo Bustamante,Red,Light Heavyweight
+09/28/2001,Yves Edwards,Matt Serra,Blue,Welterweight
+09/28/2001,Gil Castillo,Dave Menne,Blue,UFC Middleweight Title
+09/28/2001,Tony DeSouza,Jutaro Nakao,Blue,Welterweight
+09/28/2001,Ricardo Almeida,Eugene Jackson,Red,Middleweight
+09/28/2001,Din Thomas,Fabiano Iha,Red,Lightweight
+06/29/2001,Tito Ortiz,Elvis Sinosic,Red,UFC Light Heavyweight Title
+06/29/2001,BJ Penn,Din Thomas,Red,Lightweight
+06/29/2001,Josh Barnett,Semmy Schilt,Red,Heavyweight
+06/29/2001,Pat Miletich,Shonie Carter,Red,Welterweight
+06/29/2001,Fabiano Iha,Caol Uno,Blue,Lightweight
+06/29/2001,Vladimir Matyushenko,Yuki Kondo,Red,Light Heavyweight
+06/29/2001,Andrei Arlovski,Ricco Rodriguez,Blue,Heavyweight
+06/29/2001,Tony DeSouza,Paul Rodriguez,Red,Welterweight
+05/04/2001,Pedro Rizzo,Randy Couture,Blue,UFC Heavyweight Title
+05/04/2001,Pat Miletich,Carlos Newton,Blue,UFC Welterweight Title
+05/04/2001,Kevin Randleman,Chuck Liddell,Blue,Light Heavyweight
+05/04/2001,Matt Serra,Shonie Carter,Blue,Welterweight
+05/04/2001,Semmy Schilt,Pete Williams,Red,Heavyweight
+05/04/2001,Matt Lindland,Ricardo Almeida,Red,Light Heavyweight
+05/04/2001,Joey Gilbert,BJ Penn,Blue,Lightweight
+05/04/2001,Tony DeSouza,Steve Berger,Red,Welterweight
+02/23/2001,Evan Tanner,Tito Ortiz,Blue,UFC Light Heavyweight Title
+02/23/2001,Caol Uno,Jens Pulver,Blue,UFC Lightweight Title
+02/23/2001,Fabiano Iha,Phil Johns,Red,Welterweight
+02/23/2001,Elvis Sinosic,Jeremy Horn,Red,Middleweight
+02/23/2001,Pedro Rizzo,Josh Barnett,Red,Heavyweight
+02/23/2001,Curtis Stout,Phil Baroni,Blue,Middleweight
+02/23/2001,Tiki Ghosn,Sean Sherk,Blue,Welterweight
+12/16/2000,Tito Ortiz,Yuki Kondo,Red,UFC Light Heavyweight Title
+12/16/2000,Pat Miletich,Kenichi Yamamoto,Red,UFC Welterweight Title
+12/16/2000,Yoji Anjo,Matt Lindland,Blue,Middleweight
+12/16/2000,Fabiano Iha,Daiju Takase,Red,Welterweight
+12/16/2000,Evan Tanner,Lance Gibson,Red,Middleweight
+12/16/2000,Matt Hughes,Dennis Hallman,Blue,Welterweight
+12/16/2000,Jeff Monson,Chuck Liddell,Blue,Middleweight
+11/17/2000,Kevin Randleman,Randy Couture,Blue,UFC Heavyweight Title
+11/17/2000,Renato Sobral,Maurice Smith,Red,Heavyweight
+11/17/2000,Gan McGee,Josh Barnett,Blue,Super Heavyweight
+11/17/2000,Aaron Brink,Andrei Arlovski,Blue,Heavyweight
+11/17/2000,John Lewis,Jens Pulver,Blue,Lightweight
+11/17/2000,Mark Hughes,Alex Stiebling,Red,Middleweight
+11/17/2000,Ben Earwood,Chris Lytle,Red,Welterweight
+09/22/2000,Pedro Rizzo,Dan Severn,Red,Heavyweight
+09/22/2000,Bobby Hoffman,Maurice Smith,Blue,Heavyweight
+09/22/2000,Jeremy Horn,Eugene Jackson,Red,Middleweight
+09/22/2000,Fabiano Iha,Laverne Clark,Red,Welterweight
+09/22/2000,Yuki Kondo,Alexandre Dantas,Red,Middleweight
+09/22/2000,Tedd Williams,Ian Freeman,Blue,Heavyweight
+09/22/2000,Tim Lajcik,Jeff Monson,Blue,Heavyweight
+06/09/2000,Kevin Randleman,Pedro Rizzo,Red,UFC Heavyweight Title
+06/09/2000,Tyrone Roberts,David Dodd,Red,Middleweight
+06/09/2000,John Alessio,Pat Miletich,Blue,UFC Welterweight Title
+06/09/2000,Amaury Bitetti,Alex Andrade,Red,Middleweight
+06/09/2000,Marcelo Aguiar,Matt Hughes,Blue,Welterweight
+06/09/2000,Joao Roque,Jens Pulver,Blue,Lightweight
+06/09/2000,Ian Freeman,Nate Schroeder,Red,Heavyweight
+06/09/2000,Adrian Serrano,Shonie Carter,Blue,Welterweight
+04/14/2000,Tito Ortiz,Wanderlei Silva,Red,UFC Light Heavyweight Title
+04/14/2000,Yoji Anjo,Murilo Bustamante,Blue,Middleweight
+04/14/2000,Sanae Kikuta,Eugene Jackson,Red,Middleweight
+04/14/2000,Satoshi Honma,Ron Waterman,Blue,Heavyweight
+04/14/2000,Joe Slick,Ikuhisa Minowa,Blue,Middleweight
+04/14/2000,Laverne Clark,Koji Oishi,Red,Lightweight
+03/10/2000,Steve Judson,Tedd Williams,Blue,Heavyweight
+03/10/2000,Jermaine Andre,Lance Gibson,Blue,Middleweight
+03/10/2000,Dave Menne,Fabiano Iha,Red,Lightweight
+03/10/2000,Tiki Ghosn,Bob Cook,Blue,Lightweight
+03/10/2000,Jens Pulver,David Velasquez,Red,Lightweight
+03/10/2000,Scott Adams,Ian Freeman,Red,Heavyweight
+03/10/2000,Brad Gumm,Shonie Carter,Blue,Lightweight
+11/19/1999,Pete Williams,Kevin Randleman,Blue,UFC Heavyweight Title
+11/19/1999,Pedro Rizzo,Tsuyoshi Kohsaka,Red,Heavyweight
+11/19/1999,Katsuhisa Fujii,Kenichi Yamamoto,Blue,Ultimate Japan 2 Heavyweight Tournament Title
+11/19/1999,Jason DeLucia,Joe Slick,Blue,Middleweight
+11/19/1999,Keiichiro Yamamiya,Eugene Jackson,Blue,Middleweight
+11/19/1999,Kenichi Yamamoto,Daiju Takase,Red,Open Weight
+11/19/1999,Katsuhisa Fujii,Masutatsu Yano,Red,Open Weight
+09/24/1999,Tito Ortiz,Frank Shamrock,Blue,UFC Light Heavyweight Title
+09/24/1999,Jason Godsey,Jeremy Horn,Blue,Heavyweight
+09/24/1999,Steve Judson,Brad Kohler,Blue,Heavyweight
+09/24/1999,Chuck Liddell,Paul Jones,Red,Middleweight
+09/24/1999,Valeri Ignatov,Matt Hughes,Blue,Lightweight
+09/24/1999,John Lewis,Lowell Anderson,Red,Middleweight
+07/16/1999,Marco Ruas,Maurice Smith,Blue,Heavyweight
+07/16/1999,Andre Pederneiras,Pat Miletich,Blue,UFC Welterweight Title
+07/16/1999,Jeremy Horn,Daiju Takase,Red,Middleweight
+07/16/1999,Paul Jones,Flavio Luiz Moura,Red,Middleweight
+07/16/1999,Tim Lajcik,Tsuyoshi Kohsaka,Blue,Heavyweight
+07/16/1999,Eugene Jackson,Royce Alger,Red,Middleweight
+07/16/1999,Andre Roberts,Ron Waterman,Red,Heavyweight
+07/16/1999,David Dodd,Travis Fulton,Blue,Heavyweight
+05/07/1999,Bas Rutten,Kevin Randleman,Red,UFC Heavyweight Title
+05/07/1999,Pedro Rizzo,Tra Telligman,Red,Heavyweight
+05/07/1999,Pete Williams,Travis Fulton,Red,Heavyweight
+05/07/1999,Tony Petarra,Wanderlei Silva,Blue,Middleweight
+05/07/1999,David Roberts,Marcelo Mello,Blue,Lightweight
+05/07/1999,Laverne Clark,Fabiano Iha,Red,Lightweight
+05/07/1999,Ron Waterman,Chris Condo,Red,Heavyweight
+03/05/1999,Tito Ortiz,Guy Mezger,Red,Middleweight
+03/05/1999,Gary Goodridge,Andre Roberts,Red,Heavyweight
+03/05/1999,Jeremy Horn,Chuck Liddell,Red,Middleweight
+03/05/1999,Kevin Randleman,Maurice Smith,Red,Heavyweight
+03/05/1999,Evan Tanner,Valeri Ignatov,Red,Middleweight
+03/05/1999,Pete Williams,Jason Godsey,Red,Heavyweight
+03/05/1999,Sione Latu,Joey Roberts,Red,Heavyweight
+01/08/1999,Tsuyoshi Kohsaka,Bas Rutten,Blue,Heavyweight
+01/08/1999,Pat Miletich,Jorge Patino,Red,UFC Welterweight Title
+01/08/1999,Pedro Rizzo,Mark Coleman,Red,Heavyweight
+01/08/1999,Jerry Bohlander,Tito Ortiz,Blue,Middleweight
+01/08/1999,Mikey Burnett,Townsend Saunders,Red,Lightweight
+01/08/1999,Darrel Gholar,Evan Tanner,Blue,Middleweight
+01/08/1999,Laverne Clark,Frank Caracci,Red,Lightweight
+10/16/1998,Frank Shamrock,John Lober,Red,UFC Light Heavyweight Title
+10/16/1998,Vitor Belfort,Wanderlei Silva,Red,Middleweight
+10/16/1998,David Abbott,Pedro Rizzo,Blue,Heavyweight
+10/16/1998,Mikey Burnett,Pat Miletich,Blue,UFC Welterweight Title
+10/16/1998,Tsuyoshi Kohsaka,Pete Williams,Red,Heavyweight
+10/16/1998,Ebenezer Fontes Braga,Jeremy Horn,Red,Middleweight
+10/16/1998,Adriano Santos,Tulio Palhares,Blue,Middleweight
+10/16/1998,Paulo Santos,Cesar Marscucci,Blue,Lightweight
+05/15/1998,Frank Shamrock,Jeremy Horn,Red,UFC Light Heavyweight Title
+05/15/1998,Pete Williams,Mark Coleman,Red,Heavyweight
+05/15/1998,Carlos Newton,Dan Henderson,Blue,UFC 17 Middleweight Tournament Title
+05/15/1998,David Abbott,Hugo Duarte,Red,Heavyweight
+05/15/1998,Mike van Arsdale,Joe Pardo,Red,Heavyweight
+05/15/1998,Bob Gilstrap,Carlos Newton,Blue,Middleweight
+05/15/1998,Allan Goes,Dan Henderson,Blue,Middleweight
+05/15/1998,Harry Moskowitz,Andre Roberts,Blue,Heavyweight
+05/15/1998,Chuck Liddell,Noe Hernandez,Red,Middleweight
+03/13/1998,Igor Zinoviev,Frank Shamrock,Blue,UFC Light Heavyweight Title
+03/13/1998,Tsuyoshi Kohsaka,Kimo Leopoldo,Red,Heavyweight
+03/13/1998,Chris Brennan,Pat Miletich,Blue,Lightweight
+03/13/1998,Kevin Jackson,Jerry Bohlander,Blue,Middleweight
+03/13/1998,Pat Miletich,Townsend Saunders,Red,Lightweight
+03/13/1998,Mikey Burnett,Eugenio Tadeu,Red,Lightweight
+03/13/1998,Courtney Turner,Chris Brennan,Blue,Lightweight
+03/13/1998,Josh Stuart,Laverne Clark,Blue,Lightweight
+12/21/1997,Maurice Smith,Randy Couture,Blue,UFC Heavyweight Title
+12/21/1997,Marcus Silveira,Kazushi Sakuraba,Blue,Ultimate Japan Heavyweight Tournament Title
+12/21/1997,Vitor Belfort,Joe Charles,Red,Heavyweight
+12/21/1997,Frank Shamrock,Kevin Jackson,Red,UFC Light Heavyweight Title
+12/21/1997,David Abbott,Yoji Anjo,Red,Heavyweight
+12/21/1997,Brad Kohler,Tra Telligman,Blue,Heavyweight
+10/17/1997,Maurice Smith,David Abbott,Red,UFC Heavyweight Title
+10/17/1997,Dwayne Cason,Mark Kerr,Blue,UFC 15 Heavyweight Tournament Title
+10/17/1997,Randy Couture,Vitor Belfort,Red,Heavyweight
+10/17/1997,Dave Beneteau,Carlos Barreto,Red,Heavyweight
+10/17/1997,Greg Stott,Mark Kerr,Blue,Heavyweight
+10/17/1997,Houston Dorr,Dwayne Cason,Blue,Heavyweight
+10/17/1997,Harry Moskowitz,Alex Hunter,Blue,Heavyweight
+07/27/1997,Mark Coleman,Maurice Smith,Blue,UFC Heavyweight Title
+07/27/1997,Dan Bobish,Mark Kerr,Blue,UFC 14 Heavyweight Tournament Title
+07/27/1997,Tony Fryklund,Kevin Jackson,Blue,UFC 14 Middleweight Tournament Title
+07/27/1997,Dan Bobish,Brian Johnston,Red,Heavyweight
+07/27/1997,Moti Horenstein,Mark Kerr,Blue,Heavyweight
+07/27/1997,Todd Butler,Kevin Jackson,Blue,Lightweight
+07/27/1997,Yuri Vaulin,Joe Moreira,Blue,Lightweight
+07/27/1997,Alex Hunter,Sam Fulton,Red,Heavyweight
+07/27/1997,Donnie Chappell,Tony Fryklund,Blue,Lightweight
+05/30/1997,Vitor Belfort,David Abbott,Red,Heavyweight
+05/30/1997,Steven Graham,Randy Couture,Blue,UFC 13 Heavyweight Tournament Title
+05/30/1997,Tito Ortiz,Guy Mezger,Blue,UFC 13 Lightweight Tournament Title
+05/30/1997,Tony Halme,Randy Couture,Blue,Heavyweight
+05/30/1997,Dmitri Stepanov,Steven Graham,Blue,Heavyweight
+05/30/1997,Royce Alger,Enson Inoue,Blue,Lightweight
+05/30/1997,Christophe Leninger,Guy Mezger,Blue,Lightweight
+05/30/1997,Jack Nilson,Saeed Hosseini,Red,Lightweight
+05/30/1997,Tito Ortiz,Wes Albritton,Red,Lightweight
+02/07/1997,Dan Severn,Mark Coleman,Blue,UFC Heavyweight Title
+02/07/1997,Scott Ferrozzo,Vitor Belfort,Blue,Heavyweight
+02/07/1997,Nick Sanzo,Jerry Bohlander,Blue,Lightweight
+02/07/1997,Vitor Belfort,Tra Telligman,Red,Heavyweight
+02/07/1997,Jim Mullen,Scott Ferrozzo,Blue,Heavyweight
+02/07/1997,Wallid Ismail,Yoshiki Takahashi,Blue,Lightweight
+02/07/1997,Jerry Bohlander,Rainy Martinez,Red,Lightweight
+02/07/1997,Eric Martin,Justin Martin,Blue,Heavyweight
+02/07/1997,Jackie Lee,Nick Sanzo,Blue,Lightweight
+12/07/1996,David Abbott,Don Frye,Blue,Ultimate Ultimate '96 Tournament Title
+12/07/1996,David Abbott,Steve Nelmark,Red,Open Weight
+12/07/1996,Don Frye,Mark Hall,Red,Open Weight
+12/07/1996,Ken Shamrock,Brian Johnston,Red,Open Weight
+12/07/1996,Kimo Leopoldo,Paul Varelans,Red,Open Weight
+12/07/1996,Cal Worsham,David Abbott,Blue,Open Weight
+12/07/1996,Don Frye,Gary Goodridge,Red,Open Weight
+12/07/1996,Tai Bowden,Jack Nilson,Red,Open Weight
+12/07/1996,Marcus Bossett,Steve Nelmark,Blue,Open Weight
+12/07/1996,Mark Hall,Felix Lee Mitchell,Red,Open Weight
+09/20/1996,David Abbott,Scott Ferrozzo,Blue,Open Weight
+09/20/1996,Mark Coleman,Brian Johnston,Red,Open Weight
+09/20/1996,Jerry Bohlander,Fabio Gurgel,Red,Open Weight
+09/20/1996,Sam Adkins,David Abbott,Blue,Open Weight
+09/20/1996,Brian Johnston,Reza Nasri,Red,Open Weight
+09/20/1996,Julian Sanchez,Mark Coleman,Blue,Open Weight
+09/20/1996,Dave Berry,Roberto Traven,Blue,Open Weight
+09/20/1996,Sam Fulton,Scott Ferrozzo,Blue,Open Weight
+07/12/1996,Don Frye,Mark Coleman,Blue,UFC 10 Tournament Title
+07/12/1996,Mark Coleman,Gary Goodridge,Red,Open Weight
+07/12/1996,Brian Johnston,Don Frye,Blue,Open Weight
+07/12/1996,Gary Goodridge,John Campetella,Red,Open Weight
+07/12/1996,Moti Horenstein,Mark Coleman,Blue,Open Weight
+07/12/1996,Scott Fiedler,Brian Johnston,Blue,Open Weight
+07/12/1996,Don Frye,Mark Hall,Red,Open Weight
+07/12/1996,Felix Lee Mitchell,Sam Adkins,Blue,Open Weight
+07/12/1996,Geza Kalman,Dieusel Berto,Red,Open Weight
+05/17/1996,Ken Shamrock,Dan Severn,Blue,UFC Superfight Championship
+05/17/1996,Don Frye,Amaury Bitetti,Red,Open Weight
+05/17/1996,Mark Hall,Koji Kitao,Red,Open Weight
+05/17/1996,Mark Schultz,Gary Goodridge,Red,Open Weight
+05/17/1996,Matt Andersen,Rafael Carino,Blue,Open Weight
+05/17/1996,Cal Worsham,Zane Frazier,Red,Open Weight
+05/17/1996,Steve Nelmark,Tai Bowden,Red,Open Weight
+02/16/1996,Gary Goodridge,Don Frye,Blue,UFC 8 Tournament Title
+02/16/1996,Ken Shamrock,Kimo Leopoldo,Red,UFC Superfight Championship
+02/16/1996,Gary Goodridge,Jerry Bohlander,Red,Open Weight
+02/16/1996,Don Frye,Sam Adkins,Red,Open Weight
+02/16/1996,Gary Goodridge,Paul Herrera,Red,Open Weight
+02/16/1996,Jerry Bohlander,Scott Ferrozzo,Red,Open Weight
+02/16/1996,Joe Moreira,Paul Varelans,Blue,Open Weight
+02/16/1996,Thomas Ramirez,Don Frye,Blue,Open Weight
+02/16/1996,Sam Adkins,Keith Mielke,Red,Open Weight
+12/16/1995,Oleg Taktarov,Dan Severn,Blue,Ultimate Ultimate '95 Tournament Title
+12/16/1995,Marco Ruas,Oleg Taktarov,Blue,Open Weight
+12/16/1995,David Abbott,Dan Severn,Blue,Open Weight
+12/16/1995,Dave Beneteau,Oleg Taktarov,Blue,Open Weight
+12/16/1995,Marco Ruas,Keith Hackney,Red,Open Weight
+12/16/1995,Paul Varelans,Dan Severn,Blue,Open Weight
+12/16/1995,David Abbott,Steve Jennum,Red,Open Weight
+12/16/1995,Mark Hall,Trent Jenkins,Red,Open Weight
+12/16/1995,Joe Charles,Scott Bessac,Red,Open Weight
+09/08/1995,Paul Varelans,Marco Ruas,Blue,UFC 7 Tournament Title
+09/08/1995,Remco Pardoel,Marco Ruas,Blue,Open Weight
+09/08/1995,Mark Hall,Paul Varelans,Blue,Open Weight
+09/08/1995,Larry Cureton,Marco Ruas,Blue,Open Weight
+09/08/1995,Ryan Parker,Remco Pardoel,Blue,Open Weight
+09/08/1995,Harold Howard,Mark Hall,Blue,Open Weight
+09/08/1995,Gerry Harris,Paul Varelans,Blue,Open Weight
+09/08/1995,David Hood,Scott Bessac,Blue,Open Weight
+09/08/1995,Francesco Maturi,Onassis Parungao,Blue,Open Weight
+09/08/1995,Geza Kalman,Joel Sutton,Blue,Open Weight
+07/14/1995,David Abbott,Oleg Taktarov,Blue,UFC 6 Tournament Title
+07/14/1995,Dan Severn,Ken Shamrock,Blue,UFC Superfight Championship
+07/14/1995,Oleg Taktarov,Anthony Macias,Red,Open Weight
+07/14/1995,David Abbott,Paul Varelans,Red,Open Weight
+07/14/1995,Dave Beneteau,Oleg Taktarov,Blue,Open Weight
+07/14/1995,Rudyard Moncayo,Patrick Smith,Blue,Open Weight
+07/14/1995,Paul Varelans,Cal Worsham,Red,Open Weight
+07/14/1995,John Matua,David Abbott,Blue,Open Weight
+07/14/1995,He-Man Gipson,Anthony Macias,Blue,Open Weight
+07/14/1995,Jack McGlaughlin,Joel Sutton,Blue,Open Weight
+04/07/1995,Dave Beneteau,Dan Severn,Blue,UFC 5 Tournament Title
+04/07/1995,Oleg Taktarov,Dan Severn,Blue,Open Weight
+04/07/1995,Todd Medina,Dave Beneteau,Blue,Open Weight
+04/07/1995,Joe Charles,Dan Severn,Blue,Open Weight
+04/07/1995,Ernie Verdicia,Oleg Taktarov,Blue,Open Weight
+04/07/1995,Todd Medina,Larry Cureton,Red,Open Weight
+04/07/1995,Andy Anderson,Jon Hess,Blue,Open Weight
+04/07/1995,Guy Mezger,John Dowdy,Red,Open Weight
+04/07/1995,Dave Beneteau,Asbel Cancio,Red,Open Weight
+12/16/1994,Dan Severn,Royce Gracie,Blue,UFC 4 Tournament Title
+12/16/1994,Dan Severn,Marcus Bossett,Red,Open Weight
+12/16/1994,Keith Hackney,Royce Gracie,Blue,Open Weight
+12/16/1994,Dan Severn,Anthony Macias,Red,Open Weight
+12/16/1994,Steve Jennum,Melton Bowen,Red,Open Weight
+12/16/1994,Joe Son,Keith Hackney,Blue,Open Weight
+12/16/1994,Royce Gracie,Ron van Clief,Red,Open Weight
+12/16/1994,Jason Fairn,Guy Mezger,Blue,Open Weight
+12/16/1994,Eldo Xavier Dias,Marcus Bossett,Blue,Open Weight
+12/16/1994,Kevin Rosier,Joe Charles,Blue,Open Weight
+09/09/1994,Harold Howard,Steve Jennum,Blue,UFC 3 Tournament Title
+09/09/1994,Felix Lee Mitchell,Ken Shamrock,Blue,Open Weight
+09/09/1994,Royce Gracie,Kimo Leopoldo,Red,Open Weight
+09/09/1994,Roland Payne,Harold Howard,Blue,Open Weight
+09/09/1994,Christophe Leninger,Ken Shamrock,Blue,Open Weight
+09/09/1994,Keith Hackney,Emmanuel Yarborough,Red,Open Weight
+03/11/1994,Patrick Smith,Royce Gracie,Blue,UFC 2 Tournament Title
+03/11/1994,Remco Pardoel,Royce Gracie,Blue,Open Weight
+03/11/1994,Patrick Smith,Johnny Rhodes,Red,Open Weight
+03/11/1994,Royce Gracie,Jason DeLucia,Red,Open Weight
+03/11/1994,Remco Pardoel,Orlando Wiet,Red,Open Weight
+03/11/1994,Johnny Rhodes,Fred Ettish,Red,Open Weight
+03/11/1994,Patrick Smith,Scott Morris,Red,Open Weight
+03/11/1994,Minoki Ichihara,Royce Gracie,Blue,Open Weight
+03/11/1994,Scott Baker,Jason DeLucia,Blue,Open Weight
+03/11/1994,Remco Pardoel,Alberta Cerra Leon,Red,Open Weight
+03/11/1994,Robert Lucarelli,Orlando Wiet,Blue,Open Weight
+03/11/1994,Frank Hamaker,Thaddeus Luster,Red,Open Weight
+03/11/1994,David Levicki,Johnny Rhodes,Blue,Open Weight
+03/11/1994,Ray Wizard,Patrick Smith,Blue,Open Weight
+03/11/1994,Scott Morris,Sean Daugherty,Red,Open Weight

--- a/temporal_gnn/model3.py
+++ b/temporal_gnn/model3.py
@@ -1,0 +1,398 @@
+# Fighter Stats의 모든 컬럼을 사용하는 GNN 모델입니다.
+
+import torch
+from torch_geometric.nn import GCNConv
+from torch.nn import functional as F
+import pandas as pd
+from collections import OrderedDict
+import numpy as np
+from sklearn.metrics import f1_score
+import matplotlib.pyplot as plt
+from sklearn.metrics import roc_curve, precision_recall_curve
+import os
+import argparse
+
+class MyGNN(torch.nn.Module):
+    def __init__(self, in_channels, hidden_channels):
+        super().__init__()
+        self.conv1 = GCNConv(in_channels, hidden_channels)
+        self.conv2 = GCNConv(hidden_channels, hidden_channels)
+        
+        self.edge_mlp = torch.nn.Sequential(
+            torch.nn.Linear(2 * hidden_channels, hidden_channels),
+            torch.nn.ReLU(),
+            torch.nn.Dropout(0.2),
+            torch.nn.Linear(hidden_channels, hidden_channels),
+            torch.nn.ReLU(),
+            torch.nn.Dropout(0.2),
+            torch.nn.Linear(hidden_channels, 1)
+        )
+    
+    def forward(self, x, edge_index):
+        x = self.conv1(x, edge_index)
+        x = F.relu(x)
+        x = F.dropout(x, p=0.2, training=self.training)
+        
+        x = self.conv2(x, edge_index)
+        x = F.relu(x)
+        x = F.dropout(x, p=0.2, training=self.training)
+        
+        source_node = x[edge_index[0]]
+        target_node = x[edge_index[1]]
+        
+        edge_features = torch.cat([source_node, target_node], dim=1)
+        edge_predictions = self.edge_mlp(edge_features)
+        edge_predictions = torch.sigmoid(edge_predictions)
+        return edge_predictions
+    
+def load_data():
+    fighter_stats_path = 'dataset/preprocessed/fighter_stats.csv'
+    event_dataset_path = './event_dataset_2.csv'
+
+    fighter_stats = pd.read_csv(fighter_stats_path)
+    event_dataset = pd.read_csv(event_dataset_path)
+    
+    event_dataset['date'] = pd.to_datetime(event_dataset['date'])
+    
+    event_dataset = event_dataset.sort_values(by='date')
+    
+    weight_classes = event_dataset['weight_class'].unique()
+    sorted_weight_class_datasets = OrderedDict()
+
+    for weight_class in sorted(weight_classes):
+        wc_data = event_dataset[event_dataset['weight_class'] == weight_class]
+        wc_data = wc_data.sort_values(by='date')
+        sorted_weight_class_datasets[weight_class] = wc_data
+        
+    node_features_dict = OrderedDict()
+    # 각 weight class 별로 노드를 구성
+    for weight_class, wc_data in sorted_weight_class_datasets.items():
+        # 해당 체급의 모든 선수 목록 추출
+        fighters = pd.concat([wc_data['r_fighter'], wc_data['b_fighter']]).unique()
+        
+        # 각 선수별 특징 저장을 위한 딕셔너리
+        weight_class_features = OrderedDict()
+        
+        for fighter in fighters:
+            # fighter_stats에서 해당 선수의 특징 찾기
+            fighter_data = fighter_stats[fighter_stats['name'] == fighter]
+            
+            if len(fighter_data) > 0:
+                # 선수 데이터가 있는 경우, 필요한 특징들을 선택
+                features = fighter_data.iloc[0].drop(['name']).values  # name 컬럼을 제외한 모든 특징
+                weight_class_features[fighter] = features
+            else:
+                # 선수 데이터가 없는 경우, 0으로 채운 특징 벡터 생성
+                features = np.zeros(len(fighter_stats.columns) - 1)  # name 컬럼을 제외한 크기
+                weight_class_features[fighter] = features
+        
+        # 체급별 선수 특징을 전체 노드 특징 딕셔너리에 저장
+        node_features_dict[weight_class] = weight_class_features
+    
+    node_features = {}
+    edge_indices = {}  # 체급별 edge_index를 저장할 딕셔너리
+    edge_labels = {}
+    for weight_class, wc_data in sorted_weight_class_datasets.items():
+        # 해당 체급의 모든 선수 목록
+        fighters = list(node_features_dict[weight_class].keys())
+        
+        # node_features
+        features_list = list(node_features_dict[weight_class].values())
+        features_array = np.array(features_list, dtype=np.float32)
+        fighters_feature = torch.tensor(features_array)
+        # 선수 이름을 인덱스로 매핑하는 딕셔너리 생성
+        fighter_to_idx = {name: idx for idx, name in enumerate(fighters)}
+        
+        node_features[weight_class] = fighters_feature
+        
+        # edge_index를 저장할 리스트 (source_nodes, target_nodes)
+        sources = [] # red
+        targets = [] # blue
+        
+        # 경기 결과 저장 (1: red 승리, 0: blue 승리)
+        labels = []
+        
+        # 각 경기에 대해 edge 생성
+        for _, fight in wc_data.iterrows():
+            r_fighter = fight['r_fighter']
+            b_fighter = fight['b_fighter']
+            winner = fight['winner']
+            
+            sources.append(fighter_to_idx[r_fighter])
+            targets.append(fighter_to_idx[b_fighter])
+            labels.append(1 if winner == "Red" else 0)
+        
+        # 리스트를 텐서로 변환
+        edge_index = torch.tensor([sources, targets], dtype=torch.long)
+        edge_indices[weight_class] = edge_index
+        
+        labels = torch.tensor(labels, dtype=torch.float)
+        edge_labels[weight_class] = labels
+    
+    return node_features, edge_indices, edge_labels, weight_classes
+
+def evaluate_model(model, node_features, validation_edge_index, validation_edge_labels, 
+                  test_edge_index, test_edge_labels):
+    with torch.no_grad():
+        # 검증 데이터로 최적 임계값 찾기
+        val_predictions = model(node_features, validation_edge_index)
+        val_loss = F.binary_cross_entropy(val_predictions.squeeze(), validation_edge_labels)
+        
+        # ROC 커브를 통한 최적 임계값 찾기
+        fpr, tpr, thresholds = roc_curve(validation_edge_labels.numpy(), 
+                                       val_predictions.squeeze().numpy())
+        optimal_idx = np.argmax(tpr - fpr)
+        optimal_threshold = thresholds[optimal_idx]
+        
+        print(f'Validation으로 찾은 Optimal Threshold: {optimal_threshold:.4f}')
+        
+        # 테스트 데이터에 최적 임계값 적용
+        test_predictions = model(node_features, test_edge_index)
+        test_loss = F.binary_cross_entropy(test_predictions.squeeze(), test_edge_labels)
+        pred_labels = (test_predictions.squeeze() > optimal_threshold).float()
+        
+        print(f'test_predictions: {test_predictions.squeeze()}')
+        print(f'예측값: {pred_labels.numpy()}')
+        print(f'실제값: {test_edge_labels.numpy()}')
+        
+        print(f'Validation Loss: {val_loss.item():.4f}')
+        print(f'Test Loss: {test_loss.item():.4f}')
+        # F1 점수 계산 시 예측값을 이진값으로 변환
+        val_pred_binary = (val_predictions.squeeze() > optimal_threshold).float().numpy()
+        test_pred_binary = (test_predictions.squeeze() > optimal_threshold).float().numpy()
+        
+        # f1 스코어 계산 (이진값 사용)
+        f1_val_pos = f1_score(validation_edge_labels.numpy(), val_pred_binary)
+        f1_val_neg = f1_score(validation_edge_labels.numpy(), val_pred_binary, pos_label=0)
+        
+        f1_test_pos = f1_score(test_edge_labels.numpy(), test_pred_binary)
+        f1_test_neg = f1_score(test_edge_labels.numpy(), test_pred_binary, pos_label=0)
+        
+        print(f'Validation F1 Score (Positive): {f1_val_pos:.4f}')
+        print(f'Validation F1 Score (Negative): {f1_val_neg:.4f}')
+        print(f'Test F1 Score (Positive): {f1_test_pos:.4f}')
+        print(f'Test F1 Score (Negative): {f1_test_neg:.4f}')
+        
+        # 검증 데이터 정확도 계산
+        val_correct = (val_pred_binary == validation_edge_labels.numpy()).sum()
+        val_total = len(validation_edge_labels)
+        val_accuracy = val_correct / val_total
+        
+        # 테스트 데이터 정확도 계산
+        test_correct = (test_pred_binary == test_edge_labels.numpy()).sum()
+        test_total = len(test_edge_labels)
+        test_accuracy = test_correct / test_total
+        
+        print("\n=== 예측 정확도 ===")
+        print(f'Validation: {val_correct}/{val_total} 경기 예측 성공 (정확도: {val_accuracy:.4f})')
+        print(f'Test: {test_correct}/{test_total} 경기 예측 성공 (정확도: {test_accuracy:.4f})')
+        
+        # Red/Blue 선수별 정확도 계산
+        val_red_correct = ((val_pred_binary == 1) & (validation_edge_labels.numpy() == 1)).sum()
+        val_red_total = (validation_edge_labels.numpy() == 1).sum()
+        val_blue_correct = ((val_pred_binary == 0) & (validation_edge_labels.numpy() == 0)).sum()
+        val_blue_total = (validation_edge_labels.numpy() == 0).sum()
+        
+        test_red_correct = ((test_pred_binary == 1) & (test_edge_labels.numpy() == 1)).sum()
+        test_red_total = (test_edge_labels.numpy() == 1).sum()
+        test_blue_correct = ((test_pred_binary == 0) & (test_edge_labels.numpy() == 0)).sum()
+        test_blue_total = (test_edge_labels.numpy() == 0).sum()
+        
+        print("\n=== Red/Blue 선수별 예측 정확도 ===")
+        print(f'Validation Red 승리 예측: {val_red_correct}/{val_red_total} (정확도: {val_red_correct/val_red_total:.4f})')
+        print(f'Validation Blue 승리 예측: {val_blue_correct}/{val_blue_total} (정확도: {val_blue_correct/val_blue_total:.4f})')
+        print(f'Test Red 승리 예측: {test_red_correct}/{test_red_total} (정확도: {test_red_correct/test_red_total:.4f})')
+        print(f'Test Blue 승리 예측: {test_blue_correct}/{test_blue_total} (정확도: {test_blue_correct/test_blue_total:.4f})')
+        
+        print(f'Test 전체 예측 정확도: {test_correct}/{test_total} (정확도: {test_accuracy:.4f})')
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='GNN Model Training and Evaluation')
+    parser.add_argument('--evaluate', type=str, help='Path to the model to evaluate')
+    parser.add_argument('--weight_class', type=str, required=True, help='Weight class to train/evaluate',
+                      choices=['Lightweight', 'Welterweight', 'Middleweight', 
+                              'Light Heavyweight', 'Heavyweight', 'Women\'s Strawweight',
+                              'Women\'s Flyweight', 'Women\'s Bantamweight'])
+    return parser.parse_args()
+
+def plot_losses(train_losses, val_losses, weight_class, save_dir):
+    plt.figure(figsize=(10, 6))
+    plt.plot(range(len(train_losses)), train_losses, label='Train Loss')
+    plt.plot(range(len(val_losses)), val_losses, label='Validation Loss')
+    plt.xlabel('Epoch')
+    plt.ylabel('Loss')
+    plt.title(f'Training and Validation Losses - {weight_class}')
+    plt.legend()
+    plt.grid(True)
+    
+    # 그래프 저장
+    plot_path = os.path.join(save_dir, 'model2_loss_plot.png')
+    plt.savefig(plot_path)
+    plt.close()
+
+if __name__ == "__main__":
+    args = parse_args()
+    node_features, edge_indices, edge_labels, weight_classes = load_data()
+    
+    if args.evaluate:
+        print(f"모델 평가 모드: {args.evaluate}")
+        weight_class = args.weight_class
+        print(f"체급: {weight_class}")
+        
+        # 데이터 준비
+        train_size = int(len(edge_labels[weight_class]) * 0.6)
+        validation_size = int(len(edge_labels[weight_class]) * 0.2)
+        test_size = int(len(edge_labels[weight_class]) * 0.2)
+        
+        print(f"train_size: {train_size}")
+        print(f"validation_size: {validation_size}")
+        print(f"test_size: {test_size}")
+        
+        validation_edge_index = edge_indices[weight_class][:, train_size:train_size+validation_size]
+        validation_edge_labels = edge_labels[weight_class][train_size:train_size+validation_size]
+        
+        test_edge_index = edge_indices[weight_class][:, train_size+validation_size:train_size+validation_size+test_size]
+        test_edge_labels = edge_labels[weight_class][train_size+validation_size:train_size+validation_size+test_size]
+        
+        # 모델 불러오기
+        model = MyGNN(in_channels=node_features[weight_class].shape[1], hidden_channels=16)
+        model.load_state_dict(torch.load(f'temporal_gnn/models/{weight_class}/{args.evaluate}'))
+        model.eval()
+        
+        # 모델 평가
+        print("\n=== 모델 평가 결과 ===")
+        evaluate_model(model, node_features[weight_class], validation_edge_index, 
+                      validation_edge_labels, test_edge_index, test_edge_labels)
+    else:
+        # 학습 모드
+        weight_classes = [args.weight_class]
+            
+        for weight_class in weight_classes:
+            print(f'============{weight_class}============')
+
+            # 경기 수가 10 미만인 경우 패스
+            if len(edge_labels[weight_class]) < 10:
+                print(f"{weight_class}의 경기 수가 너무 적습니다. 건너뜁니다.")
+                continue
+            
+            train_size = int(len(edge_labels[weight_class]) * 0.6)
+            validation_size = int(len(edge_labels[weight_class]) * 0.2)
+            test_size = int(len(edge_labels[weight_class]) * 0.2)
+            
+            # edge_indices와 edge_labels를 train, validation, test로 나누기
+            train_edge_index = edge_indices[weight_class][:, :train_size]
+            train_edge_labels = edge_labels[weight_class][:train_size]
+            
+            validation_edge_index = edge_indices[weight_class][:, train_size:train_size+validation_size]
+            validation_edge_labels = edge_labels[weight_class][train_size:train_size+validation_size]
+            
+            test_edge_index = edge_indices[weight_class][:, train_size+validation_size:train_size+validation_size+test_size]
+            test_edge_labels = edge_labels[weight_class][train_size+validation_size:train_size+validation_size+test_size]
+            
+            # print("train_edge_index", train_edge_index.shape)
+            # print("train_edge_labels", train_edge_labels.shape)
+            # print("validation_edge_index", validation_edge_index.shape)
+            # print("validation_edge_labels", validation_edge_labels.shape)
+            # print("test_edge_index", test_edge_index.shape)
+            # print("test_edge_labels", test_edge_labels.shape)
+            
+            # 모델 초기화
+            model = MyGNN(in_channels=node_features[weight_class].shape[1], hidden_channels=16)
+            optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+            
+            # 학습 시작 전 초기화
+            train_losses = []
+            val_losses = []
+            
+            # 모델 저장 디렉토리 생성
+            save_dir = f'temporal_gnn/models/{weight_class}'
+            os.makedirs(save_dir, exist_ok=True)
+            
+            best_val_f1 = 0
+            best_val_epoch = 0
+            best_test_f1_at_best_val = 0
+            best_test_f1 = 0
+            best_test_epoch = 0
+            best_val_f1_at_best_test = 0
+            
+            # 학습 시작 전 초기화에 추가
+            best_val_loss = float('inf')
+            best_val_loss_epoch = 0
+            test_f1_at_best_val_loss = 0
+            val_f1_at_best_val_loss = 0
+            
+            # 학습
+            for epoch in range(300):
+                model.train()
+                optimizer.zero_grad()
+                
+                predictions = model(node_features[weight_class], train_edge_index)
+                loss = F.binary_cross_entropy(predictions.squeeze(), train_edge_labels)
+                
+                loss.backward()
+                optimizer.step()
+                
+                if (epoch + 1) % 10 == 0:
+                    # 모델 저장
+                    model_path = os.path.join(save_dir, f'model_epoch_{epoch+1}.pt')
+                    torch.save(model.state_dict(), model_path)
+                    
+                    # 평가 모드로 전환
+                    model.eval()
+                    with torch.no_grad():
+                        # Validation 데이터로 최적 임계값 찾기
+                        val_predictions = model(node_features[weight_class], validation_edge_index)
+                        val_loss = F.binary_cross_entropy(val_predictions.squeeze(), validation_edge_labels)
+                        
+                        # ROC 커브로 최적 임계값 찾기
+                        fpr, tpr, thresholds = roc_curve(validation_edge_labels.numpy(), 
+                                                       val_predictions.squeeze().numpy())
+                        optimal_idx = np.argmax(tpr - fpr)
+                        optimal_threshold = thresholds[optimal_idx]
+                        
+                        # Validation F1 Score 계산
+                        val_pred_labels = (val_predictions.squeeze() > optimal_threshold).float()
+                        val_f1 = f1_score(validation_edge_labels.numpy(), val_pred_labels.numpy())
+                        
+                        # Test F1 Score 계산
+                        test_predictions = model(node_features[weight_class], test_edge_index)
+                        test_pred_labels = (test_predictions.squeeze() > optimal_threshold).float()
+                        test_f1 = f1_score(test_edge_labels.numpy(), test_pred_labels.numpy())
+                        
+                        # 최고 성능 업데이트
+                        if val_f1 > best_val_f1:
+                            best_val_f1 = val_f1
+                            best_val_epoch = epoch + 1
+                            best_test_f1_at_best_val = test_f1
+                        
+                        if test_f1 > best_test_f1:
+                            best_test_f1 = test_f1
+                            best_test_epoch = epoch + 1
+                            best_val_f1_at_best_test = val_f1
+                            
+                        # validation loss 기준 최고 성능 업데이트
+                        if val_loss < best_val_loss:
+                            best_val_loss = val_loss
+                            best_val_loss_epoch = epoch + 1
+                            test_f1_at_best_val_loss = test_f1
+                            val_f1_at_best_val_loss = val_f1
+                        
+                        print(f'\nEpoch {epoch+1}:')
+                        print(f'Threshold: {optimal_threshold:.4f}')
+                        print(f'Train Loss: {loss.item():.4f}')
+                        print(f'Validation Loss: {val_loss.item():.4f}')
+                
+                        # 학습 루프 내부에서 손실값 저장 (epoch 루프 내)
+                        train_losses.append(loss.item())
+                        val_losses.append(val_loss.item())
+            
+            # 학습 완료 후 그래프 그리기 (학습 루프 종료 후)
+            plot_losses(train_losses, val_losses, weight_class, save_dir)
+            
+            # 학습 완료 후 최종 결과 출력
+            print("\n=== 학습 최종 결과 ===")
+            print(f"Best Validation Loss: {best_val_loss:.4f} (Epoch {best_val_loss_epoch})")
+            print(f"- At Best Val Loss - Val F1: {val_f1_at_best_val_loss:.4f}, Test F1: {test_f1_at_best_val_loss:.4f}")
+            print("")
+            print(f"Best Validation F1 Score: {best_val_f1:.4f} (Epoch {best_val_epoch}, Test F1 Score: {best_test_f1_at_best_val:.4f})")
+            print(f"Best Test F1 Score: {best_test_f1:.4f} (Epoch {best_test_epoch}, Validation F1 Score: {best_val_f1_at_best_test:.4f})")


### PR DESCRIPTION
1) 데이터셋 편향성 제거
 - red blue 라벨을 선수에게 랜덤으로 부여하고, 승리 비율을 red:blue=5:5로 설정
 
|                  | Lightweight | Heavyweight | Welterweight |
|------------------|-------------|-------------|--------------|
| Val Accuracy     | 0.5934      | 0.6053      | 0.6017       |
| Test Accuracy    | 0.5702      | 0.5439      | 0.5975       |
2) 모델 복잡도 증가
 - gcn convolution과 linear layer 추가

|                  | Lightweight | Heavyweight | Welterweight |
|------------------|-------------|-------------|--------------|
| Val Accuracy     | 0.6390      | 0.6140      | 0.6186       |
| Test Accuracy    | 0.6017      | 0.5439      | 0.6102       |


(그외)
* 90년대 데이터셋 제거 -> 큰 성능 변화 없었음
* 최종 데이터셋 비율 train : val : test = 6 : 2 : 2 
  * train 비율 더 낮춰도 큰 차이 없거나 성능 감소하였음


학습 명령어 예시
```
python3 temporal_gnn/model3.py --weight_class Heavyweight
```
